### PR TITLE
Fix theme toggle: working sun/moon morph and a sun that reads as a sun

### DIFF
--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -35,14 +35,14 @@ export function ThemeToggle() {
         <circle
           cx="12"
           cy="12"
-          r="5"
+          r="4.25"
           fill="currentColor"
           mask="url(#theme-toggle-moon-mask)"
           className="transition-[r] duration-500 ease-[cubic-bezier(0.34,1.56,0.64,1)] motion-reduce:transition-none dark:[r:8px]"
         />
         <g
           stroke="currentColor"
-          strokeWidth="1.75"
+          strokeWidth="1.6"
           strokeLinecap="round"
           className="transition-opacity duration-300 motion-reduce:transition-none dark:opacity-0"
         >
@@ -50,9 +50,9 @@ export function ThemeToggle() {
             <line
               key={angle}
               x1="12"
-              y1="3.5"
+              y1="6.4"
               x2="12"
-              y2="1.5"
+              y2="2.6"
               transform={`rotate(${angle} 12 12)`}
               className="origin-center transition-transform duration-500 ease-[cubic-bezier(0.34,1.56,0.64,1)] motion-reduce:transition-none dark:scale-0"
             />

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -29,7 +29,7 @@ export function ThemeToggle() {
             cy="6"
             r="6"
             fill="black"
-            className="transition-[cx,cy] duration-500 ease-[cubic-bezier(0.34,1.56,0.64,1)] motion-reduce:transition-none dark:[cx:17] dark:[cy:7]"
+            className="transition-[cx,cy] duration-500 ease-[cubic-bezier(0.34,1.56,0.64,1)] motion-reduce:transition-none dark:[cx:17px] dark:[cy:7px]"
           />
         </mask>
         <circle
@@ -38,7 +38,7 @@ export function ThemeToggle() {
           r="5"
           fill="currentColor"
           mask="url(#theme-toggle-moon-mask)"
-          className="transition-[r] duration-500 ease-[cubic-bezier(0.34,1.56,0.64,1)] motion-reduce:transition-none dark:[r:8]"
+          className="transition-[r] duration-500 ease-[cubic-bezier(0.34,1.56,0.64,1)] motion-reduce:transition-none dark:[r:8px]"
         />
         <g
           stroke="currentColor"


### PR DESCRIPTION
## Summary
Follow-up to #47, two fixes to `ThemeToggle`:

1. **Morph never played.** The dark-mode geometry overrides (`dark:[cx:17]`, `dark:[cy:7]`, `dark:[r:8]`) were unitless, and CSS requires `<length>` values for SVG geometry properties, so browsers discarded them. Now `17px`/`7px`/`8px`.
2. **Sun didn't look like a sun.** Rays were 2px stubs sitting far from a large disc. Rebalanced to Lucide-ish proportions: disc `r` 5 → 4.25, rays `y1/y2` 3.5→1.5 becomes 6.4→2.6, `strokeWidth` 1.75 → 1.6.

Rendered both states (light / dark):

![sun and moon icon states](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctOTFlZTA2ZGFhYjRlNGZkMGFiNjExMzU1MmRiOTY5YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctOTFlZTA2ZGFhYjRlNGZkMGFiNjExMzU1MmRiOTY5YmUvMWMwZTZiYjQtZWUwMC00ODQ0LWI0NDktMDU2NDIyM2E0MDI2IiwiaWF0IjoxNzg2NzIyMzExLCJleHAiOjE3ODczMjcxMTEsImZpbGVuYW1lIjoicHJldmlldy5wbmcifQ.gtpFlhRXccL5dEWRLJuTe7y0Mq9S1azNfUZlLRrziQw)

Link to Devin session: https://app.devin.ai/sessions/5093b3f8069c4e05afae86356fac4d82
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/48" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->