### PR TITLE
Flag cross-event duplicate signups for manual review

### DIFF
--- a/.agents/skills/testing-vending-machine/SKILL.md
+++ b/.agents/skills/testing-vending-machine/SKILL.md
@@ -17,6 +17,8 @@ description: Run and test the Vending Machine app locally (Next.js + Convex + Cl
    grep -v -E 'CLERK_COOKIE' /run/repo_secrets/dabit3/vending-machine/.env.secrets | sed 's/^export //' > .env.local
    ```
 2. `npm install` then `npm run dev`. Home `/` and claim pages `/<slug>` are public; `/admin` requires auth.
+3. If the branch under test changes `convex/` (schema or functions), push them with `npx convex dev --once`. Watch out: the shared dev deployment's data may have drifted from the schema, which makes schema validation fail the deploy. Workaround: temporarily add the missing optional field to the schema before deploying, clean up the stale data (see `git log -S removeLegacyEventUrl` for a prior migration example), then restore the strict schema.
+4. Inspect backend state (e.g. `auditLogs`, `flaggedEmails`) with `npx convex data <table> --order desc --limit N`.
 
 ## Authenticating as admin for testing
 `CLERK_COOKIE` (repo secret) is a base64 blob that decodes to `;`-separated JSON cookie objects for localhost. **Caveat:** it may only contain the Clerk dev-browser token (`__clerk_db_jwt`) with `__client_uat=0` (a signed-OUT state) and therefore may NOT authenticate on its own — after injecting it `window.Clerk.user` stays `null` and `/admin` redirects to `${_repo_secret_dabit3/vending-machine_NEXT_PUBLIC_CLERK_SIGN_IN_URL}`. Verify by decoding it and checking for a real session; if it lacks `__session`/`__client_uat>0`, it needs re-exporting while signed in.
@@ -24,7 +26,7 @@ description: Run and test the Vending Machine app locally (Next.js + Convex + Cl
 Reliable fallback (uses `CLERK_SECRET_KEY` from repo secrets): mint a single-use sign-in ticket for the admin user and consume it via Clerk's ticket strategy.
 1. Find the admin user id: `GET https://api.clerk.com/v1/users?email_address=dabit3@gmail.com` with `Authorization: Bearer $CLERK_SECRET_KEY`.
 2. `POST https://api.clerk.com/v1/sign_in_tokens` with `{"user_id":"<id>","expires_in_seconds":1800}` → returns `token`.
-3. In the browser, navigate to `http://localhost:3000${_repo_secret_dabit3/vending-machine_NEXT_PUBLIC_CLERK_SIGN_IN_URL}?__clerk_ticket=<token>`. Clerk's `<SignIn>` consumes the ticket, sets `__session`, and redirects. Drive this via Playwright over CDP (`http://localhost:29229`) using the already-running Chrome so cookies persist; `playwright-core` can be installed with `npm install --no-save playwright-core` and run with `NODE_PATH=<repo>/node_modules`.
+3. In the browser, navigate to `http://localhost:3000${_repo_secret_dabit3/vending-machine_NEXT_PUBLIC_CLERK_SIGN_IN_URL}?__clerk_ticket=<token>`. Clerk's `<SignIn>` consumes the ticket, sets `__session`, and redirects. Easiest: open the ticket URL with `DISPLAY=:1 xdg-open "$URL"` in the already-running Chrome (typing the long URL into the omnibox via keyboard emulation can drop characters and yield "This ticket is invalid"). Tickets are single-use — mint a fresh one per attempt. Alternatively drive it via Playwright over CDP (`http://localhost:29229`) using the already-running Chrome so cookies persist; `playwright-core` can be installed with `npm install --no-save playwright-core` and run with `NODE_PATH=<repo>/node_modules`.
 
 After sign-in, `/admin` shows the "Admin" badge + avatar and the Events dashboard. Global admins see the "New event" button and per-event "Delete event" button (they render only when `access.isGlobalAdmin`).
 

--- a/components/ManageEvent.tsx
+++ b/components/ManageEvent.tsx
@@ -154,15 +154,18 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
         eventId: id,
         emails: list,
       });
-      toast.success(`Added ${added} emails`, {
-        description:
-          [
-            flagged ? `${flagged} flagged for review (found in past events).` : "",
-            skipped ? `Skipped ${skipped} (duplicates/invalid).` : "",
-          ]
-            .filter(Boolean)
-            .join(" ") || undefined,
-      });
+      const description =
+        [
+          flagged ? `${flagged} flagged for review (found in past events).` : "",
+          skipped ? `Skipped ${skipped} (duplicates/invalid).` : "",
+        ]
+          .filter(Boolean)
+          .join(" ") || undefined;
+      if (added === 0 && flagged > 0) {
+        toast.warning(`${flagged} emails awaiting review`, { description });
+      } else {
+        toast.success(`Added ${added} emails`, { description });
+      }
       setEmailInput("");
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Failed to add emails");
@@ -246,16 +249,24 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
         skipped += res.skipped;
         flagged += res.flagged ?? 0;
       }
-      toast.success(`Added ${added} from ${file.name}`, {
-        id: toastId,
-        description:
-          [
-            flagged ? `${flagged} flagged for review (found in past events).` : "",
-            skipped ? `Skipped ${skipped} duplicates or invalid rows.` : "",
-          ]
-            .filter(Boolean)
-            .join(" ") || undefined,
-      });
+      const description =
+        [
+          flagged ? `${flagged} flagged for review (found in past events).` : "",
+          skipped ? `Skipped ${skipped} duplicates or invalid rows.` : "",
+        ]
+          .filter(Boolean)
+          .join(" ") || undefined;
+      if (added === 0 && flagged > 0) {
+        toast.warning(`${flagged} from ${file.name} awaiting review`, {
+          id: toastId,
+          description,
+        });
+      } else {
+        toast.success(`Added ${added} from ${file.name}`, {
+          id: toastId,
+          description,
+        });
+      }
     } catch {
       toast.error(`Could not read ${file.name}`, {
         id: toastId,

--- a/components/ManageEvent.tsx
+++ b/components/ManageEvent.tsx
@@ -363,8 +363,14 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
                     <span className="truncate text-sm">{f.email}</span>
                     <span className="truncate text-xs text-muted-dim">
                       Also in:{" "}
-                      {f.matchedEvents.map((e) => e.name).join(", ") ||
-                        "deleted event(s)"}
+                      {[
+                        f.matchedEvents.map((e) => e.name).join(", "),
+                        f.otherMatchCount > 0
+                          ? `${f.otherMatchCount} other event(s)`
+                          : "",
+                      ]
+                        .filter(Boolean)
+                        .join(", ") || "deleted event(s)"}
                     </span>
                   </div>
                   <div className="flex shrink-0 items-center gap-2">

--- a/components/ManageEvent.tsx
+++ b/components/ManageEvent.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import {
+  AlertTriangle,
   ArrowLeft,
   ArrowUpRight,
   Check,
@@ -70,10 +71,13 @@ const UPLOAD_CHUNK_SIZE = 500;
 export default function ManageEvent({ id }: { id: Id<"events"> }) {
   const event = useQuery(api.events.get, { id });
   const emails = useQuery(api.emails.list, { eventId: id });
+  const flagged = useQuery(api.emails.listFlagged, { eventId: id });
   const codes = useQuery(api.codes.list, { eventId: id });
   const access = useQuery(api.admins.accessLevel);
   const addEmails = useMutation(api.emails.add);
   const removeEmail = useMutation(api.emails.remove);
+  const approveFlagged = useMutation(api.emails.approveFlagged);
+  const rejectFlagged = useMutation(api.emails.rejectFlagged);
   const addCodes = useMutation(api.codes.add);
   const removeCode = useMutation(api.codes.remove);
 
@@ -146,9 +150,18 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
     if (list.length === 0) return;
     setEmailBusy(true);
     try {
-      const { added, skipped } = await addEmails({ eventId: id, emails: list });
+      const { added, skipped, flagged } = await addEmails({
+        eventId: id,
+        emails: list,
+      });
       toast.success(`Added ${added} emails`, {
-        description: skipped ? `Skipped ${skipped} (duplicates/invalid).` : undefined,
+        description:
+          [
+            flagged ? `${flagged} flagged for review (found in past events).` : "",
+            skipped ? `Skipped ${skipped} (duplicates/invalid).` : "",
+          ]
+            .filter(Boolean)
+            .join(" ") || undefined,
       });
       setEmailInput("");
     } catch (err) {
@@ -199,7 +212,9 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
   async function importFile(
     file: File,
     kind: "emails" | "codes",
-    send: (items: string[]) => Promise<{ added: number; skipped: number }>,
+    send: (
+      items: string[]
+    ) => Promise<{ added: number; skipped: number; flagged?: number }>,
     setBusy: (busy: boolean) => void
   ) {
     setBusy(true);
@@ -212,6 +227,7 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
       }
       let added = 0;
       let skipped = 0;
+      let flagged = 0;
       for (let i = 0; i < items.length; i += UPLOAD_CHUNK_SIZE) {
         toast.loading(
           `Uploading ${Math.min(i + UPLOAD_CHUNK_SIZE, items.length)} / ${items.length}...`,
@@ -220,10 +236,17 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
         const res = await send(items.slice(i, i + UPLOAD_CHUNK_SIZE));
         added += res.added;
         skipped += res.skipped;
+        flagged += res.flagged ?? 0;
       }
       toast.success(`Added ${added} from ${file.name}`, {
         id: toastId,
-        description: skipped ? `Skipped ${skipped} duplicates or invalid rows.` : undefined,
+        description:
+          [
+            flagged ? `${flagged} flagged for review (found in past events).` : "",
+            skipped ? `Skipped ${skipped} duplicates or invalid rows.` : "",
+          ]
+            .filter(Boolean)
+            .join(" ") || undefined,
       });
     } catch {
       toast.error(`Could not read ${file.name}`, {
@@ -314,6 +337,69 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
         event={event}
         canDelete={access?.isGlobalAdmin ?? false}
       />
+
+      {flagged && flagged.length > 0 ? (
+        <Card className="border-amber-500/40">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <AlertTriangle className="size-4 text-amber-500" aria-hidden />
+              Flagged for review
+              <Badge variant="secondary">{flagged.length}</Badge>
+            </CardTitle>
+            <CardDescription>
+              These uploaded emails already signed up for previous events.
+              Approve each one individually to add it to the eligible list, or
+              reject it to discard it.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ul className="max-h-96 divide-y divide-border overflow-y-auto border-y border-border">
+              {flagged.map((f) => (
+                <li
+                  key={f._id}
+                  className="flex min-h-12 flex-wrap items-center justify-between gap-3 px-1 py-2 transition-colors hover:bg-surface"
+                >
+                  <div className="flex min-w-0 flex-col">
+                    <span className="truncate text-sm">{f.email}</span>
+                    <span className="truncate text-xs text-muted-dim">
+                      Also in:{" "}
+                      {f.matchedEvents.map((e) => e.name).join(", ") ||
+                        "deleted event(s)"}
+                    </span>
+                  </div>
+                  <div className="flex shrink-0 items-center gap-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() =>
+                        approveFlagged({ id: f._id })
+                          .then(() => toast.success(`Approved ${f.email}`))
+                          .catch(() => toast.error("Failed to approve"))
+                      }
+                    >
+                      <Check data-icon="inline-start" />
+                      Approve
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="text-muted-foreground"
+                      onClick={() =>
+                        rejectFlagged({ id: f._id })
+                          .then(() => toast.success(`Rejected ${f.email}`))
+                          .catch(() => toast.error("Failed to reject"))
+                      }
+                    >
+                      <X data-icon="inline-start" />
+                      Reject
+                    </Button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+      ) : null}
 
       <div className="grid gap-8 lg:grid-cols-2">
         <Card>

--- a/components/ManageEvent.tsx
+++ b/components/ManageEvent.tsx
@@ -389,7 +389,7 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
                           : "",
                       ]
                         .filter(Boolean)
-                        .join(", ") || "deleted event(s)"}
+                        .join(", ") || "no longer on another event's list"}
                     </span>
                   </div>
                   <div className="flex shrink-0 items-center gap-2">

--- a/components/ManageEvent.tsx
+++ b/components/ManageEvent.tsx
@@ -357,23 +357,29 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
         canDelete={access?.isGlobalAdmin ?? false}
       />
 
-      {flagged && flagged.length > 0 ? (
+      {flagged && flagged.entries.length > 0 ? (
         <Card className="border-amber-500/40">
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <AlertTriangle className="size-4 text-amber-500" aria-hidden />
               Flagged for review
-              <Badge variant="secondary">{flagged.length}</Badge>
+              <Badge variant="secondary">
+                {flagged.entries.length}
+                {flagged.hasMore ? "+" : ""}
+              </Badge>
             </CardTitle>
             <CardDescription>
               These uploaded emails already signed up for previous events.
               Approve each one individually to add it to the eligible list, or
               reject it to discard it.
+              {flagged.hasMore
+                ? " Showing the first batch; more will appear as these are resolved."
+                : ""}
             </CardDescription>
           </CardHeader>
           <CardContent>
             <ul className="max-h-96 divide-y divide-border overflow-y-auto border-y border-border">
-              {flagged.map((f) => (
+              {flagged.entries.map((f) => (
                 <li
                   key={f._id}
                   className="flex min-h-12 flex-wrap items-center justify-between gap-3 px-1 py-2 transition-colors hover:bg-surface"

--- a/components/ManageEvent.tsx
+++ b/components/ManageEvent.tsx
@@ -220,13 +220,21 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
     setBusy(true);
     const toastId = toast.loading(`Reading ${file.name}...`);
     try {
-      const items = await fileToItems(file, kind);
+      const rows = await fileToItems(file, kind);
+      // Dedupe up front so repeats split across upload chunks aren't
+      // double-counted by the server.
+      const items = [
+        ...new Set(
+          rows.map((r) => (kind === "emails" ? r.trim().toLowerCase() : r.trim()))
+        ),
+      ];
+      const dropped = rows.length - items.length;
       if (items.length === 0) {
         toast.warning(`Nothing to import found in ${file.name}`, { id: toastId });
         return;
       }
       let added = 0;
-      let skipped = 0;
+      let skipped = dropped;
       let flagged = 0;
       for (let i = 0; i < items.length; i += UPLOAD_CHUNK_SIZE) {
         toast.loading(

--- a/components/WalkUpClaim.tsx
+++ b/components/WalkUpClaim.tsx
@@ -65,10 +65,17 @@ export default function WalkUpClaim({ id }: { id: Id<"events"> }) {
     if (!trimmed) return;
     setSubmitting(true);
     try {
-      const { added, skipped } = await addEmails({
+      const { added, skipped, flagged } = await addEmails({
         eventId: id,
         emails: [trimmed],
       });
+      if (flagged > 0) {
+        toast.warning(`${trimmed} needs organizer approval`, {
+          description:
+            "This email signed up for a previous event. Approve it under Flagged for review on the manage event page.",
+        });
+        return;
+      }
       if (added === 0 && skipped > 0) {
         toast.info(`${trimmed} is already on the list`, {
           description: "They can scan the code and claim right away.",

--- a/convex/emails.ts
+++ b/convex/emails.ts
@@ -102,6 +102,11 @@ export const approveFlagged = mutation({
     const flagged = await ctx.db.get(args.id);
     if (!flagged) return;
     const actorEmail = await requireEventAdmin(ctx, flagged.eventId);
+    const event = await ctx.db.get(flagged.eventId);
+    if (!event) {
+      await ctx.db.delete(args.id);
+      return;
+    }
     const existing = await ctx.db
       .query("emails")
       .withIndex("by_event_email", (q) =>

--- a/convex/emails.ts
+++ b/convex/emails.ts
@@ -1,6 +1,7 @@
 import { mutation, query } from "./_generated/server";
 import { v } from "convex/values";
-import { requireEventAdmin } from "./admins";
+import type { Id } from "./_generated/dataModel";
+import { adminEmailStatus, requireEventAdmin } from "./admins";
 import { logAudit } from "./auditLog";
 
 export const list = query({
@@ -52,15 +53,18 @@ export const add = mutation({
             q.eq("eventId", args.eventId).eq("email", email)
           )
           .unique();
+        const matchedEventIds = [...new Set(otherEvents.map((e) => e.eventId))];
         if (alreadyFlagged) {
-          // Still pending review — report as flagged so callers don't treat
-          // it as an ordinary duplicate that can already claim.
+          // Still pending review — refresh the matches so the organizer sees
+          // every event the address appears in, and report as flagged so
+          // callers don't treat it as an ordinary duplicate that can claim.
+          await ctx.db.patch(alreadyFlagged._id, { matchedEventIds });
           flagged++;
         } else {
           await ctx.db.insert("flaggedEmails", {
             eventId: args.eventId,
             email,
-            matchedEventIds: [...new Set(otherEvents.map((e) => e.eventId))],
+            matchedEventIds,
           });
           flagged++;
         }
@@ -87,23 +91,39 @@ export const add = mutation({
 export const listFlagged = query({
   args: { eventId: v.id("events") },
   handler: async (ctx, args) => {
-    await requireEventAdmin(ctx, args.eventId);
-    const flagged = await ctx.db
-      .query("flaggedEmails")
-      .withIndex("by_event", (q) => q.eq("eventId", args.eventId))
-      .collect();
+    const callerEmail = await requireEventAdmin(ctx, args.eventId);
+    const { isAdmin: isGlobalAdmin } = await adminEmailStatus(ctx);
     return await Promise.all(
-      flagged.map(async (f) => {
-        const events = await Promise.all(
-          f.matchedEventIds.map((id) => ctx.db.get(id))
-        );
-        return {
-          _id: f._id,
-          email: f.email,
-          matchedEvents: events
-            .filter((e) => e !== null)
-            .map((e) => ({ id: e._id, name: e.name })),
-        };
+      (
+        await ctx.db
+          .query("flaggedEmails")
+          .withIndex("by_event", (q) => q.eq("eventId", args.eventId))
+          .collect()
+      ).map(async (f) => {
+        // Event names are only disclosed for events the caller can manage;
+        // matches in other admins' events are reported as a count.
+        const matchedEvents: { id: Id<"events">; name: string }[] = [];
+        let otherMatchCount = 0;
+        for (const eventId of f.matchedEventIds) {
+          const event = await ctx.db.get(eventId);
+          if (!event) continue;
+          let canSee = isGlobalAdmin;
+          if (!canSee && callerEmail) {
+            const membership = await ctx.db
+              .query("eventAdmins")
+              .withIndex("by_event_email", (q) =>
+                q.eq("eventId", eventId).eq("email", callerEmail)
+              )
+              .unique();
+            canSee = membership !== null;
+          }
+          if (canSee) {
+            matchedEvents.push({ id: event._id, name: event.name });
+          } else {
+            otherMatchCount++;
+          }
+        }
+        return { _id: f._id, email: f.email, matchedEvents, otherMatchCount };
       })
     );
   },

--- a/convex/emails.ts
+++ b/convex/emails.ts
@@ -22,12 +22,14 @@ export const add = mutation({
     let added = 0;
     let skipped = 0;
     let flagged = 0;
+    const seen = new Set<string>();
     for (const raw of args.emails) {
       const email = raw.trim().toLowerCase();
-      if (!email || !email.includes("@")) {
+      if (!email || !email.includes("@") || seen.has(email)) {
         skipped++;
         continue;
       }
+      seen.add(email);
       const existing = await ctx.db
         .query("emails")
         .withIndex("by_event_email", (q) =>

--- a/convex/emails.ts
+++ b/convex/emails.ts
@@ -1,6 +1,7 @@
 import { mutation, query } from "./_generated/server";
 import { v } from "convex/values";
 import { requireEventAdmin } from "./admins";
+import { logAudit } from "./auditLog";
 
 export const list = query({
   args: { eventId: v.id("events") },
@@ -19,6 +20,7 @@ export const add = mutation({
     await requireEventAdmin(ctx, args.eventId);
     let added = 0;
     let skipped = 0;
+    let flagged = 0;
     for (const raw of args.emails) {
       const email = raw.trim().toLowerCase();
       if (!email || !email.includes("@")) {
@@ -35,10 +37,108 @@ export const add = mutation({
         skipped++;
         continue;
       }
+      // Emails already signed up for other events are held for manual
+      // review instead of being added directly.
+      const otherEvents = (
+        await ctx.db
+          .query("emails")
+          .withIndex("by_email", (q) => q.eq("email", email))
+          .collect()
+      ).filter((e) => e.eventId !== args.eventId);
+      if (otherEvents.length > 0) {
+        const alreadyFlagged = await ctx.db
+          .query("flaggedEmails")
+          .withIndex("by_event_email", (q) =>
+            q.eq("eventId", args.eventId).eq("email", email)
+          )
+          .unique();
+        if (alreadyFlagged) {
+          skipped++;
+        } else {
+          await ctx.db.insert("flaggedEmails", {
+            eventId: args.eventId,
+            email,
+            matchedEventIds: [...new Set(otherEvents.map((e) => e.eventId))],
+          });
+          flagged++;
+        }
+        continue;
+      }
       await ctx.db.insert("emails", { eventId: args.eventId, email });
       added++;
     }
-    return { added, skipped };
+    return { added, skipped, flagged };
+  },
+});
+
+export const listFlagged = query({
+  args: { eventId: v.id("events") },
+  handler: async (ctx, args) => {
+    await requireEventAdmin(ctx, args.eventId);
+    const flagged = await ctx.db
+      .query("flaggedEmails")
+      .withIndex("by_event", (q) => q.eq("eventId", args.eventId))
+      .collect();
+    return await Promise.all(
+      flagged.map(async (f) => {
+        const events = await Promise.all(
+          f.matchedEventIds.map((id) => ctx.db.get(id))
+        );
+        return {
+          _id: f._id,
+          email: f.email,
+          matchedEvents: events
+            .filter((e) => e !== null)
+            .map((e) => ({ id: e._id, name: e.name })),
+        };
+      })
+    );
+  },
+});
+
+export const approveFlagged = mutation({
+  args: { id: v.id("flaggedEmails") },
+  handler: async (ctx, args) => {
+    const flagged = await ctx.db.get(args.id);
+    if (!flagged) return;
+    const actorEmail = await requireEventAdmin(ctx, flagged.eventId);
+    const existing = await ctx.db
+      .query("emails")
+      .withIndex("by_event_email", (q) =>
+        q.eq("eventId", flagged.eventId).eq("email", flagged.email)
+      )
+      .unique();
+    if (!existing) {
+      await ctx.db.insert("emails", {
+        eventId: flagged.eventId,
+        email: flagged.email,
+      });
+    }
+    await ctx.db.delete(args.id);
+    await logAudit(ctx, {
+      eventId: flagged.eventId,
+      action: "flagged_email_approved",
+      actorEmail: actorEmail ?? undefined,
+      subjectEmail: flagged.email,
+      details: `Duplicate across ${flagged.matchedEventIds.length} other event(s)`,
+    });
+  },
+});
+
+export const rejectFlagged = mutation({
+  args: { id: v.id("flaggedEmails") },
+  handler: async (ctx, args) => {
+    const flagged = await ctx.db.get(args.id);
+    if (!flagged) return;
+    const actorEmail = await requireEventAdmin(ctx, flagged.eventId);
+    await ctx.db.delete(args.id);
+    await logAudit(ctx, {
+      eventId: flagged.eventId,
+      action: "flagged_email_rejected",
+      actorEmail: actorEmail ?? undefined,
+      subjectEmail: flagged.email,
+      details: `Duplicate across ${flagged.matchedEventIds.length} other event(s)`,
+    });
   },
 });
 

--- a/convex/emails.ts
+++ b/convex/emails.ts
@@ -90,53 +90,70 @@ export const add = mutation({
   },
 });
 
+const FLAGGED_PAGE_SIZE = 200;
+
 export const listFlagged = query({
   args: { eventId: v.id("events") },
   handler: async (ctx, args) => {
     const callerEmail = await requireEventAdmin(ctx, args.eventId);
     const { isAdmin: isGlobalAdmin } = await adminEmailStatus(ctx);
-    return await Promise.all(
-      (
-        await ctx.db
-          .query("flaggedEmails")
-          .withIndex("by_event", (q) => q.eq("eventId", args.eventId))
-          .collect()
-      ).map(async (f) => {
-        // Event names are only disclosed for events the caller can manage;
-        // matches in other admins' events are reported as a count.
-        const matchedEvents: { id: Id<"events">; name: string }[] = [];
-        let otherMatchCount = 0;
-        for (const eventId of f.matchedEventIds) {
+    // Bounded page plus memoized per-event lookups keep the query within
+    // Convex's per-request read limits after large uploads.
+    const rows = await ctx.db
+      .query("flaggedEmails")
+      .withIndex("by_event", (q) => q.eq("eventId", args.eventId))
+      .take(FLAGGED_PAGE_SIZE + 1);
+    const hasMore = rows.length > FLAGGED_PAGE_SIZE;
+    const eventCache = new Map<
+      Id<"events">,
+      { name: string; canSee: boolean } | null
+    >();
+    const entries = [];
+    for (const f of rows.slice(0, FLAGGED_PAGE_SIZE)) {
+      // Event names are only disclosed for events the caller can manage;
+      // matches in other admins' events are reported as a count.
+      const matchedEvents: { id: Id<"events">; name: string }[] = [];
+      let otherMatchCount = 0;
+      for (const eventId of f.matchedEventIds) {
+        let info = eventCache.get(eventId);
+        if (info === undefined) {
           const event = await ctx.db.get(eventId);
-          if (!event) continue;
-          // The stored matches are a snapshot; only show events where the
-          // address is still on the eligible list.
-          const stillListed = await ctx.db
-            .query("emails")
-            .withIndex("by_event_email", (q) =>
-              q.eq("eventId", eventId).eq("email", f.email)
-            )
-            .unique();
-          if (!stillListed) continue;
-          let canSee = isGlobalAdmin;
-          if (!canSee && callerEmail) {
-            const membership = await ctx.db
-              .query("eventAdmins")
-              .withIndex("by_event_email", (q) =>
-                q.eq("eventId", eventId).eq("email", callerEmail)
-              )
-              .unique();
-            canSee = membership !== null;
-          }
-          if (canSee) {
-            matchedEvents.push({ id: event._id, name: event.name });
+          if (!event) {
+            info = null;
           } else {
-            otherMatchCount++;
+            let canSee = isGlobalAdmin;
+            if (!canSee && callerEmail) {
+              const membership = await ctx.db
+                .query("eventAdmins")
+                .withIndex("by_event_email", (q) =>
+                  q.eq("eventId", eventId).eq("email", callerEmail)
+                )
+                .unique();
+              canSee = membership !== null;
+            }
+            info = { name: event.name, canSee };
           }
+          eventCache.set(eventId, info);
         }
-        return { _id: f._id, email: f.email, matchedEvents, otherMatchCount };
-      })
-    );
+        if (!info) continue;
+        // The stored matches are a snapshot; only show events where the
+        // address is still on the eligible list.
+        const stillListed = await ctx.db
+          .query("emails")
+          .withIndex("by_event_email", (q) =>
+            q.eq("eventId", eventId).eq("email", f.email)
+          )
+          .unique();
+        if (!stillListed) continue;
+        if (info.canSee) {
+          matchedEvents.push({ id: eventId, name: info.name });
+        } else {
+          otherMatchCount++;
+        }
+      }
+      entries.push({ _id: f._id, email: f.email, matchedEvents, otherMatchCount });
+    }
+    return { entries, hasMore };
   },
 });
 

--- a/convex/emails.ts
+++ b/convex/emails.ts
@@ -109,6 +109,15 @@ export const listFlagged = query({
         for (const eventId of f.matchedEventIds) {
           const event = await ctx.db.get(eventId);
           if (!event) continue;
+          // The stored matches are a snapshot; only show events where the
+          // address is still on the eligible list.
+          const stillListed = await ctx.db
+            .query("emails")
+            .withIndex("by_event_email", (q) =>
+              q.eq("eventId", eventId).eq("email", f.email)
+            )
+            .unique();
+          if (!stillListed) continue;
           let canSee = isGlobalAdmin;
           if (!canSee && callerEmail) {
             const membership = await ctx.db

--- a/convex/emails.ts
+++ b/convex/emails.ts
@@ -53,7 +53,9 @@ export const add = mutation({
           )
           .unique();
         if (alreadyFlagged) {
-          skipped++;
+          // Still pending review — report as flagged so callers don't treat
+          // it as an ordinary duplicate that can already claim.
+          flagged++;
         } else {
           await ctx.db.insert("flaggedEmails", {
             eventId: args.eventId,
@@ -137,6 +139,28 @@ export const rejectFlagged = mutation({
     if (!flagged) return;
     const actorEmail = await requireEventAdmin(ctx, flagged.eventId);
     await ctx.db.delete(args.id);
+    // The address may have become eligible through another path (e.g. an
+    // approved access request) while flagged — rejection removes it from the
+    // eligible list and releases any code held for it.
+    const eligible = await ctx.db
+      .query("emails")
+      .withIndex("by_event_email", (q) =>
+        q.eq("eventId", flagged.eventId).eq("email", flagged.email)
+      )
+      .unique();
+    if (eligible) {
+      await ctx.db.delete(eligible._id);
+      const reserved = await ctx.db
+        .query("codes")
+        .withIndex("by_event_reservedFor", (q) =>
+          q.eq("eventId", flagged.eventId).eq("reservedFor", flagged.email)
+        )
+        .filter((q) => q.eq(q.field("claimedBy"), undefined))
+        .collect();
+      for (const code of reserved) {
+        await ctx.db.patch(code._id, { reservedFor: undefined });
+      }
+    }
     await logAudit(ctx, {
       eventId: flagged.eventId,
       action: "flagged_email_rejected",

--- a/convex/emails.ts
+++ b/convex/emails.ts
@@ -67,6 +67,17 @@ export const add = mutation({
         continue;
       }
       await ctx.db.insert("emails", { eventId: args.eventId, email });
+      // A stale review entry (e.g. left over after the matching event was
+      // deleted) is resolved by the address becoming eligible normally.
+      const staleFlag = await ctx.db
+        .query("flaggedEmails")
+        .withIndex("by_event_email", (q) =>
+          q.eq("eventId", args.eventId).eq("email", email)
+        )
+        .unique();
+      if (staleFlag) {
+        await ctx.db.delete(staleFlag._id);
+      }
       added++;
     }
     return { added, skipped, flagged };
@@ -159,6 +170,17 @@ export const rejectFlagged = mutation({
         .collect();
       for (const code of reserved) {
         await ctx.db.patch(code._id, { reservedFor: undefined });
+      }
+      // Drop an approved access request so the attendee isn't stuck showing
+      // "approved" while no longer being eligible.
+      const request = await ctx.db
+        .query("accessRequests")
+        .withIndex("by_event_email", (q) =>
+          q.eq("eventId", flagged.eventId).eq("email", flagged.email)
+        )
+        .unique();
+      if (request && request.status === "approved") {
+        await ctx.db.delete(request._id);
       }
     }
     await logAudit(ctx, {

--- a/convex/events.ts
+++ b/convex/events.ts
@@ -205,6 +205,11 @@ export const remove = mutation({
       .withIndex("by_event", (q) => q.eq("eventId", args.id))
       .collect();
     for (const email of emails) await ctx.db.delete(email._id);
+    const flagged = await ctx.db
+      .query("flaggedEmails")
+      .withIndex("by_event", (q) => q.eq("eventId", args.id))
+      .collect();
+    for (const entry of flagged) await ctx.db.delete(entry._id);
     const codes = await ctx.db
       .query("codes")
       .withIndex("by_event", (q) => q.eq("eventId", args.id))

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -27,6 +27,15 @@ export default defineSchema({
     email: v.string(),
   })
     .index("by_event", ["eventId"])
+    .index("by_event_email", ["eventId", "email"])
+    .index("by_email", ["email"]),
+
+  flaggedEmails: defineTable({
+    eventId: v.id("events"),
+    email: v.string(),
+    matchedEventIds: v.array(v.id("events")),
+  })
+    .index("by_event", ["eventId"])
     .index("by_event_email", ["eventId", "email"]),
 
   codes: defineTable({

--- a/convex/waitlist.ts
+++ b/convex/waitlist.ts
@@ -107,21 +107,34 @@ export const listRequests = query({
   },
   handler: async (ctx, args) => {
     await requireEventAdmin(ctx, args.eventId);
-    if (args.status !== undefined) {
-      const status = args.status;
-      return await ctx.db
-        .query("accessRequests")
-        .withIndex("by_event_status", (q) =>
-          q.eq("eventId", args.eventId).eq("status", status)
-        )
-        .order("desc")
-        .collect();
-    }
-    return await ctx.db
-      .query("accessRequests")
-      .withIndex("by_event", (q) => q.eq("eventId", args.eventId))
-      .order("desc")
-      .collect();
+    const status = args.status;
+    const requests =
+      status !== undefined
+        ? await ctx.db
+            .query("accessRequests")
+            .withIndex("by_event_status", (q) =>
+              q.eq("eventId", args.eventId).eq("status", status)
+            )
+            .order("desc")
+            .collect()
+        : await ctx.db
+            .query("accessRequests")
+            .withIndex("by_event", (q) => q.eq("eventId", args.eventId))
+            .order("desc")
+            .collect();
+    // Surface pending duplicate-review flags so approvers know the address
+    // appears on other events' lists before deciding.
+    return await Promise.all(
+      requests.map(async (r) => {
+        const pendingFlag = await ctx.db
+          .query("flaggedEmails")
+          .withIndex("by_event_email", (q) =>
+            q.eq("eventId", args.eventId).eq("email", r.email)
+          )
+          .unique();
+        return { ...r, flaggedForReview: pendingFlag !== null };
+      })
+    );
   },
 });
 
@@ -183,6 +196,13 @@ export const approve = mutation({
       .unique();
     if (pendingFlag) {
       await ctx.db.delete(pendingFlag._id);
+      await logAudit(ctx, {
+        eventId: request.eventId,
+        action: "flagged_email_approved",
+        actorEmail: adminEmail ?? undefined,
+        subjectEmail: request.email,
+        details: "Resolved via access request approval",
+      });
     }
 
     // Reserve the first unclaimed, unreserved code so the pool can't be

--- a/convex/waitlist.ts
+++ b/convex/waitlist.ts
@@ -173,6 +173,17 @@ export const approve = mutation({
         email: request.email,
       });
     }
+    // Approving an access request resolves any pending duplicate-review flag
+    // for the same address, so it doesn't sit both eligible and flagged.
+    const pendingFlag = await ctx.db
+      .query("flaggedEmails")
+      .withIndex("by_event_email", (q) =>
+        q.eq("eventId", request.eventId).eq("email", request.email)
+      )
+      .unique();
+    if (pendingFlag) {
+      await ctx.db.delete(pendingFlag._id);
+    }
 
     // Reserve the first unclaimed, unreserved code so the pool can't be
     // exhausted before the approved attendee gets a chance to claim. Skip


### PR DESCRIPTION
## Summary
When emails are uploaded (CSV/XLSX or pasted), any address that already appears in another event's eligible list is no longer added directly. Instead it goes to a new `flaggedEmails` table and shows up in a "Flagged for review" section on the manage-event page, where the organizer must approve or reject each one individually — guarding against abuse via repeat signups across events.

- `emails.add` now checks a new `emails.by_email` index across all events; hits go to `flaggedEmails` (with `matchedEventIds`) and are returned as a `flagged` count in the toast.
- New `emails.listFlagged` (resolves matched event names), `emails.approveFlagged` (moves to eligible list) and `emails.rejectFlagged` (discards); both decisions are written to the audit log (`flagged_email_approved` / `flagged_email_rejected`).
- `ManageEvent` shows an amber "Flagged for review" card (only when non-empty) listing each flagged email with the events it also appeared in and per-row Approve/Reject buttons.

Link to Devin session: https://app.devin.ai/sessions/84722b8527974806aa7dbdaf557d414a
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/46" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->