### PR TITLE
Remove the external event URL (Luma link) feature

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -216,7 +216,6 @@ function NewEventDialog() {
   const [description, setDescription] = useState("");
   const [eventDate, setEventDate] = useState("");
   const [creditAmount, setCreditAmount] = useState("");
-  const [eventUrl, setEventUrl] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
@@ -231,7 +230,6 @@ function NewEventDialog() {
         description: description || undefined,
         eventDate: eventDate || undefined,
         creditAmount: creditAmount || undefined,
-        eventUrl: eventUrl || undefined,
       });
       toast.success(`Event "${name}" created`);
       router.push(`/admin/events/${id}`);
@@ -312,19 +310,6 @@ function NewEventDialog() {
                 onChange={(e) => setCreditAmount(e.target.value)}
                 placeholder="$100"
               />
-            </Field>
-            <Field>
-              <FieldLabel htmlFor="event-url">Event URL</FieldLabel>
-              <Input
-                id="event-url"
-                type="url"
-                value={eventUrl}
-                onChange={(e) => setEventUrl(e.target.value)}
-                placeholder="https://tokyohackathon.com"
-              />
-              <FieldDescription>
-                Optional — linked from the claim page.
-              </FieldDescription>
             </Field>
           </FieldGroup>
           {error ? (

--- a/app/my-codes/page.tsx
+++ b/app/my-codes/page.tsx
@@ -47,7 +47,6 @@ interface EventInfo {
   slug: string;
   creditAmount?: string;
   eventDate?: string;
-  eventUrl?: string;
 }
 
 function eventMeta(event: EventInfo) {

--- a/components/ClaimPage.tsx
+++ b/components/ClaimPage.tsx
@@ -67,14 +67,6 @@ function subscribeNoop() {
   return () => {};
 }
 
-function urlLabel(url: string) {
-  try {
-    return new URL(url).hostname.replace(/^www\./, "");
-  } catch {
-    return url;
-  }
-}
-
 export default function ClaimPage({ slug }: { slug: string }) {
   const event = useQuery(api.events.getBySlug, { slug });
   const claim = useMutation(api.claims.claim);
@@ -186,7 +178,7 @@ export default function ClaimPage({ slug }: { slug: string }) {
                     {event.description}
                   </CardDescription>
                 ) : null}
-                {event.eventDate || event.eventUrl ? (
+                {event.eventDate ? (
                   <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs text-muted-foreground">
                     {event.eventDate ? (
                       <span className="flex items-center gap-1.5 tabular-nums">
@@ -208,20 +200,6 @@ export default function ClaimPage({ slug }: { slug: string }) {
                           )
                         ) : null}
                       </span>
-                    ) : null}
-                    {event.eventUrl ? (
-                      <a
-                        href={event.eventUrl}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="group flex w-fit items-center gap-1 rounded-sm transition-colors hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ring"
-                      >
-                        {urlLabel(event.eventUrl)}
-                        <ArrowUpRight
-                          className="size-3.5 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
-                          aria-hidden
-                        />
-                      </a>
                     ) : null}
                   </div>
                 ) : null}

--- a/components/ManageEvent.tsx
+++ b/components/ManageEvent.tsx
@@ -662,7 +662,6 @@ function EventDetailsForm({
   const [description, setDescription] = useState(event.description ?? "");
   const [eventDate, setEventDate] = useState(event.eventDate ?? "");
   const [creditAmount, setCreditAmount] = useState(event.creditAmount ?? "");
-  const [eventUrl, setEventUrl] = useState(event.eventUrl ?? "");
   const [saving, setSaving] = useState(false);
 
   async function handleSave(e: React.FormEvent) {
@@ -676,7 +675,6 @@ function EventDetailsForm({
         description: description || undefined,
         eventDate: eventDate || undefined,
         creditAmount: creditAmount || undefined,
-        eventUrl: eventUrl || undefined,
       });
       setSlug(savedSlug);
       toast.success("Event saved");
@@ -754,19 +752,6 @@ function EventDetailsForm({
                 placeholder="$100"
               />
               <FieldDescription>Shown on the claim page.</FieldDescription>
-            </Field>
-            <Field>
-              <FieldLabel htmlFor="detail-url">Event URL</FieldLabel>
-              <Input
-                id="detail-url"
-                type="url"
-                value={eventUrl}
-                onChange={(e) => setEventUrl(e.target.value)}
-                placeholder="https://tokyohackathon.com"
-              />
-              <FieldDescription>
-                Optional — linked from the claim page.
-              </FieldDescription>
             </Field>
           </FieldGroup>
           <div className="flex items-center justify-between gap-4">

--- a/convex/codes.ts
+++ b/convex/codes.ts
@@ -64,7 +64,6 @@ export const mine = query({
                 slug: event.slug,
                 creditAmount: event.creditAmount,
                 eventDate: event.eventDate,
-                eventUrl: event.eventUrl,
               }
             : null,
         };

--- a/convex/events.ts
+++ b/convex/events.ts
@@ -12,21 +12,6 @@ function slugify(name: string): string {
     .replace(/^-|-$/g, "");
 }
 
-// Empty -> undefined; bare domains get https://; anything unparseable throws.
-function normalizeUrl(raw?: string): string | undefined {
-  const trimmed = raw?.trim();
-  if (!trimmed) return undefined;
-  const withProtocol = /^https?:\/\//i.test(trimmed)
-    ? trimmed
-    : `https://${trimmed}`;
-  try {
-    new URL(withProtocol);
-  } catch {
-    throw new Error("Enter a valid event URL");
-  }
-  return withProtocol;
-}
-
 // Empty -> undefined; expects YYYY-MM-DD from the date input.
 function normalizeEventDate(raw?: string): string | undefined {
   const trimmed = raw?.trim();
@@ -92,7 +77,6 @@ export const getBySlug = query({
       name: event.name,
       slug: event.slug,
       description: event.description,
-      eventUrl: event.eventUrl,
       eventDate: event.eventDate,
       soldOut: available === null,
     };
@@ -103,7 +87,17 @@ export const get = query({
   args: { id: v.id("events") },
   handler: async (ctx, args) => {
     await requireEventAdmin(ctx, args.id);
-    return await ctx.db.get(args.id);
+    const event = await ctx.db.get(args.id);
+    if (!event) return null;
+    return {
+      _id: event._id,
+      _creationTime: event._creationTime,
+      name: event.name,
+      slug: event.slug,
+      description: event.description,
+      creditAmount: event.creditAmount,
+      eventDate: event.eventDate,
+    };
   },
 });
 
@@ -145,7 +139,6 @@ export const create = mutation({
     slug: v.optional(v.string()),
     description: v.optional(v.string()),
     creditAmount: v.optional(v.string()),
-    eventUrl: v.optional(v.string()),
     eventDate: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
@@ -166,7 +159,6 @@ export const create = mutation({
       slug,
       description: args.description?.trim() || undefined,
       creditAmount: args.creditAmount?.trim() || undefined,
-      eventUrl: normalizeUrl(args.eventUrl),
       eventDate: normalizeEventDate(args.eventDate),
     });
     return { id, slug };
@@ -180,7 +172,6 @@ export const update = mutation({
     slug: v.string(),
     description: v.optional(v.string()),
     creditAmount: v.optional(v.string()),
-    eventUrl: v.optional(v.string()),
     eventDate: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
@@ -199,7 +190,6 @@ export const update = mutation({
       slug,
       description: args.description?.trim() || undefined,
       creditAmount: args.creditAmount?.trim() || undefined,
-      eventUrl: normalizeUrl(args.eventUrl),
       eventDate: normalizeEventDate(args.eventDate),
     });
     return { slug };

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -19,7 +19,6 @@ export default defineSchema({
     slug: v.string(),
     description: v.optional(v.string()),
     creditAmount: v.optional(v.string()),
-    eventUrl: v.optional(v.string()),
     eventDate: v.optional(v.string()),
   }).index("by_slug", ["slug"]),
 


### PR DESCRIPTION
## Summary
Removes the optional external event link (the Luma link) end-to-end: the `events.eventUrl` schema field, the "Event URL" inputs in the new-event dialog and event details form, the `normalizeUrl` helper, and the link rendered next to the date on the claim page. The claim-page metadata row now renders on `eventDate` alone.

`events.get` previously returned the raw document; it now projects explicit fields, so legacy documents that still carry `eventUrl` can't leak it back into the admin UI.

**Deploy note:** Convex validates existing documents when pushing a schema, so if any event row still has `eventUrl` set, `convex deploy` will reject this schema until those values are cleared (unset the field on existing events, or push once with `schemaValidation: false`). No migration is included here.


Link to Devin session: https://app.devin.ai/sessions/07156c6c22664a299bc1b6f25c2f0b85
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/43" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->