### PR TITLE
Animated sun/moon morph icon for theme toggle

### DIFF
--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -2,6 +2,8 @@
 
 import { useTheme } from "next-themes";
 
+const RAY_ANGLES = [0, 45, 90, 135, 180, 225, 270, 315];
+
 export function ThemeToggle() {
   const { setTheme, resolvedTheme } = useTheme();
   const nextTheme = resolvedTheme === "dark" ? "light" : "dark";
@@ -12,16 +14,51 @@ export function ThemeToggle() {
       onClick={() => setTheme(nextTheme)}
       aria-label="Toggle color theme"
       title="Toggle color theme"
-      className="group flex h-8 cursor-pointer items-center gap-1.5 rounded-full px-2 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+      className="group flex size-8 cursor-pointer items-center justify-center rounded-full text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
     >
-      <span aria-hidden className="grid overflow-hidden text-left">
-        <span className="[grid-area:1/1] transition-[translate,opacity] duration-300 motion-reduce:transition-none dark:-translate-y-2 dark:opacity-0">
-          light
-        </span>
-        <span className="[grid-area:1/1] translate-y-2 opacity-0 transition-[translate,opacity] duration-300 motion-reduce:transition-none dark:translate-y-0 dark:opacity-100">
-          dark
-        </span>
-      </span>
+      <svg
+        aria-hidden
+        viewBox="0 0 24 24"
+        fill="none"
+        className="size-4.5 -rotate-90 transition-transform duration-500 ease-[cubic-bezier(0.34,1.56,0.64,1)] group-active:scale-90 motion-reduce:transition-none dark:rotate-0"
+      >
+        <mask id="theme-toggle-moon-mask">
+          <rect width="24" height="24" fill="white" />
+          <circle
+            cx="30"
+            cy="6"
+            r="6"
+            fill="black"
+            className="transition-[cx,cy] duration-500 ease-[cubic-bezier(0.34,1.56,0.64,1)] motion-reduce:transition-none dark:[cx:17] dark:[cy:7]"
+          />
+        </mask>
+        <circle
+          cx="12"
+          cy="12"
+          r="5"
+          fill="currentColor"
+          mask="url(#theme-toggle-moon-mask)"
+          className="transition-[r] duration-500 ease-[cubic-bezier(0.34,1.56,0.64,1)] motion-reduce:transition-none dark:[r:8]"
+        />
+        <g
+          stroke="currentColor"
+          strokeWidth="1.75"
+          strokeLinecap="round"
+          className="transition-opacity duration-300 motion-reduce:transition-none dark:opacity-0"
+        >
+          {RAY_ANGLES.map((angle) => (
+            <line
+              key={angle}
+              x1="12"
+              y1="3.5"
+              x2="12"
+              y2="1.5"
+              transform={`rotate(${angle} 12 12)`}
+              className="origin-center transition-transform duration-500 ease-[cubic-bezier(0.34,1.56,0.64,1)] motion-reduce:transition-none dark:scale-0"
+            />
+          ))}
+        </g>
+      </svg>
     </button>
   );
 }


### PR DESCRIPTION
## Summary
Replaces the "light"/"dark" text swap in `ThemeToggle` with a custom animated sun→moon morph icon (no shadcn/lucide toggle, no new deps).

How it animates (pure CSS via `dark:` variants, all one inline SVG):
- Light: small sun disc (`r:5`) with 8 rays.
- Dark: disc grows to `r:8` while a masking circle slides in from off-canvas to carve a crescent; rays scale to 0 and fade; the whole icon rotates 90° with a springy `cubic-bezier(0.34,1.56,0.64,1)` ease.
- `motion-reduce:transition-none` respects reduced motion; `group-active:scale-90` gives a little press squish. Keeps the same `aria-label`/focus styles.


Link to Devin session: https://app.devin.ai/sessions/5093b3f8069c4e05afae86356fac4d82
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/47" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->