### PR TITLE
Unblock deploy: strip legacy eventUrl data (step 1 of 2)

### DIFF
--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -1,0 +1,24 @@
+import { internalMutation } from "./_generated/server";
+import type { Doc } from "./_generated/dataModel";
+
+export const removeLegacyEventUrl = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const events = await ctx.db.query("events").collect();
+    let cleaned = 0;
+
+    for (const event of events) {
+      if (!Object.prototype.hasOwnProperty.call(event, "eventUrl")) {
+        continue;
+      }
+
+      await ctx.db.patch(
+        event._id,
+        { eventUrl: undefined } as unknown as Partial<Doc<"events">>,
+      );
+      cleaned++;
+    }
+
+    return { cleaned };
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1,68 +1,72 @@
 import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
 
-export default defineSchema({
-  admins: defineTable({
-    email: v.string(),
-  }).index("by_email", ["email"]),
+// Temporarily disabled pending cleanup of legacy eventUrl fields.
+export default defineSchema(
+  {
+    admins: defineTable({
+      email: v.string(),
+    }).index("by_email", ["email"]),
 
-  eventAdmins: defineTable({
-    eventId: v.id("events"),
-    email: v.string(),
-  })
-    .index("by_event", ["eventId"])
-    .index("by_email", ["email"])
-    .index("by_event_email", ["eventId", "email"]),
+    eventAdmins: defineTable({
+      eventId: v.id("events"),
+      email: v.string(),
+    })
+      .index("by_event", ["eventId"])
+      .index("by_email", ["email"])
+      .index("by_event_email", ["eventId", "email"]),
 
-  events: defineTable({
-    name: v.string(),
-    slug: v.string(),
-    description: v.optional(v.string()),
-    creditAmount: v.optional(v.string()),
-    eventDate: v.optional(v.string()),
-  }).index("by_slug", ["slug"]),
+    events: defineTable({
+      name: v.string(),
+      slug: v.string(),
+      description: v.optional(v.string()),
+      creditAmount: v.optional(v.string()),
+      eventDate: v.optional(v.string()),
+    }).index("by_slug", ["slug"]),
 
-  emails: defineTable({
-    eventId: v.id("events"),
-    email: v.string(),
-  })
-    .index("by_event", ["eventId"])
-    .index("by_event_email", ["eventId", "email"]),
+    emails: defineTable({
+      eventId: v.id("events"),
+      email: v.string(),
+    })
+      .index("by_event", ["eventId"])
+      .index("by_event_email", ["eventId", "email"]),
 
-  codes: defineTable({
-    eventId: v.id("events"),
-    code: v.string(),
-    claimedBy: v.optional(v.string()),
-    claimedAt: v.optional(v.number()),
-    reservedFor: v.optional(v.string()),
-  })
-    .index("by_event", ["eventId"])
-    .index("by_event_claimedBy", ["eventId", "claimedBy"])
-    .index("by_event_reservedFor", ["eventId", "reservedFor"])
-    .index("by_claimedBy", ["claimedBy"]),
+    codes: defineTable({
+      eventId: v.id("events"),
+      code: v.string(),
+      claimedBy: v.optional(v.string()),
+      claimedAt: v.optional(v.number()),
+      reservedFor: v.optional(v.string()),
+    })
+      .index("by_event", ["eventId"])
+      .index("by_event_claimedBy", ["eventId", "claimedBy"])
+      .index("by_event_reservedFor", ["eventId", "reservedFor"])
+      .index("by_claimedBy", ["claimedBy"]),
 
-  accessRequests: defineTable({
-    eventId: v.id("events"),
-    email: v.string(),
-    status: v.union(
-      v.literal("pending"),
-      v.literal("approved"),
-      v.literal("denied")
-    ),
-    note: v.optional(v.string()),
-    decidedBy: v.optional(v.string()),
-    decidedAt: v.optional(v.number()),
-  })
-    .index("by_event", ["eventId"])
-    .index("by_event_status", ["eventId", "status"])
-    .index("by_event_email", ["eventId", "email"])
-    .index("by_email", ["email"]),
+    accessRequests: defineTable({
+      eventId: v.id("events"),
+      email: v.string(),
+      status: v.union(
+        v.literal("pending"),
+        v.literal("approved"),
+        v.literal("denied")
+      ),
+      note: v.optional(v.string()),
+      decidedBy: v.optional(v.string()),
+      decidedAt: v.optional(v.number()),
+    })
+      .index("by_event", ["eventId"])
+      .index("by_event_status", ["eventId", "status"])
+      .index("by_event_email", ["eventId", "email"])
+      .index("by_email", ["email"]),
 
-  auditLogs: defineTable({
-    eventId: v.id("events"),
-    action: v.string(),
-    actorEmail: v.optional(v.string()),
-    subjectEmail: v.optional(v.string()),
-    details: v.optional(v.string()),
-  }).index("by_event", ["eventId"]),
-});
+    auditLogs: defineTable({
+      eventId: v.id("events"),
+      action: v.string(),
+      actorEmail: v.optional(v.string()),
+      subjectEmail: v.optional(v.string()),
+      details: v.optional(v.string()),
+    }).index("by_event", ["eventId"]),
+  },
+  { schemaValidation: false },
+);

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2,71 +2,68 @@ import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
 
 // Temporarily disabled pending cleanup of legacy eventUrl fields.
-export default defineSchema(
-  {
-    admins: defineTable({
-      email: v.string(),
-    }).index("by_email", ["email"]),
+export default defineSchema({
+  admins: defineTable({
+    email: v.string(),
+  }).index("by_email", ["email"]),
 
-    eventAdmins: defineTable({
-      eventId: v.id("events"),
-      email: v.string(),
-    })
-      .index("by_event", ["eventId"])
-      .index("by_email", ["email"])
-      .index("by_event_email", ["eventId", "email"]),
+  eventAdmins: defineTable({
+    eventId: v.id("events"),
+    email: v.string(),
+  })
+    .index("by_event", ["eventId"])
+    .index("by_email", ["email"])
+    .index("by_event_email", ["eventId", "email"]),
 
-    events: defineTable({
-      name: v.string(),
-      slug: v.string(),
-      description: v.optional(v.string()),
-      creditAmount: v.optional(v.string()),
-      eventDate: v.optional(v.string()),
-    }).index("by_slug", ["slug"]),
+  events: defineTable({
+    name: v.string(),
+    slug: v.string(),
+    description: v.optional(v.string()),
+    creditAmount: v.optional(v.string()),
+    eventDate: v.optional(v.string()),
+  }).index("by_slug", ["slug"]),
 
-    emails: defineTable({
-      eventId: v.id("events"),
-      email: v.string(),
-    })
-      .index("by_event", ["eventId"])
-      .index("by_event_email", ["eventId", "email"]),
+  emails: defineTable({
+    eventId: v.id("events"),
+    email: v.string(),
+  })
+    .index("by_event", ["eventId"])
+    .index("by_event_email", ["eventId", "email"]),
 
-    codes: defineTable({
-      eventId: v.id("events"),
-      code: v.string(),
-      claimedBy: v.optional(v.string()),
-      claimedAt: v.optional(v.number()),
-      reservedFor: v.optional(v.string()),
-    })
-      .index("by_event", ["eventId"])
-      .index("by_event_claimedBy", ["eventId", "claimedBy"])
-      .index("by_event_reservedFor", ["eventId", "reservedFor"])
-      .index("by_claimedBy", ["claimedBy"]),
+  codes: defineTable({
+    eventId: v.id("events"),
+    code: v.string(),
+    claimedBy: v.optional(v.string()),
+    claimedAt: v.optional(v.number()),
+    reservedFor: v.optional(v.string()),
+  })
+    .index("by_event", ["eventId"])
+    .index("by_event_claimedBy", ["eventId", "claimedBy"])
+    .index("by_event_reservedFor", ["eventId", "reservedFor"])
+    .index("by_claimedBy", ["claimedBy"]),
 
-    accessRequests: defineTable({
-      eventId: v.id("events"),
-      email: v.string(),
-      status: v.union(
-        v.literal("pending"),
-        v.literal("approved"),
-        v.literal("denied")
-      ),
-      note: v.optional(v.string()),
-      decidedBy: v.optional(v.string()),
-      decidedAt: v.optional(v.number()),
-    })
-      .index("by_event", ["eventId"])
-      .index("by_event_status", ["eventId", "status"])
-      .index("by_event_email", ["eventId", "email"])
-      .index("by_email", ["email"]),
+  accessRequests: defineTable({
+    eventId: v.id("events"),
+    email: v.string(),
+    status: v.union(
+      v.literal("pending"),
+      v.literal("approved"),
+      v.literal("denied")
+    ),
+    note: v.optional(v.string()),
+    decidedBy: v.optional(v.string()),
+    decidedAt: v.optional(v.number()),
+  })
+    .index("by_event", ["eventId"])
+    .index("by_event_status", ["eventId", "status"])
+    .index("by_event_email", ["eventId", "email"])
+    .index("by_email", ["email"]),
 
-    auditLogs: defineTable({
-      eventId: v.id("events"),
-      action: v.string(),
-      actorEmail: v.optional(v.string()),
-      subjectEmail: v.optional(v.string()),
-      details: v.optional(v.string()),
-    }).index("by_event", ["eventId"]),
-  },
-  { schemaValidation: false },
-);
+  auditLogs: defineTable({
+    eventId: v.id("events"),
+    action: v.string(),
+    actorEmail: v.optional(v.string()),
+    subjectEmail: v.optional(v.string()),
+    details: v.optional(v.string()),
+  }).index("by_event", ["eventId"]),
+}, { schemaValidation: false });


### PR DESCRIPTION
## Summary
The deploy after #43 fails because existing `events` documents still carry the removed `eventUrl` field and Convex validates existing rows on schema push. This is step 1 of a two-step deploy: it turns schema validation off so the push can land, and adds a one-off internal mutation that strips the stale field.

`defineSchema(..., { schemaValidation: false })` is temporary. `migrations:removeLegacyEventUrl` walks `events`, patches `eventUrl: undefined` on any doc that still has the own-property (narrow cast, since the field is intentionally gone from the generated types), and returns `{ cleaned }`. Idempotent.

### Deploy steps
1. Merge this → deploy succeeds with validation off.
2. Run the migration against prod:
   ```bash
   npx convex run migrations:removeLegacyEventUrl '{}' --prod
   ```
3. Merge the follow-up PR that re-enables `schemaValidation` and deletes `convex/migrations.ts`.


Link to Devin session: https://app.devin.ai/sessions/07156c6c22664a299bc1b6f25c2f0b85
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/44" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->