### PR TITLE
Fix scattered sun rays in theme toggle

### DIFF
--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -47,15 +47,15 @@ export function ThemeToggle() {
           className="transition-opacity duration-300 motion-reduce:transition-none dark:opacity-0"
         >
           {RAY_ANGLES.map((angle) => (
-            <line
-              key={angle}
-              x1="12"
-              y1="6.4"
-              x2="12"
-              y2="2.6"
-              transform={`rotate(${angle} 12 12)`}
-              className="origin-center transition-transform duration-500 ease-[cubic-bezier(0.34,1.56,0.64,1)] motion-reduce:transition-none dark:scale-0"
-            />
+            <g key={angle} transform={`rotate(${angle} 12 12)`}>
+              <line
+                x1="12"
+                y1="6.4"
+                x2="12"
+                y2="2.6"
+                className="[transform-box:view-box] [transform-origin:12px_12px] transition-transform duration-500 ease-[cubic-bezier(0.34,1.56,0.64,1)] motion-reduce:transition-none dark:scale-0"
+              />
+            </g>
           ))}
         </g>
       </svg>


### PR DESCRIPTION
## Summary
The sun rendered as a disc with two stray dashes: `origin-center` on each `<line>` set `transform-origin: center`, and since the SVG `transform` attribute *is* the CSS `transform` property, `rotate(45 12 12)` was then resolved about the line's own box center instead of the view-box origin — scattering the rays, most of them outside the 24×24 viewBox (clipped).

Fix: move the rotation onto a wrapping `<g transform="rotate(a 12 12)">` (untouched by CSS) and keep only the dark-mode `scale-0` on the `<line>`, anchored with `[transform-box:view-box] [transform-origin:12px_12px]` so the rays retract into the disc.

Before / after (rendered with the same CSS declarations Tailwind emits), plus the dark state:

![repro](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctOTFlZTA2ZGFhYjRlNGZkMGFiNjExMzU1MmRiOTY5YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctOTFlZTA2ZGFhYjRlNGZkMGFiNjExMzU1MmRiOTY5YmUvZDc4ZWI2NzUtYmI4Yy00NGMwLWI5MjctYzI4ZjFlMTM0YTM3IiwiaWF0IjoxNzg2NzIyNjQ5LCJleHAiOjE3ODczMjc0NDksImZpbGVuYW1lIjoicmVwcm8ucG5nIn0.qWHXszjXpiZ_6ITk7bCJO3d2wy3e5SFAV2xfX3At-v4)

Link to Devin session: https://app.devin.ai/sessions/5093b3f8069c4e05afae86356fac4d82
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/49" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->