### PR TITLE
Add native iOS Tetris clone (SwiftUI) with engine unit tests

### DIFF
--- a/TetrisiOS/.gitignore
+++ b/TetrisiOS/.gitignore
@@ -1,0 +1,2 @@
+build/
+xcuserdata/

--- a/TetrisiOS/README.md
+++ b/TetrisiOS/README.md
@@ -1,0 +1,33 @@
+# Tetris (iOS)
+
+A native iOS Tetris clone built with SwiftUI.
+
+## Features
+
+- SRS rotation system with full wall-kick tables (JLSTZ + I)
+- 7-bag randomizer, 5-piece next queue, hold piece
+- Ghost piece, soft drop, hard drop, lock delay with move resets (15)
+- Guideline scoring (100/300/500/800 x level, combos, drop bonuses)
+- Level progression every 10 lines with guideline gravity curve
+- Line-clear flash animation, haptic feedback, persistent high score
+- Touch controls (swipe to move, tap to rotate, swipe down to drop),
+  on-screen buttons, and hardware keyboard support
+  (arrows, space = hard drop, `z` = ccw, `c` = hold, `p` = pause)
+
+## Run
+
+```sh
+brew install xcodegen   # if Tetris.xcodeproj is not present
+xcodegen generate
+xcodebuild -project Tetris.xcodeproj -scheme Tetris \
+  -destination 'platform=iOS Simulator,name=iPhone 15 Pro' build
+```
+
+Or open `Tetris.xcodeproj` in Xcode and hit Run.
+
+## Test
+
+```sh
+xcodebuild -project Tetris.xcodeproj -scheme Tetris \
+  -destination 'platform=iOS Simulator,name=iPhone 15 Pro' test
+```

--- a/TetrisiOS/Tetris.xcodeproj/project.pbxproj
+++ b/TetrisiOS/Tetris.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		2D8C697A8BE79AF9E1240D42 /* Tetromino.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDDFE98741657679248C8515 /* Tetromino.swift */; };
 		3B8FB1E3E9E4D20CE1283E39 /* GameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F78E1C582C8D9EBC720F557A /* GameView.swift */; };
 		807C1C12B9C8E47CED849D2E /* GameEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62685271166F4E387662859E /* GameEngineTests.swift */; };
+		8CD02C73309F26F1B9482D30 /* MultiplayerClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29A5E7D634A8749F92517AC6 /* MultiplayerClient.swift */; };
 		97A686558A19063CA6A0C7A0 /* Haptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7450D91BA3E1BCBFEBC23658 /* Haptics.swift */; };
 		C01C748147D7163FA1CFFF52 /* TetrisApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBD255A95AB33B7A69628221 /* TetrisApp.swift */; };
 /* End PBXBuildFile section */
@@ -28,6 +29,7 @@
 
 /* Begin PBXFileReference section */
 		16FC9002A9619D4BBC6DE810 /* Tetris.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = Tetris.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		29A5E7D634A8749F92517AC6 /* MultiplayerClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiplayerClient.swift; sourceTree = "<group>"; };
 		40783BDDC35BCC4608892D2D /* BoardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardView.swift; sourceTree = "<group>"; };
 		609C5ED49D4F27CFE6CC64DE /* GameEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameEngine.swift; sourceTree = "<group>"; };
 		62685271166F4E387662859E /* GameEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameEngineTests.swift; sourceTree = "<group>"; };
@@ -46,6 +48,7 @@
 				609C5ED49D4F27CFE6CC64DE /* GameEngine.swift */,
 				F78E1C582C8D9EBC720F557A /* GameView.swift */,
 				7450D91BA3E1BCBFEBC23658 /* Haptics.swift */,
+				29A5E7D634A8749F92517AC6 /* MultiplayerClient.swift */,
 				FBD255A95AB33B7A69628221 /* TetrisApp.swift */,
 				FDDFE98741657679248C8515 /* Tetromino.swift */,
 			);
@@ -157,6 +160,7 @@
 				2BD02C6ED0DE4E0DA4C7CA82 /* GameEngine.swift in Sources */,
 				3B8FB1E3E9E4D20CE1283E39 /* GameView.swift in Sources */,
 				97A686558A19063CA6A0C7A0 /* Haptics.swift in Sources */,
+				8CD02C73309F26F1B9482D30 /* MultiplayerClient.swift in Sources */,
 				C01C748147D7163FA1CFFF52 /* TetrisApp.swift in Sources */,
 				2D8C697A8BE79AF9E1240D42 /* Tetromino.swift in Sources */,
 			);

--- a/TetrisiOS/Tetris.xcodeproj/project.pbxproj
+++ b/TetrisiOS/Tetris.xcodeproj/project.pbxproj
@@ -1,0 +1,408 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		262E6FA87E6D2AF6351CF456 /* BoardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40783BDDC35BCC4608892D2D /* BoardView.swift */; };
+		2BD02C6ED0DE4E0DA4C7CA82 /* GameEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 609C5ED49D4F27CFE6CC64DE /* GameEngine.swift */; };
+		2D8C697A8BE79AF9E1240D42 /* Tetromino.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDDFE98741657679248C8515 /* Tetromino.swift */; };
+		3B8FB1E3E9E4D20CE1283E39 /* GameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F78E1C582C8D9EBC720F557A /* GameView.swift */; };
+		807C1C12B9C8E47CED849D2E /* GameEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62685271166F4E387662859E /* GameEngineTests.swift */; };
+		97A686558A19063CA6A0C7A0 /* Haptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7450D91BA3E1BCBFEBC23658 /* Haptics.swift */; };
+		C01C748147D7163FA1CFFF52 /* TetrisApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBD255A95AB33B7A69628221 /* TetrisApp.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		FD10D4ED099ED0C2677AC6F9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5FB45E5109A04A610CD1DE01 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2389D453726E91D1E62BCF88;
+			remoteInfo = Tetris;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		16FC9002A9619D4BBC6DE810 /* Tetris.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = Tetris.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		40783BDDC35BCC4608892D2D /* BoardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardView.swift; sourceTree = "<group>"; };
+		609C5ED49D4F27CFE6CC64DE /* GameEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameEngine.swift; sourceTree = "<group>"; };
+		62685271166F4E387662859E /* GameEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameEngineTests.swift; sourceTree = "<group>"; };
+		7450D91BA3E1BCBFEBC23658 /* Haptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Haptics.swift; sourceTree = "<group>"; };
+		EF8B052B81B313A1760CB9D9 /* TetrisTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = TetrisTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		F78E1C582C8D9EBC720F557A /* GameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameView.swift; sourceTree = "<group>"; };
+		FBD255A95AB33B7A69628221 /* TetrisApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TetrisApp.swift; sourceTree = "<group>"; };
+		FDDFE98741657679248C8515 /* Tetromino.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tetromino.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXGroup section */
+		5B2914F7528A8FFE5663C531 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				40783BDDC35BCC4608892D2D /* BoardView.swift */,
+				609C5ED49D4F27CFE6CC64DE /* GameEngine.swift */,
+				F78E1C582C8D9EBC720F557A /* GameView.swift */,
+				7450D91BA3E1BCBFEBC23658 /* Haptics.swift */,
+				FBD255A95AB33B7A69628221 /* TetrisApp.swift */,
+				FDDFE98741657679248C8515 /* Tetromino.swift */,
+			);
+			name = Sources;
+			path = Tetris/Sources;
+			sourceTree = "<group>";
+		};
+		5DBB68825DE0DF9ED8C5BC1C = {
+			isa = PBXGroup;
+			children = (
+				5B2914F7528A8FFE5663C531 /* Sources */,
+				92CF724BCBD43E944D8243FC /* TetrisTests */,
+				A779147BF93CF3002F237326 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		92CF724BCBD43E944D8243FC /* TetrisTests */ = {
+			isa = PBXGroup;
+			children = (
+				62685271166F4E387662859E /* GameEngineTests.swift */,
+			);
+			path = TetrisTests;
+			sourceTree = "<group>";
+		};
+		A779147BF93CF3002F237326 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				16FC9002A9619D4BBC6DE810 /* Tetris.app */,
+				EF8B052B81B313A1760CB9D9 /* TetrisTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		2389D453726E91D1E62BCF88 /* Tetris */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B969ECA5B3210E53C28CEAB6 /* Build configuration list for PBXNativeTarget "Tetris" */;
+			buildPhases = (
+				716E875FBEFACC9DD3AF8DB8 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Tetris;
+			packageProductDependencies = (
+			);
+			productName = Tetris;
+			productReference = 16FC9002A9619D4BBC6DE810 /* Tetris.app */;
+			productType = "com.apple.product-type.application";
+		};
+		C6F803C2080D712FCCB49600 /* TetrisTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5C62AD506261C301DFF44FB9 /* Build configuration list for PBXNativeTarget "TetrisTests" */;
+			buildPhases = (
+				EC885B478EE4BA5C3C54F4E4 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				DC929CBD5939FB11F3C73E34 /* PBXTargetDependency */,
+			);
+			name = TetrisTests;
+			packageProductDependencies = (
+			);
+			productName = TetrisTests;
+			productReference = EF8B052B81B313A1760CB9D9 /* TetrisTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		5FB45E5109A04A610CD1DE01 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = YES;
+				LastUpgradeCheck = 1430;
+				TargetAttributes = {
+				};
+			};
+			buildConfigurationList = 626CAA0D5BFECF0FE0DD813E /* Build configuration list for PBXProject "Tetris" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				Base,
+				en,
+			);
+			mainGroup = 5DBB68825DE0DF9ED8C5BC1C;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 77;
+			productRefGroup = A779147BF93CF3002F237326 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				2389D453726E91D1E62BCF88 /* Tetris */,
+				C6F803C2080D712FCCB49600 /* TetrisTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		716E875FBEFACC9DD3AF8DB8 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				262E6FA87E6D2AF6351CF456 /* BoardView.swift in Sources */,
+				2BD02C6ED0DE4E0DA4C7CA82 /* GameEngine.swift in Sources */,
+				3B8FB1E3E9E4D20CE1283E39 /* GameView.swift in Sources */,
+				97A686558A19063CA6A0C7A0 /* Haptics.swift in Sources */,
+				C01C748147D7163FA1CFFF52 /* TetrisApp.swift in Sources */,
+				2D8C697A8BE79AF9E1240D42 /* Tetromino.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EC885B478EE4BA5C3C54F4E4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				807C1C12B9C8E47CED849D2E /* GameEngineTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		DC929CBD5939FB11F3C73E34 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 2389D453726E91D1E62BCF88 /* Tetris */;
+			targetProxy = FD10D4ED099ED0C2677AC6F9 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		6DCCE9C2D5C3FAF6E0FF37E0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGNING_ALLOWED = NO;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.dabit3.TetrisTests;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.9;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Tetris.app/Tetris";
+			};
+			name = Debug;
+		};
+		7545BD66FFD6F3196B08968F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				INFOPLIST_FILE = Tetris/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.dabit3.tetris;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.9;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Release;
+		};
+		90F4D1FCFEE0FE96CED57172 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGNING_ALLOWED = NO;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.dabit3.TetrisTests;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.9;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Tetris.app/Tetris";
+			};
+			name = Release;
+		};
+		966DC5E4F5A83242C33CEC47 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"DEBUG=1",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		BF43E0B9C0CF7C3C9FA187A5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				INFOPLIST_FILE = Tetris/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.dabit3.tetris;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.9;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Debug;
+		};
+		F7EF7BBEB879C8D1F9B6015C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		5C62AD506261C301DFF44FB9 /* Build configuration list for PBXNativeTarget "TetrisTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6DCCE9C2D5C3FAF6E0FF37E0 /* Debug */,
+				90F4D1FCFEE0FE96CED57172 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		626CAA0D5BFECF0FE0DD813E /* Build configuration list for PBXProject "Tetris" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				966DC5E4F5A83242C33CEC47 /* Debug */,
+				F7EF7BBEB879C8D1F9B6015C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		B969ECA5B3210E53C28CEAB6 /* Build configuration list for PBXNativeTarget "Tetris" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BF43E0B9C0CF7C3C9FA187A5 /* Debug */,
+				7545BD66FFD6F3196B08968F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 5FB45E5109A04A610CD1DE01 /* Project object */;
+}

--- a/TetrisiOS/Tetris.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/TetrisiOS/Tetris.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/TetrisiOS/Tetris/Info.plist
+++ b/TetrisiOS/Tetris/Info.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Tetris</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+	</array>
+	<key>UIUserInterfaceStyle</key>
+	<string>Dark</string>
+</dict>
+</plist>

--- a/TetrisiOS/Tetris/Sources/BoardView.swift
+++ b/TetrisiOS/Tetris/Sources/BoardView.swift
@@ -89,6 +89,35 @@ struct BoardView: View {
     }
 }
 
+struct OpponentBoardView: View {
+    let board: [[Int]]
+
+    private static let palette: [Color] = [.clear] + PieceType.allCases.map(\.color)
+
+    var body: some View {
+        Canvas { ctx, size in
+            let cell = min(size.width / CGFloat(GameEngine.width),
+                           size.height / CGFloat(GameEngine.height))
+            let ox = (size.width - cell * CGFloat(GameEngine.width)) / 2
+            let oy = (size.height - cell * CGFloat(GameEngine.height)) / 2
+            ctx.fill(
+                Path(CGRect(x: ox, y: oy,
+                            width: cell * CGFloat(GameEngine.width),
+                            height: cell * CGFloat(GameEngine.height))),
+                with: .color(.black.opacity(0.55)))
+            for (r, row) in board.enumerated() {
+                for (c, code) in row.enumerated() where code > 0 {
+                    let color = Self.palette[min(code, Self.palette.count - 1)]
+                    ctx.fill(
+                        Path(CGRect(x: ox + CGFloat(c) * cell, y: oy + CGFloat(r) * cell,
+                                    width: cell, height: cell).insetBy(dx: 0.25, dy: 0.25)),
+                        with: .color(color))
+                }
+            }
+        }
+    }
+}
+
 struct MiniPieceView: View {
     let type: PieceType?
     var dimmed = false

--- a/TetrisiOS/Tetris/Sources/BoardView.swift
+++ b/TetrisiOS/Tetris/Sources/BoardView.swift
@@ -1,0 +1,120 @@
+import SwiftUI
+
+struct BoardView: View {
+    @ObservedObject var engine: GameEngine
+
+    var body: some View {
+        GeometryReader { geo in
+            let cell = min(
+                geo.size.width / CGFloat(GameEngine.width),
+                geo.size.height / CGFloat(GameEngine.height))
+            let boardW = cell * CGFloat(GameEngine.width)
+            let boardH = cell * CGFloat(GameEngine.height)
+            let ox = (geo.size.width - boardW) / 2
+            let oy = (geo.size.height - boardH) / 2
+
+            Canvas { ctx, _ in
+                // Background
+                let boardRect = CGRect(x: ox, y: oy, width: boardW, height: boardH)
+                ctx.fill(
+                    Path(roundedRect: boardRect, cornerRadius: 6),
+                    with: .color(Color(white: 0.07)))
+
+                // Grid lines
+                var grid = Path()
+                for c in 1..<GameEngine.width {
+                    grid.move(to: CGPoint(x: ox + CGFloat(c) * cell, y: oy))
+                    grid.addLine(to: CGPoint(x: ox + CGFloat(c) * cell, y: oy + boardH))
+                }
+                for r in 1..<GameEngine.height {
+                    grid.move(to: CGPoint(x: ox, y: oy + CGFloat(r) * cell))
+                    grid.addLine(to: CGPoint(x: ox + boardW, y: oy + CGFloat(r) * cell))
+                }
+                ctx.stroke(grid, with: .color(Color(white: 0.13)), lineWidth: 0.5)
+
+                func drawBlock(x: Int, y: Int, color: Color, ghost: Bool = false, flash: Bool = false) {
+                    guard y >= 0 else { return }
+                    let rect = CGRect(
+                        x: ox + CGFloat(x) * cell + 1,
+                        y: oy + CGFloat(y) * cell + 1,
+                        width: cell - 2, height: cell - 2)
+                    let path = Path(roundedRect: rect, cornerRadius: cell * 0.18)
+                    if ghost {
+                        ctx.stroke(path, with: .color(color.opacity(0.45)), lineWidth: 1.5)
+                        return
+                    }
+                    if flash {
+                        ctx.fill(path, with: .color(.white))
+                        return
+                    }
+                    ctx.fill(path, with: .linearGradient(
+                        Gradient(colors: [color.opacity(1.0), color.opacity(0.72)]),
+                        startPoint: rect.origin,
+                        endPoint: CGPoint(x: rect.maxX, y: rect.maxY)))
+                    // Top bevel highlight
+                    let bevel = CGRect(
+                        x: rect.minX + cell * 0.12, y: rect.minY + cell * 0.10,
+                        width: rect.width - cell * 0.24, height: cell * 0.16)
+                    ctx.fill(
+                        Path(roundedRect: bevel, cornerRadius: cell * 0.08),
+                        with: .color(.white.opacity(0.28)))
+                }
+
+                // Settled blocks
+                for y in 0..<GameEngine.height {
+                    let flash = engine.clearingRows.contains(y)
+                    for x in 0..<GameEngine.width {
+                        if let t = engine.board[y][x] {
+                            drawBlock(x: x, y: y, color: t.color, flash: flash)
+                        }
+                    }
+                }
+
+                // Ghost
+                if let ghost = engine.ghost, engine.phase == .playing {
+                    for (x, y) in ghost.cells {
+                        drawBlock(x: x, y: y, color: ghost.type.color, ghost: true)
+                    }
+                }
+
+                // Current piece
+                if let piece = engine.current {
+                    for (x, y) in piece.cells {
+                        drawBlock(x: x, y: y, color: piece.type.color)
+                    }
+                }
+            }
+        }
+        .aspectRatio(CGFloat(GameEngine.width) / CGFloat(GameEngine.height), contentMode: .fit)
+    }
+}
+
+struct MiniPieceView: View {
+    let type: PieceType?
+    var dimmed = false
+
+    var body: some View {
+        Canvas { ctx, size in
+            guard let type else { return }
+            let cells = type.baseCells
+            let minX = cells.map(\.0).min()!
+            let maxX = cells.map(\.0).max()!
+            let minY = cells.map(\.1).min()!
+            let maxY = cells.map(\.1).max()!
+            let w = CGFloat(maxX - minX + 1)
+            let h = CGFloat(maxY - minY + 1)
+            let cell = min(size.width / w, size.height / h, size.width / 4)
+            let ox = (size.width - w * cell) / 2
+            let oy = (size.height - h * cell) / 2
+            for (x, y) in cells {
+                let rect = CGRect(
+                    x: ox + CGFloat(x - minX) * cell + 1,
+                    y: oy + CGFloat(y - minY) * cell + 1,
+                    width: cell - 2, height: cell - 2)
+                ctx.fill(
+                    Path(roundedRect: rect, cornerRadius: cell * 0.18),
+                    with: .color(type.color.opacity(dimmed ? 0.35 : 0.9)))
+            }
+        }
+    }
+}

--- a/TetrisiOS/Tetris/Sources/GameEngine.swift
+++ b/TetrisiOS/Tetris/Sources/GameEngine.swift
@@ -1,6 +1,20 @@
 import SwiftUI
 import Combine
 
+struct RunSummary {
+    let score: Int
+    let lines: Int
+    let level: Int
+    let isNewBest: Bool
+}
+
+enum ClearKind: String {
+    case single = "SINGLE"
+    case double = "DOUBLE"
+    case triple = "TRIPLE"
+    case tetris = "TETRIS!"
+}
+
 @MainActor
 final class GameEngine: ObservableObject {
     static let width = 10
@@ -21,6 +35,28 @@ final class GameEngine: ObservableObject {
     @Published var clearingRows: Set<Int> = []
     @Published var lastClearWasTetris = false
     @Published var comboCount = -1
+    @Published var clearKind: ClearKind?
+    @Published var feedbackID = 0
+    @Published var lockPulseID = 0
+    @Published var bestLines = UserDefaults.standard.integer(forKey: "bestLines")
+    @Published var highestLevel = max(1, UserDefaults.standard.integer(forKey: "highestLevel"))
+    @Published var longestCombo = UserDefaults.standard.integer(forKey: "longestCombo")
+    @Published var lastRun: RunSummary?
+
+    var onLinesCleared: ((Int) -> Void)?
+    var onPieceLocked: (() -> Void)?
+    var onGameOver: (() -> Void)?
+
+    var holdAvailable: Bool { canHold }
+
+    var boardCode: [[Int]] {
+        board.map { row in
+            row.map { type in
+                guard let type else { return 0 }
+                return (PieceType.allCases.firstIndex(of: type) ?? 0) + 1
+            }
+        }
+    }
 
     private var bag: [PieceType] = []
     private var canHold = true
@@ -70,11 +106,38 @@ final class GameEngine: ObservableObject {
     private func endGame() {
         phase = .gameOver
         timer?.cancel()
-        if score > highScore {
+        let isNewBest = score > highScore
+        if isNewBest {
             highScore = score
             UserDefaults.standard.set(score, forKey: "highScore")
         }
+        if lines > bestLines {
+            bestLines = lines
+            UserDefaults.standard.set(lines, forKey: "bestLines")
+        }
+        if level > highestLevel {
+            highestLevel = level
+            UserDefaults.standard.set(level, forKey: "highestLevel")
+        }
+        lastRun = RunSummary(score: score, lines: lines, level: level, isNewBest: isNewBest)
         Haptics.gameOver()
+        onGameOver?()
+    }
+
+    func addGarbage(_ count: Int) {
+        guard phase == .playing || phase == .paused, count > 0 else { return }
+        let hole = Int.random(in: 0..<Self.width)
+        for _ in 0..<count {
+            board.removeFirst()
+            var row = [PieceType?](repeating: .j, count: Self.width)
+            row[hole] = nil
+            board.append(row)
+        }
+        if let p = current, collides(p) {
+            var moved = p
+            moved.y -= count
+            if !collides(moved) { current = moved }
+        }
     }
 
     // MARK: - Tick
@@ -248,6 +311,8 @@ final class GameEngine: ObservableObject {
             }
         }
         current = nil
+        lockPulseID += 1
+        onPieceLocked?()
         if topOut {
             endGame()
             return
@@ -263,9 +328,21 @@ final class GameEngine: ObservableObject {
             return
         }
         comboCount += 1
+        if comboCount > longestCombo {
+            longestCombo = comboCount
+            UserDefaults.standard.set(comboCount, forKey: "longestCombo")
+        }
         clearingRows = Set(full)
         lastClearWasTetris = full.count == 4
+        switch full.count {
+        case 1: clearKind = .single
+        case 2: clearKind = .double
+        case 3: clearKind = .triple
+        default: clearKind = .tetris
+        }
+        feedbackID += 1
         Haptics.lineClear(count: full.count)
+        onLinesCleared?(full.count)
 
         let base: Int
         switch full.count {

--- a/TetrisiOS/Tetris/Sources/GameEngine.swift
+++ b/TetrisiOS/Tetris/Sources/GameEngine.swift
@@ -1,0 +1,298 @@
+import SwiftUI
+import Combine
+
+@MainActor
+final class GameEngine: ObservableObject {
+    static let width = 10
+    static let height = 20
+
+    enum Phase { case ready, playing, paused, gameOver }
+
+    @Published var board: [[PieceType?]] = Array(
+        repeating: Array(repeating: nil, count: width), count: height)
+    @Published var current: Piece?
+    @Published var holdPiece: PieceType?
+    @Published var nextQueue: [PieceType] = []
+    @Published var phase: Phase = .ready
+    @Published var score = 0
+    @Published var lines = 0
+    @Published var level = 1
+    @Published var highScore = UserDefaults.standard.integer(forKey: "highScore")
+    @Published var clearingRows: Set<Int> = []
+    @Published var lastClearWasTetris = false
+    @Published var comboCount = -1
+
+    private var bag: [PieceType] = []
+    private var canHold = true
+    private var timer: AnyCancellable?
+    private var gravityAccumulator: TimeInterval = 0
+    private var lockTimer: TimeInterval = 0
+    private var isOnGround = false
+    private var lockResets = 0
+    private var lastTick = Date()
+
+    private var gravityInterval: TimeInterval {
+        // Guideline-ish gravity curve.
+        max(0.05, pow(0.8 - Double(level - 1) * 0.007, Double(level - 1)))
+    }
+
+    // MARK: - Lifecycle
+
+    func start() {
+        board = Array(repeating: Array(repeating: nil, count: Self.width), count: Self.height)
+        score = 0
+        lines = 0
+        level = 1
+        comboCount = -1
+        holdPiece = nil
+        canHold = true
+        bag = []
+        nextQueue = []
+        clearingRows = []
+        refillQueue()
+        spawnNext()
+        phase = .playing
+        lastTick = Date()
+        timer = Timer.publish(every: 1.0 / 60.0, on: .main, in: .common)
+            .autoconnect()
+            .sink { [weak self] _ in self?.tick() }
+    }
+
+    func togglePause() {
+        if phase == .playing {
+            phase = .paused
+        } else if phase == .paused {
+            phase = .playing
+            lastTick = Date()
+        }
+    }
+
+    private func endGame() {
+        phase = .gameOver
+        timer?.cancel()
+        if score > highScore {
+            highScore = score
+            UserDefaults.standard.set(score, forKey: "highScore")
+        }
+        Haptics.gameOver()
+    }
+
+    // MARK: - Tick
+
+    private func tick() {
+        guard phase == .playing, current != nil else { return }
+        let now = Date()
+        let dt = min(now.timeIntervalSince(lastTick), 0.25)
+        lastTick = now
+
+        if grounded() {
+            if !isOnGround { isOnGround = true; lockTimer = 0 }
+            lockTimer += dt
+            if lockTimer >= 0.5 || lockResets >= 15 {
+                lockCurrent()
+                return
+            }
+        } else {
+            isOnGround = false
+            gravityAccumulator += dt
+            while gravityAccumulator >= gravityInterval {
+                gravityAccumulator -= gravityInterval
+                _ = tryMove(dx: 0, dy: 1)
+            }
+        }
+    }
+
+    // MARK: - Queue / spawn
+
+    private func refillQueue() {
+        while nextQueue.count < 5 {
+            if bag.isEmpty { bag = PieceType.allCases.shuffled() }
+            nextQueue.append(bag.removeFirst())
+        }
+    }
+
+    private func spawnNext() {
+        refillQueue()
+        let type = nextQueue.removeFirst()
+        refillQueue()
+        var piece = Piece.spawn(type, boardWidth: Self.width)
+        if collides(piece) {
+            piece.y -= 1
+            if collides(piece) {
+                current = piece
+                endGame()
+                return
+            }
+        }
+        current = piece
+        canHold = true
+        gravityAccumulator = 0
+        lockTimer = 0
+        lockResets = 0
+        isOnGround = false
+    }
+
+    // MARK: - Collision
+
+    private func collides(_ piece: Piece) -> Bool {
+        for (x, y) in piece.cells {
+            if x < 0 || x >= Self.width || y >= Self.height { return true }
+            if y >= 0, board[y][x] != nil { return true }
+        }
+        return false
+    }
+
+    private func grounded() -> Bool {
+        guard var p = current else { return false }
+        p.y += 1
+        return collides(p)
+    }
+
+    // MARK: - Player actions
+
+    @discardableResult
+    func tryMove(dx: Int, dy: Int) -> Bool {
+        guard phase == .playing, var p = current else { return false }
+        p.x += dx
+        p.y += dy
+        guard !collides(p) else { return false }
+        current = p
+        if dx != 0, isOnGround, lockResets < 15 {
+            lockTimer = 0
+            lockResets += 1
+        }
+        if dx != 0 { Haptics.move() }
+        return true
+    }
+
+    func rotate(clockwise: Bool) {
+        guard phase == .playing, let p = current else { return }
+        let from = p.rotation
+        let to = (p.rotation + (clockwise ? 1 : 3)) % 4
+        for (kx, ky) in SRS.kicks(type: p.type, from: from, to: to) {
+            var candidate = p
+            candidate.rotation = to
+            candidate.x += kx
+            candidate.y += ky
+            if !collides(candidate) {
+                current = candidate
+                if isOnGround, lockResets < 15 {
+                    lockTimer = 0
+                    lockResets += 1
+                }
+                Haptics.rotate()
+                return
+            }
+        }
+    }
+
+    func softDrop() {
+        if tryMove(dx: 0, dy: 1) { score += 1 }
+    }
+
+    func hardDrop() {
+        guard phase == .playing, var p = current else { return }
+        var distance = 0
+        while true {
+            var next = p
+            next.y += 1
+            if collides(next) { break }
+            p = next
+            distance += 1
+        }
+        current = p
+        score += distance * 2
+        Haptics.hardDrop()
+        lockCurrent()
+    }
+
+    func hold() {
+        guard phase == .playing, canHold, let p = current else { return }
+        canHold = false
+        let previous = holdPiece
+        holdPiece = p.type
+        if let previous {
+            var piece = Piece.spawn(previous, boardWidth: Self.width)
+            if collides(piece) { piece.y -= 1 }
+            current = piece
+        } else {
+            spawnNext()
+            canHold = false
+        }
+        gravityAccumulator = 0
+        lockTimer = 0
+        isOnGround = false
+        Haptics.rotate()
+    }
+
+    var ghost: Piece? {
+        guard var p = current else { return nil }
+        while true {
+            var next = p
+            next.y += 1
+            if collides(next) { break }
+            p = next
+        }
+        return p
+    }
+
+    // MARK: - Locking & clearing
+
+    private func lockCurrent() {
+        guard let p = current else { return }
+        var topOut = true
+        for (x, y) in p.cells {
+            if y >= 0 {
+                board[y][x] = p.type
+                topOut = false
+            }
+        }
+        current = nil
+        if topOut {
+            endGame()
+            return
+        }
+        clearLines()
+    }
+
+    private func clearLines() {
+        let full = (0..<Self.height).filter { row in board[row].allSatisfy { $0 != nil } }
+        guard !full.isEmpty else {
+            comboCount = -1
+            spawnNext()
+            return
+        }
+        comboCount += 1
+        clearingRows = Set(full)
+        lastClearWasTetris = full.count == 4
+        Haptics.lineClear(count: full.count)
+
+        let base: Int
+        switch full.count {
+        case 1: base = 100
+        case 2: base = 300
+        case 3: base = 500
+        default: base = 800
+        }
+        score += base * level + max(0, comboCount) * 50 * level
+        lines += full.count
+        level = lines / 10 + 1
+
+        // Brief pause for clear animation, then collapse.
+        phase = .paused
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { [weak self] in
+            guard let self else { return }
+            var newBoard = self.board.enumerated()
+                .filter { !full.contains($0.offset) }
+                .map { $0.element }
+            while newBoard.count < Self.height {
+                newBoard.insert(Array(repeating: nil, count: Self.width), at: 0)
+            }
+            self.board = newBoard
+            self.clearingRows = []
+            self.phase = .playing
+            self.lastTick = Date()
+            self.spawnNext()
+        }
+    }
+}

--- a/TetrisiOS/Tetris/Sources/GameEngine.swift
+++ b/TetrisiOS/Tetris/Sources/GameEngine.swift
@@ -66,6 +66,8 @@ final class GameEngine: ObservableObject {
     private var isOnGround = false
     private var lockResets = 0
     private var lastTick = Date()
+    private var pendingGarbage = 0
+    private var pauseRequested = false
 
     private var gravityInterval: TimeInterval {
         // Guideline-ish gravity curve.
@@ -85,6 +87,8 @@ final class GameEngine: ObservableObject {
         bag = []
         nextQueue = []
         clearingRows = []
+        pendingGarbage = 0
+        pauseRequested = false
         refillQueue()
         spawnNext()
         phase = .playing
@@ -95,6 +99,10 @@ final class GameEngine: ObservableObject {
     }
 
     func togglePause() {
+        if !clearingRows.isEmpty {
+            pauseRequested.toggle()
+            return
+        }
         if phase == .playing {
             phase = .paused
         } else if phase == .paused {
@@ -126,6 +134,14 @@ final class GameEngine: ObservableObject {
 
     func addGarbage(_ count: Int) {
         guard phase == .playing || phase == .paused, count > 0 else { return }
+        if !clearingRows.isEmpty {
+            pendingGarbage += count
+            return
+        }
+        insertGarbageRows(count)
+    }
+
+    private func insertGarbageRows(_ count: Int) {
         let hole = Int.random(in: 0..<Self.width)
         for _ in 0..<count {
             board.removeFirst()
@@ -367,9 +383,15 @@ final class GameEngine: ObservableObject {
             }
             self.board = newBoard
             self.clearingRows = []
-            self.phase = .playing
+            self.phase = self.pauseRequested ? .paused : .playing
+            self.pauseRequested = false
             self.lastTick = Date()
             self.spawnNext()
+            if self.pendingGarbage > 0 {
+                let queued = self.pendingGarbage
+                self.pendingGarbage = 0
+                self.insertGarbageRows(queued)
+            }
         }
     }
 }

--- a/TetrisiOS/Tetris/Sources/GameEngine.swift
+++ b/TetrisiOS/Tetris/Sources/GameEngine.swift
@@ -294,12 +294,17 @@ final class GameEngine: ObservableObject {
             var piece = Piece.spawn(previous, boardWidth: Self.width)
             if collides(piece) { piece.y -= 1 }
             current = piece
+            if collides(piece) {
+                endGame()
+                return
+            }
         } else {
             spawnNext()
             canHold = false
         }
         gravityAccumulator = 0
         lockTimer = 0
+        lockResets = 0
         isOnGround = false
         Haptics.rotate()
     }

--- a/TetrisiOS/Tetris/Sources/GameView.swift
+++ b/TetrisiOS/Tetris/Sources/GameView.swift
@@ -1,0 +1,218 @@
+import SwiftUI
+
+struct GameView: View {
+    @StateObject private var engine = GameEngine()
+    @State private var dragOffset: CGFloat = 0
+    @State private var dragCells = 0
+    @State private var didSoftDrop = false
+    @FocusState private var focused: Bool
+
+    var body: some View {
+        content
+            .focusable()
+            .focused($focused)
+            .focusEffectDisabled()
+            .onAppear { focused = true }
+            .onKeyPress(phases: .down) { press in
+                switch press.key {
+                case .leftArrow: engine.tryMove(dx: -1, dy: 0)
+                case .rightArrow: engine.tryMove(dx: 1, dy: 0)
+                case .downArrow: engine.softDrop()
+                case .upArrow: engine.rotate(clockwise: true)
+                case .space: engine.hardDrop()
+                case .init("z"): engine.rotate(clockwise: false)
+                case .init("c"): engine.hold()
+                case .init("p"): engine.togglePause()
+                case .return:
+                    if engine.phase == .ready || engine.phase == .gameOver { engine.start() }
+                default: return .ignored
+                }
+                return .handled
+            }
+    }
+
+    private var content: some View {
+        ZStack {
+            LinearGradient(
+                colors: [Color(red: 0.05, green: 0.05, blue: 0.10), Color(red: 0.10, green: 0.06, blue: 0.16)],
+                startPoint: .top, endPoint: .bottom)
+            .ignoresSafeArea()
+
+            VStack(spacing: 12) {
+                header
+                HStack(alignment: .top, spacing: 8) {
+                    sidePanel(title: "HOLD") {
+                        MiniPieceView(type: engine.holdPiece)
+                            .frame(width: 48, height: 36)
+                    }
+                    .frame(width: 66)
+                    BoardView(engine: engine)
+                        .overlay(overlayContent)
+                        .gesture(playGesture)
+                        .onTapGesture { engine.rotate(clockwise: true) }
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    sidePanel(title: "NEXT") {
+                        VStack(spacing: 8) {
+                            ForEach(Array(engine.nextQueue.prefix(4).enumerated()), id: \.offset) { i, t in
+                                MiniPieceView(type: t, dimmed: i > 0)
+                                    .frame(width: 44, height: i == 0 ? 32 : 24)
+                            }
+                        }
+                    }
+                    .frame(width: 66)
+                }
+                .padding(.horizontal, 8)
+                controls
+            }
+            .padding(.vertical, 8)
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(spacing: 0) {
+            stat("SCORE", "\(engine.score)")
+            stat("LEVEL", "\(engine.level)")
+            stat("LINES", "\(engine.lines)")
+            stat("BEST", "\(engine.highScore)")
+        }
+        .padding(.horizontal, 14)
+    }
+
+    private func stat(_ label: String, _ value: String) -> some View {
+        VStack(spacing: 2) {
+            Text(label)
+                .font(.system(size: 10, weight: .bold, design: .rounded))
+                .foregroundStyle(.white.opacity(0.45))
+            Text(value)
+                .font(.system(size: 19, weight: .heavy, design: .rounded))
+                .foregroundStyle(.white)
+                .contentTransition(.numericText())
+                .animation(.snappy, value: value)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private func sidePanel<Content: View>(title: String, @ViewBuilder content: () -> Content) -> some View {
+        VStack(spacing: 6) {
+            Text(title)
+                .font(.system(size: 10, weight: .bold, design: .rounded))
+                .foregroundStyle(.white.opacity(0.45))
+            content()
+        }
+        .padding(8)
+        .background(.white.opacity(0.05), in: RoundedRectangle(cornerRadius: 10))
+    }
+
+    // MARK: - Overlays
+
+    @ViewBuilder
+    private var overlayContent: some View {
+        switch engine.phase {
+        case .ready:
+            menuOverlay(title: "TETRIS", subtitle: "Swipe to move · Tap to rotate\nSwipe down to drop", button: "PLAY") {
+                engine.start()
+            }
+        case .gameOver:
+            menuOverlay(
+                title: "GAME OVER",
+                subtitle: "Score \(engine.score)" + (engine.score >= engine.highScore && engine.score > 0 ? " · New Best!" : ""),
+                button: "PLAY AGAIN") {
+                engine.start()
+            }
+        case .paused where engine.clearingRows.isEmpty:
+            menuOverlay(title: "PAUSED", subtitle: "", button: "RESUME") {
+                engine.togglePause()
+            }
+        default:
+            EmptyView()
+        }
+    }
+
+    private func menuOverlay(title: String, subtitle: String, button: String, action: @escaping () -> Void) -> some View {
+        VStack(spacing: 16) {
+            Text(title)
+                .font(.system(size: 34, weight: .black, design: .rounded))
+                .foregroundStyle(
+                    LinearGradient(colors: [.cyan, .purple], startPoint: .leading, endPoint: .trailing))
+            if !subtitle.isEmpty {
+                Text(subtitle)
+                    .font(.system(size: 14, weight: .medium, design: .rounded))
+                    .foregroundStyle(.white.opacity(0.6))
+                    .multilineTextAlignment(.center)
+            }
+            Button(action: action) {
+                Text(button)
+                    .font(.system(size: 17, weight: .heavy, design: .rounded))
+                    .foregroundStyle(.black)
+                    .padding(.horizontal, 36)
+                    .padding(.vertical, 12)
+                    .background(.white, in: Capsule())
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(.black.opacity(0.72), in: RoundedRectangle(cornerRadius: 6))
+    }
+
+    // MARK: - Controls
+
+    private var controls: some View {
+        HStack(spacing: 8) {
+            controlButton("arrow.left") { engine.tryMove(dx: -1, dy: 0) }
+            controlButton("arrow.down") { engine.softDrop() }
+            controlButton("arrow.right") { engine.tryMove(dx: 1, dy: 0) }
+            controlButton("rotate.right") { engine.rotate(clockwise: true) }
+            controlButton("arrow.down.to.line", prominent: true) { engine.hardDrop() }
+            controlButton("tray.and.arrow.down") { engine.hold() }
+            controlButton(engine.phase == .paused ? "play.fill" : "pause.fill") { engine.togglePause() }
+        }
+        .padding(.horizontal, 12)
+    }
+
+    private func controlButton(_ symbol: String, prominent: Bool = false, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Image(systemName: symbol)
+                .font(.system(size: 18, weight: .bold))
+                .foregroundStyle(prominent ? .black : .white)
+                .frame(maxWidth: .infinity)
+                .frame(height: 46)
+                .background(
+                    prominent ? AnyShapeStyle(.white) : AnyShapeStyle(.white.opacity(0.08)),
+                    in: RoundedRectangle(cornerRadius: 12))
+        }
+        .buttonRepeatBehavior(.enabled)
+    }
+
+    // MARK: - Gestures
+
+    private var playGesture: some Gesture {
+        DragGesture(minimumDistance: 12)
+            .onChanged { value in
+                guard engine.phase == .playing else { return }
+                let dx = value.translation.width
+                let dy = value.translation.height
+                if abs(dy) > abs(dx) * 1.5, dy > 30, !didSoftDrop {
+                    if value.predictedEndTranslation.height > 220 {
+                        didSoftDrop = true
+                        engine.hardDrop()
+                    } else {
+                        engine.softDrop()
+                    }
+                    return
+                }
+                let cellWidth: CGFloat = 26
+                let targetCells = Int((dx / cellWidth).rounded(.towardZero))
+                while dragCells < targetCells {
+                    if engine.tryMove(dx: 1, dy: 0) { dragCells += 1 } else { break }
+                }
+                while dragCells > targetCells {
+                    if engine.tryMove(dx: -1, dy: 0) { dragCells -= 1 } else { break }
+                }
+            }
+            .onEnded { _ in
+                dragCells = 0
+                didSoftDrop = false
+            }
+    }
+}

--- a/TetrisiOS/Tetris/Sources/GameView.swift
+++ b/TetrisiOS/Tetris/Sources/GameView.swift
@@ -2,9 +2,18 @@ import SwiftUI
 
 struct GameView: View {
     @StateObject private var engine = GameEngine()
-    @State private var dragOffset: CGFloat = 0
+    @StateObject private var match = MultiplayerClient()
     @State private var dragCells = 0
     @State private var didSoftDrop = false
+    @State private var showingInfo = false
+    @State private var showingSettings = false
+    @State private var feedbackVisible = false
+    @State private var lockGlow = false
+    @State private var vsMode = false
+    @State private var matchResult: Bool?
+    @AppStorage("hapticsEnabled") private var hapticsEnabled = true
+    @AppStorage("leftHandedControls") private var leftHandedControls = false
+    @AppStorage("themeIndex") private var themeIndex = 0
     @FocusState private var focused: Bool
 
     var body: some View {
@@ -12,7 +21,22 @@ struct GameView: View {
             .focusable()
             .focused($focused)
             .focusEffectDisabled()
-            .onAppear { focused = true }
+            .onAppear {
+                focused = true
+                Haptics.enabled = hapticsEnabled
+                configureMultiplayer()
+            }
+            .onChange(of: hapticsEnabled) { _, enabled in Haptics.enabled = enabled }
+            .onChange(of: engine.feedbackID) { _, _ in showClearFeedback() }
+            .onChange(of: engine.lockPulseID) { _, _ in showLockGlow() }
+            .onChange(of: match.allOpponentsOut) { _, allOut in
+                if allOut, vsMode, matchResult == nil, engine.phase != .gameOver {
+                    matchResult = true
+                    if engine.phase == .playing { engine.togglePause() }
+                }
+            }
+            .sheet(isPresented: $showingInfo) { infoSheet }
+            .sheet(isPresented: $showingSettings) { settingsSheet }
             .onKeyPress(phases: .down) { press in
                 switch press.key {
                 case .leftArrow: engine.tryMove(dx: -1, dy: 0)
@@ -31,169 +55,431 @@ struct GameView: View {
             }
     }
 
-    private var content: some View {
-        ZStack {
-            LinearGradient(
-                colors: [Color(red: 0.05, green: 0.05, blue: 0.10), Color(red: 0.10, green: 0.06, blue: 0.16)],
-                startPoint: .top, endPoint: .bottom)
-            .ignoresSafeArea()
+    private func configureMultiplayer() {
+        engine.onLinesCleared = { [weak match] count in
+            let garbage = [0, 1, 2, 4][min(count, 4) - 1]
+            match?.sendGarbage(garbage)
+        }
+        engine.onPieceLocked = { [weak match, weak engine] in
+            guard let engine, let match, match.state == .playing else { return }
+            match.sendState(board: engine.boardCode, score: engine.score, lines: engine.lines)
+        }
+        engine.onGameOver = { [weak match, weak engine] in
+            guard let engine, let match, match.state == .playing else { return }
+            match.sendGameOver(score: engine.score)
+        }
+        match.onGarbage = { [weak engine] count in
+            engine?.addGarbage(count)
+        }
+        match.onMatched = { [weak engine] in
+            engine?.start()
+        }
+    }
 
-            VStack(spacing: 12) {
-                header
-                HStack(alignment: .top, spacing: 8) {
-                    sidePanel(title: "HOLD") {
-                        MiniPieceView(type: engine.holdPiece)
-                            .frame(width: 48, height: 36)
-                    }
-                    .frame(width: 66)
-                    BoardView(engine: engine)
-                        .overlay(overlayContent)
-                        .gesture(playGesture)
-                        .onTapGesture { engine.rotate(clockwise: true) }
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    sidePanel(title: "NEXT") {
-                        VStack(spacing: 8) {
-                            ForEach(Array(engine.nextQueue.prefix(4).enumerated()), id: \.offset) { i, t in
-                                MiniPieceView(type: t, dimmed: i > 0)
-                                    .frame(width: 44, height: i == 0 ? 32 : 24)
-                            }
-                        }
-                    }
-                    .frame(width: 66)
+    private var content: some View {
+        GeometryReader { geometry in
+            let safeWidth = geometry.size.width - 16
+            let reservedHeight: CGFloat = 176
+            let boardWidth = min(safeWidth, max(180, (geometry.size.height - reservedHeight) / 2))
+
+            ZStack {
+                background
+                VStack(spacing: 6) {
+                    header
+                    previewRow
+                    board(width: boardWidth)
+                    controls
                 }
                 .padding(.horizontal, 8)
-                controls
+                .padding(.vertical, 4)
             }
-            .padding(.vertical, 8)
         }
     }
 
-    // MARK: - Header
+    private var background: some View {
+        let palettes: [[Color]] = [
+            [Color(red: 0.035, green: 0.04, blue: 0.09), Color(red: 0.12, green: 0.055, blue: 0.17)],
+            [Color(red: 0.015, green: 0.08, blue: 0.11), Color(red: 0.02, green: 0.16, blue: 0.17)],
+            [Color(red: 0.12, green: 0.035, blue: 0.07), Color(red: 0.19, green: 0.08, blue: 0.035)]
+        ]
+        let palette = palettes[min(themeIndex, unlockedThemeCount - 1)]
+        return ZStack {
+            LinearGradient(colors: palette, startPoint: .topLeading, endPoint: .bottomTrailing)
+            RadialGradient(
+                colors: [.purple.opacity(0.12), .clear],
+                center: .top,
+                startRadius: 20,
+                endRadius: 420)
+        }
+        .ignoresSafeArea()
+    }
 
     private var header: some View {
-        HStack(spacing: 0) {
-            stat("SCORE", "\(engine.score)")
-            stat("LEVEL", "\(engine.level)")
-            stat("LINES", "\(engine.lines)")
-            stat("BEST", "\(engine.highScore)")
+        HStack(spacing: 5) {
+            stat("SCORE", "\(engine.score)", symbol: "sparkles", color: .cyan)
+            stat("LEVEL", "\(engine.level)", symbol: "speedometer", color: .purple)
+            stat("LINES", "\(engine.lines)", symbol: "line.3.horizontal", color: .green)
+            stat("BEST", "\(engine.highScore)", symbol: "crown.fill", color: .yellow)
+            Button { showingSettings = true } label: {
+                Image(systemName: "gearshape.fill")
+                    .font(.system(size: 14, weight: .bold))
+                    .frame(width: 34, height: 43)
+                    .foregroundStyle(.white.opacity(0.8))
+                    .background(.white.opacity(0.07), in: RoundedRectangle(cornerRadius: 11))
+            }
+            .accessibilityLabel("Settings")
         }
-        .padding(.horizontal, 14)
     }
 
-    private func stat(_ label: String, _ value: String) -> some View {
-        VStack(spacing: 2) {
-            Text(label)
-                .font(.system(size: 10, weight: .bold, design: .rounded))
-                .foregroundStyle(.white.opacity(0.45))
+    private func stat(_ label: String, _ value: String, symbol: String, color: Color) -> some View {
+        VStack(spacing: 1) {
+            HStack(spacing: 3) {
+                Image(systemName: symbol)
+                Text(label)
+            }
+            .font(.system(size: 8, weight: .bold, design: .rounded))
+            .foregroundStyle(color.opacity(0.75))
             Text(value)
-                .font(.system(size: 19, weight: .heavy, design: .rounded))
+                .font(.system(size: 17, weight: .heavy, design: .rounded))
                 .foregroundStyle(.white)
                 .contentTransition(.numericText())
                 .animation(.snappy, value: value)
         }
         .frame(maxWidth: .infinity)
+        .frame(height: 43)
+        .background(.white.opacity(0.055), in: RoundedRectangle(cornerRadius: 11))
+        .overlay(RoundedRectangle(cornerRadius: 11).stroke(color.opacity(0.12)))
     }
 
-    private func sidePanel<Content: View>(title: String, @ViewBuilder content: () -> Content) -> some View {
-        VStack(spacing: 6) {
+    private var previewRow: some View {
+        HStack(spacing: 6) {
+            previewCard(title: engine.holdAvailable ? "HOLD · READY" : "HOLD · USED", accent: engine.holdAvailable ? .cyan : .gray) {
+                MiniPieceView(type: engine.holdPiece, dimmed: !engine.holdAvailable)
+                    .frame(width: 50, height: 30)
+            }
+            previewCard(title: "NEXT", accent: .purple) {
+                HStack(spacing: 5) {
+                    ForEach(Array(engine.nextQueue.prefix(vsMode ? 3 : 5).enumerated()), id: \.offset) { index, type in
+                        MiniPieceView(type: type, dimmed: index > 0)
+                            .frame(maxWidth: .infinity)
+                            .frame(height: index == 0 ? 30 : 24)
+                            .transition(.push(from: .trailing).combined(with: .opacity))
+                    }
+                }
+                .animation(.snappy, value: engine.nextQueue)
+            }
+            if vsMode {
+                ForEach(match.sortedOpponentIDs, id: \.self) { id in
+                    let rival = match.opponents[id] ?? Opponent()
+                    previewCard(
+                        title: rival.gameOver || rival.left ? "P\(id + 1) · OUT" : "P\(id + 1) · \(rival.score)",
+                        accent: rival.gameOver || rival.left ? .gray : .red
+                    ) {
+                        OpponentBoardView(board: rival.board)
+                            .frame(width: 22, height: 30)
+                            .opacity(rival.gameOver || rival.left ? 0.4 : 1)
+                    }
+                }
+            }
+            Button { showingInfo = true } label: {
+                Image(systemName: "info.circle.fill")
+                    .font(.system(size: 18, weight: .bold))
+                    .frame(width: 40, height: 47)
+                    .foregroundStyle(.white.opacity(0.85))
+                    .background(.white.opacity(0.055), in: RoundedRectangle(cornerRadius: 11))
+            }
+            .accessibilityLabel("How to play")
+        }
+    }
+
+    private func previewCard<Content: View>(
+        title: String,
+        accent: Color,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
             Text(title)
-                .font(.system(size: 10, weight: .bold, design: .rounded))
-                .foregroundStyle(.white.opacity(0.45))
+                .font(.system(size: 8, weight: .bold, design: .rounded))
+                .foregroundStyle(accent.opacity(0.8))
             content()
         }
-        .padding(8)
-        .background(.white.opacity(0.05), in: RoundedRectangle(cornerRadius: 10))
+        .padding(.horizontal, 8)
+        .frame(maxWidth: .infinity, minHeight: 47)
+        .background(.white.opacity(0.055), in: RoundedRectangle(cornerRadius: 11))
+        .overlay(RoundedRectangle(cornerRadius: 11).stroke(accent.opacity(0.18)))
     }
 
-    // MARK: - Overlays
+    private func board(width: CGFloat) -> some View {
+        BoardView(engine: engine)
+            .frame(width: width, height: width * 2)
+            .overlay {
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(.white.opacity(lockGlow ? 0.8 : 0), lineWidth: 3)
+                    .shadow(color: .cyan.opacity(lockGlow ? 0.9 : 0), radius: 14)
+            }
+            .overlay(alignment: .center) { clearFeedback }
+            .overlay { overlayContent }
+            .gesture(playGesture(cellWidth: width / 10))
+            .onTapGesture { engine.rotate(clockwise: true) }
+            .frame(maxWidth: .infinity)
+    }
+
+    @ViewBuilder
+    private var clearFeedback: some View {
+        if feedbackVisible, let clearKind = engine.clearKind {
+            VStack(spacing: 2) {
+                Text(clearKind.rawValue)
+                    .font(.system(size: clearKind == .tetris ? 31 : 24, weight: .black, design: .rounded))
+                    .foregroundStyle(
+                        LinearGradient(colors: [.cyan, .white, .purple], startPoint: .leading, endPoint: .trailing))
+                if engine.comboCount > 0 {
+                    Text("\(engine.comboCount + 1)× COMBO")
+                        .font(.system(size: 13, weight: .heavy, design: .rounded))
+                        .foregroundStyle(.yellow)
+                }
+            }
+            .padding(.horizontal, 18)
+            .padding(.vertical, 10)
+            .background(.black.opacity(0.72), in: Capsule())
+            .transition(.scale.combined(with: .opacity))
+        }
+    }
 
     @ViewBuilder
     private var overlayContent: some View {
-        switch engine.phase {
-        case .ready:
-            menuOverlay(title: "TETRIS", subtitle: "Swipe to move · Tap to rotate\nSwipe down to drop", button: "PLAY") {
-                engine.start()
+        if let matchResult {
+            matchResultOverlay(won: matchResult)
+        } else {
+            switch engine.phase {
+            case .ready:
+                startOverlay
+            case .gameOver:
+                resultOverlay
+            case .paused where engine.clearingRows.isEmpty:
+                menuOverlay(title: "PAUSED", subtitle: "Take a breath", button: "RESUME") {
+                    engine.togglePause()
+                }
+            default:
+                EmptyView()
             }
-        case .gameOver:
-            menuOverlay(
-                title: "GAME OVER",
-                subtitle: "Score \(engine.score)" + (engine.score >= engine.highScore && engine.score > 0 ? " · New Best!" : ""),
-                button: "PLAY AGAIN") {
-                engine.start()
-            }
-        case .paused where engine.clearingRows.isEmpty:
-            menuOverlay(title: "PAUSED", subtitle: "", button: "RESUME") {
-                engine.togglePause()
-            }
-        default:
-            EmptyView()
         }
     }
 
-    private func menuOverlay(title: String, subtitle: String, button: String, action: @escaping () -> Void) -> some View {
-        VStack(spacing: 16) {
-            Text(title)
-                .font(.system(size: 34, weight: .black, design: .rounded))
+    private var startOverlay: some View {
+        VStack(spacing: 14) {
+            Text("TETRIS")
+                .font(.system(size: 36, weight: .black, design: .rounded))
                 .foregroundStyle(
                     LinearGradient(colors: [.cyan, .purple], startPoint: .leading, endPoint: .trailing))
-            if !subtitle.isEmpty {
-                Text(subtitle)
-                    .font(.system(size: 14, weight: .medium, design: .rounded))
-                    .foregroundStyle(.white.opacity(0.6))
-                    .multilineTextAlignment(.center)
+            Text(match.state == .waiting || match.state == .connecting
+                 ? "Waiting for opponents…"
+                 : "Daily goal · clear 10 lines")
+                .font(.system(size: 13, weight: .semibold, design: .rounded))
+                .foregroundStyle(.white.opacity(0.62))
+            if match.state == .waiting || match.state == .connecting {
+                ProgressView().tint(.white)
+                Button("CANCEL") {
+                    vsMode = false
+                    match.disconnect()
+                }
+                .font(.system(size: 13, weight: .heavy, design: .rounded))
+                .foregroundStyle(.white.opacity(0.7))
+            } else {
+                Button {
+                    vsMode = false
+                    engine.start()
+                } label: {
+                    Text("PLAY")
+                        .font(.system(size: 16, weight: .heavy, design: .rounded))
+                        .foregroundStyle(.black)
+                        .padding(.horizontal, 38)
+                        .padding(.vertical, 11)
+                        .background(.white, in: Capsule())
+                }
+                Button {
+                    vsMode = true
+                    matchResult = nil
+                    match.connect()
+                } label: {
+                    Text("VS MATCH")
+                        .font(.system(size: 14, weight: .heavy, design: .rounded))
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 28)
+                        .padding(.vertical, 9)
+                        .background(.white.opacity(0.14), in: Capsule())
+                        .overlay(Capsule().stroke(.white.opacity(0.3)))
+                }
+                .accessibilityLabel("Versus match")
             }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(.black.opacity(0.8), in: RoundedRectangle(cornerRadius: 10))
+    }
+
+    private var rivalScoreLine: String {
+        let scores = match.sortedOpponentIDs.compactMap { id -> String? in
+            guard let rival = match.opponents[id] else { return nil }
+            return "P\(id + 1) \(rival.score)"
+        }
+        return (["You \(engine.score)"] + scores).joined(separator: " · ")
+    }
+
+    private func matchResultOverlay(won: Bool) -> some View {
+        VStack(spacing: 14) {
+            Text(won ? "YOU WIN" : "DEFEAT")
+                .font(.system(size: 33, weight: .black, design: .rounded))
+                .foregroundStyle(
+                    LinearGradient(
+                        colors: won ? [.yellow, .orange] : [.red, .purple],
+                        startPoint: .leading, endPoint: .trailing))
+            Text(rivalScoreLine)
+                .font(.system(size: 13, weight: .semibold, design: .rounded))
+                .foregroundStyle(.white.opacity(0.62))
+            Button("BACK TO MENU") {
+                matchResult = nil
+                vsMode = false
+                match.disconnect()
+                engine.phase = .ready
+            }
+            .font(.system(size: 15, weight: .heavy, design: .rounded))
+            .foregroundStyle(.black)
+            .padding(.horizontal, 30)
+            .padding(.vertical, 11)
+            .background(.white, in: Capsule())
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(.black.opacity(0.86), in: RoundedRectangle(cornerRadius: 10))
+    }
+
+    private func menuOverlay(title: String, subtitle: String, button: String, action: @escaping () -> Void) -> some View {
+        VStack(spacing: 14) {
+            Text(title)
+                .font(.system(size: 36, weight: .black, design: .rounded))
+                .foregroundStyle(
+                    LinearGradient(colors: [.cyan, .purple], startPoint: .leading, endPoint: .trailing))
+            Text(subtitle)
+                .font(.system(size: 13, weight: .semibold, design: .rounded))
+                .foregroundStyle(.white.opacity(0.62))
             Button(action: action) {
                 Text(button)
-                    .font(.system(size: 17, weight: .heavy, design: .rounded))
+                    .font(.system(size: 16, weight: .heavy, design: .rounded))
                     .foregroundStyle(.black)
-                    .padding(.horizontal, 36)
-                    .padding(.vertical, 12)
+                    .padding(.horizontal, 38)
+                    .padding(.vertical, 11)
                     .background(.white, in: Capsule())
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(.black.opacity(0.72), in: RoundedRectangle(cornerRadius: 6))
+        .background(.black.opacity(0.8), in: RoundedRectangle(cornerRadius: 10))
     }
 
-    // MARK: - Controls
+    private var resultOverlay: some View {
+        VStack(spacing: 12) {
+            Text(vsMode ? "DEFEAT" : (engine.lastRun?.isNewBest == true ? "NEW BEST" : "GAME OVER"))
+                .font(.system(size: 27, weight: .black, design: .rounded))
+                .foregroundStyle(
+                    LinearGradient(
+                        colors: vsMode ? [.red, .purple] : [.cyan, .purple],
+                        startPoint: .leading, endPoint: .trailing))
+            HStack(spacing: 6) {
+                resultStat("SCORE", engine.score)
+                resultStat("LINES", engine.lines)
+                resultStat("LEVEL", engine.level)
+            }
+            Text("Best lines \(engine.bestLines) · Highest level \(engine.highestLevel) · Longest combo \(engine.longestCombo)")
+                .font(.system(size: 10, weight: .semibold, design: .rounded))
+                .foregroundStyle(.white.opacity(0.58))
+                .multilineTextAlignment(.center)
+            Button(vsMode ? "BACK TO MENU" : "TRY AGAIN") {
+                if vsMode {
+                    vsMode = false
+                    matchResult = nil
+                    match.disconnect()
+                    engine.phase = .ready
+                } else {
+                    engine.start()
+                }
+            }
+            .font(.system(size: 16, weight: .heavy, design: .rounded))
+            .foregroundStyle(.black)
+            .padding(.horizontal, 35)
+            .padding(.vertical, 11)
+            .background(.white, in: Capsule())
+            Text("Tap or press Return to restart")
+                .font(.system(size: 9, weight: .medium, design: .rounded))
+                .foregroundStyle(.white.opacity(0.42))
+        }
+        .padding(15)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(.black.opacity(0.84), in: RoundedRectangle(cornerRadius: 10))
+    }
+
+    private func resultStat(_ label: String, _ value: Int) -> some View {
+        VStack(spacing: 2) {
+            Text(label).font(.system(size: 8, weight: .bold, design: .rounded)).foregroundStyle(.white.opacity(0.48))
+            Text("\(value)").font(.system(size: 17, weight: .heavy, design: .rounded))
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 7)
+        .background(.white.opacity(0.07), in: RoundedRectangle(cornerRadius: 9))
+    }
 
     private var controls: some View {
-        HStack(spacing: 8) {
-            controlButton("arrow.left") { engine.tryMove(dx: -1, dy: 0) }
-            controlButton("arrow.down") { engine.softDrop() }
-            controlButton("arrow.right") { engine.tryMove(dx: 1, dy: 0) }
-            controlButton("rotate.right") { engine.rotate(clockwise: true) }
-            controlButton("arrow.down.to.line", prominent: true) { engine.hardDrop() }
-            controlButton("tray.and.arrow.down") { engine.hold() }
-            controlButton(engine.phase == .paused ? "play.fill" : "pause.fill") { engine.togglePause() }
+        let buttons = leftHandedControls ? leftHandedButtons : standardButtons
+        return HStack(spacing: 6) {
+            ForEach(buttons) { item in
+                controlButton(item)
+            }
         }
-        .padding(.horizontal, 12)
     }
 
-    private func controlButton(_ symbol: String, prominent: Bool = false, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            Image(systemName: symbol)
-                .font(.system(size: 18, weight: .bold))
-                .foregroundStyle(prominent ? .black : .white)
+    private struct ControlItem: Identifiable {
+        let id: String
+        let symbol: String
+        let label: String
+        let prominent: Bool
+        let action: () -> Void
+    }
+
+    private var standardButtons: [ControlItem] {
+        [
+            ControlItem(id: "left", symbol: "arrow.left", label: "Move left", prominent: false) { engine.tryMove(dx: -1, dy: 0) },
+            ControlItem(id: "down", symbol: "arrow.down", label: "Soft drop", prominent: false) { engine.softDrop() },
+            ControlItem(id: "right", symbol: "arrow.right", label: "Move right", prominent: false) { engine.tryMove(dx: 1, dy: 0) },
+            ControlItem(id: "rotate", symbol: "rotate.right", label: "Rotate clockwise", prominent: false) { engine.rotate(clockwise: true) },
+            ControlItem(id: "drop", symbol: "arrow.down.to.line", label: "Hard drop", prominent: true) { engine.hardDrop() },
+            ControlItem(id: "hold", symbol: "tray.and.arrow.down", label: engine.holdAvailable ? "Hold piece" : "Hold already used", prominent: false) { engine.hold() },
+            ControlItem(id: "pause", symbol: engine.phase == .paused ? "play.fill" : "pause.fill", label: engine.phase == .paused ? "Resume" : "Pause", prominent: false) { engine.togglePause() }
+        ]
+    }
+
+    private var leftHandedButtons: [ControlItem] {
+        [standardButtons[5], standardButtons[4], standardButtons[3], standardButtons[0], standardButtons[1], standardButtons[2], standardButtons[6]]
+    }
+
+    private func controlButton(_ item: ControlItem) -> some View {
+        Button(action: item.action) {
+            Image(systemName: item.symbol)
+                .font(.system(size: 17, weight: .bold))
+                .foregroundStyle(item.prominent ? .black : .white)
                 .frame(maxWidth: .infinity)
-                .frame(height: 46)
+                .frame(height: 42)
                 .background(
-                    prominent ? AnyShapeStyle(.white) : AnyShapeStyle(.white.opacity(0.08)),
-                    in: RoundedRectangle(cornerRadius: 12))
+                    item.prominent ? AnyShapeStyle(.white) : AnyShapeStyle(.white.opacity(item.id == "pause" ? 0.14 : 0.075)),
+                    in: RoundedRectangle(cornerRadius: 11))
         }
-        .buttonRepeatBehavior(.enabled)
+        .buttonRepeatBehavior(item.id == "left" || item.id == "right" || item.id == "down" ? .enabled : .disabled)
+        .accessibilityLabel(item.label)
     }
 
-    // MARK: - Gestures
-
-    private var playGesture: some Gesture {
-        DragGesture(minimumDistance: 12)
+    private func playGesture(cellWidth: CGFloat) -> some Gesture {
+        DragGesture(minimumDistance: 10)
             .onChanged { value in
                 guard engine.phase == .playing else { return }
                 let dx = value.translation.width
                 let dy = value.translation.height
-                if abs(dy) > abs(dx) * 1.5, dy > 30, !didSoftDrop {
-                    if value.predictedEndTranslation.height > 220 {
+                if abs(dy) > abs(dx) * 1.5, dy > 24, !didSoftDrop {
+                    if value.predictedEndTranslation.height > 170 {
                         didSoftDrop = true
                         engine.hardDrop()
                     } else {
@@ -201,7 +487,6 @@ struct GameView: View {
                     }
                     return
                 }
-                let cellWidth: CGFloat = 26
                 let targetCells = Int((dx / cellWidth).rounded(.towardZero))
                 while dragCells < targetCells {
                     if engine.tryMove(dx: 1, dy: 0) { dragCells += 1 } else { break }
@@ -214,5 +499,78 @@ struct GameView: View {
                 dragCells = 0
                 didSoftDrop = false
             }
+    }
+
+    private var infoSheet: some View {
+        NavigationStack {
+            List {
+                Section("Touch") {
+                    Label("Swipe sideways to move", systemImage: "arrow.left.and.right")
+                    Label("Tap the board to rotate", systemImage: "rotate.right")
+                    Label("Swipe down to drop", systemImage: "arrow.down.to.line")
+                }
+                Section("Keyboard") {
+                    Text("Arrows move · Space hard drops · Z rotates left · C holds · P pauses")
+                }
+                Section("Versus") {
+                    Text("VS Match pairs three players over the local relay. Clearing lines sends garbage rows to every rival: double sends 1, triple 2, Tetris 4. Last player standing wins.")
+                }
+                Section("Progress") {
+                    Text("Clear lines to raise your level. Themes unlock at best scores of 500 and 1,500.")
+                }
+            }
+            .navigationTitle("How to Play")
+            .toolbar { Button("Done") { showingInfo = false } }
+        }
+        .presentationDetents([.medium])
+    }
+
+    private var settingsSheet: some View {
+        NavigationStack {
+            Form {
+                Section("Gameplay") {
+                    Toggle("Haptics", isOn: $hapticsEnabled)
+                    Toggle("Left-handed controls", isOn: $leftHandedControls)
+                }
+                Section("Theme") {
+                    Picker("Board theme", selection: $themeIndex) {
+                        Text("Neon Night").tag(0)
+                        Text(engine.highScore >= 500 ? "Aurora" : "Aurora · 500 points").tag(1)
+                            .disabled(engine.highScore < 500)
+                        Text(engine.highScore >= 1500 ? "Ember" : "Ember · 1,500 points").tag(2)
+                            .disabled(engine.highScore < 1500)
+                    }
+                }
+                Section("Records") {
+                    LabeledContent("Best score", value: "\(engine.highScore)")
+                    LabeledContent("Best lines", value: "\(engine.bestLines)")
+                    LabeledContent("Highest level", value: "\(engine.highestLevel)")
+                    LabeledContent("Longest combo", value: "\(engine.longestCombo)")
+                }
+            }
+            .navigationTitle("Settings")
+            .toolbar { Button("Done") { showingSettings = false } }
+        }
+        .presentationDetents([.medium, .large])
+    }
+
+    private var unlockedThemeCount: Int {
+        if engine.highScore >= 1500 { return 3 }
+        if engine.highScore >= 500 { return 2 }
+        return 1
+    }
+
+    private func showClearFeedback() {
+        withAnimation(.spring(response: 0.25, dampingFraction: 0.62)) { feedbackVisible = true }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.85) {
+            withAnimation(.easeOut(duration: 0.25)) { feedbackVisible = false }
+        }
+    }
+
+    private func showLockGlow() {
+        withAnimation(.easeOut(duration: 0.08)) { lockGlow = true }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.13) {
+            withAnimation(.easeOut(duration: 0.2)) { lockGlow = false }
+        }
     }
 }

--- a/TetrisiOS/Tetris/Sources/GameView.swift
+++ b/TetrisiOS/Tetris/Sources/GameView.swift
@@ -30,8 +30,14 @@ struct GameView: View {
             .onChange(of: engine.feedbackID) { _, _ in showClearFeedback() }
             .onChange(of: engine.lockPulseID) { _, _ in showLockGlow() }
             .onChange(of: match.allOpponentsOut) { _, allOut in
-                if allOut, vsMode, matchResult == nil, engine.phase != .gameOver {
+                if allOut, vsMode, matchResult == nil, engine.phase != .gameOver, !match.connectionLost {
                     matchResult = true
+                    if engine.phase == .playing { engine.togglePause() }
+                }
+            }
+            .onChange(of: match.connectionLost) { _, lost in
+                if lost, vsMode, matchResult == nil, engine.phase != .gameOver {
+                    matchResult = false
                     if engine.phase == .playing { engine.togglePause() }
                 }
             }
@@ -326,8 +332,8 @@ struct GameView: View {
 
     private func matchResultOverlay(won: Bool) -> some View {
         VStack(spacing: 14) {
-            Text(won ? "YOU WIN" : "DEFEAT")
-                .font(.system(size: 33, weight: .black, design: .rounded))
+            Text(match.connectionLost ? "CONNECTION LOST" : (won ? "YOU WIN" : "DEFEAT"))
+                .font(.system(size: match.connectionLost ? 24 : 33, weight: .black, design: .rounded))
                 .foregroundStyle(
                     LinearGradient(
                         colors: won ? [.yellow, .orange] : [.red, .purple],

--- a/TetrisiOS/Tetris/Sources/GameView.swift
+++ b/TetrisiOS/Tetris/Sources/GameView.swift
@@ -32,13 +32,13 @@ struct GameView: View {
             .onChange(of: match.allOpponentsOut) { _, allOut in
                 if allOut, vsMode, matchResult == nil, engine.phase != .gameOver, !match.connectionLost {
                     matchResult = true
-                    if engine.phase == .playing { engine.togglePause() }
+                    if engine.phase == .playing || !engine.clearingRows.isEmpty { engine.togglePause() }
                 }
             }
             .onChange(of: match.connectionLost) { _, lost in
                 if lost, vsMode, matchResult == nil, engine.phase != .gameOver {
                     matchResult = false
-                    if engine.phase == .playing { engine.togglePause() }
+                    if engine.phase == .playing || !engine.clearingRows.isEmpty { engine.togglePause() }
                 }
             }
             .sheet(isPresented: $showingInfo) { infoSheet }

--- a/TetrisiOS/Tetris/Sources/Haptics.swift
+++ b/TetrisiOS/Tetris/Sources/Haptics.swift
@@ -1,0 +1,22 @@
+import UIKit
+
+enum Haptics {
+    private static let light = UIImpactFeedbackGenerator(style: .light)
+    private static let medium = UIImpactFeedbackGenerator(style: .medium)
+    private static let heavy = UIImpactFeedbackGenerator(style: .heavy)
+    private static let notify = UINotificationFeedbackGenerator()
+
+    static func move() { light.impactOccurred(intensity: 0.5) }
+    static func rotate() { light.impactOccurred() }
+    static func hardDrop() { heavy.impactOccurred() }
+
+    static func lineClear(count: Int) {
+        if count >= 4 {
+            notify.notificationOccurred(.success)
+        } else {
+            medium.impactOccurred()
+        }
+    }
+
+    static func gameOver() { notify.notificationOccurred(.error) }
+}

--- a/TetrisiOS/Tetris/Sources/Haptics.swift
+++ b/TetrisiOS/Tetris/Sources/Haptics.swift
@@ -1,16 +1,19 @@
 import UIKit
 
 enum Haptics {
+    static var enabled = true
+
     private static let light = UIImpactFeedbackGenerator(style: .light)
     private static let medium = UIImpactFeedbackGenerator(style: .medium)
     private static let heavy = UIImpactFeedbackGenerator(style: .heavy)
     private static let notify = UINotificationFeedbackGenerator()
 
-    static func move() { light.impactOccurred(intensity: 0.5) }
-    static func rotate() { light.impactOccurred() }
-    static func hardDrop() { heavy.impactOccurred() }
+    static func move() { if enabled { light.impactOccurred(intensity: 0.5) } }
+    static func rotate() { if enabled { light.impactOccurred() } }
+    static func hardDrop() { if enabled { heavy.impactOccurred() } }
 
     static func lineClear(count: Int) {
+        guard enabled else { return }
         if count >= 4 {
             notify.notificationOccurred(.success)
         } else {
@@ -18,5 +21,5 @@ enum Haptics {
         }
     }
 
-    static func gameOver() { notify.notificationOccurred(.error) }
+    static func gameOver() { if enabled { notify.notificationOccurred(.error) } }
 }

--- a/TetrisiOS/Tetris/Sources/MultiplayerClient.swift
+++ b/TetrisiOS/Tetris/Sources/MultiplayerClient.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+struct Opponent {
+    var board: [[Int]] = Array(repeating: Array(repeating: 0, count: GameEngine.width),
+                               count: GameEngine.height)
+    var score = 0
+    var lines = 0
+    var gameOver = false
+    var left = false
+}
+
+@MainActor
+final class MultiplayerClient: ObservableObject {
+    enum MatchState { case idle, connecting, waiting, playing }
+
+    @Published var state: MatchState = .idle
+    @Published var playerID = -1
+    @Published var opponents: [Int: Opponent] = [:]
+
+    var onGarbage: ((Int) -> Void)?
+    var onMatched: (() -> Void)?
+
+    var allOpponentsOut: Bool {
+        !opponents.isEmpty && opponents.values.allSatisfy { $0.gameOver || $0.left }
+    }
+
+    var sortedOpponentIDs: [Int] { opponents.keys.sorted() }
+
+    private var task: URLSessionWebSocketTask?
+
+    func connect(url: URL = URL(string: "ws://127.0.0.1:8765")!) {
+        guard state == .idle else { return }
+        state = .connecting
+        let task = URLSession.shared.webSocketTask(with: url)
+        self.task = task
+        task.resume()
+        receive()
+    }
+
+    func disconnect() {
+        task?.cancel(with: .goingAway, reason: nil)
+        task = nil
+        state = .idle
+        playerID = -1
+        opponents = [:]
+    }
+
+    func sendState(board: [[Int]], score: Int, lines: Int) {
+        send(["type": "state", "board": board, "score": score, "lines": lines])
+    }
+
+    func sendGarbage(_ count: Int) {
+        guard count > 0 else { return }
+        send(["type": "garbage", "count": count])
+    }
+
+    func sendGameOver(score: Int) {
+        send(["type": "gameOver", "score": score])
+    }
+
+    private func send(_ payload: [String: Any]) {
+        guard state == .playing || state == .waiting,
+              let data = try? JSONSerialization.data(withJSONObject: payload),
+              let text = String(data: data, encoding: .utf8) else { return }
+        task?.send(.string(text)) { _ in }
+    }
+
+    private func receive() {
+        task?.receive { [weak self] result in
+            guard let self else { return }
+            Task { @MainActor in
+                switch result {
+                case .failure:
+                    if self.state != .idle {
+                        for id in self.opponents.keys { self.opponents[id]?.left = true }
+                    }
+                case .success(let message):
+                    if case .string(let text) = message,
+                       let data = text.data(using: .utf8),
+                       let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+                        self.handle(json)
+                    }
+                    self.receive()
+                }
+            }
+        }
+    }
+
+    private func handle(_ json: [String: Any]) {
+        switch json["type"] as? String {
+        case "waiting":
+            state = .waiting
+        case "matched":
+            playerID = json["you"] as? Int ?? -1
+            opponents = [:]
+            for id in json["peers"] as? [Int] ?? [] {
+                opponents[id] = Opponent()
+            }
+            state = .playing
+            onMatched?()
+        case "state":
+            guard let from = json["from"] as? Int else { return }
+            if let board = json["board"] as? [[Int]] { opponents[from]?.board = board }
+            if let score = json["score"] as? Int { opponents[from]?.score = score }
+            if let lines = json["lines"] as? Int { opponents[from]?.lines = lines }
+        case "garbage":
+            if let count = json["count"] as? Int { onGarbage?(count) }
+        case "gameOver":
+            if let from = json["from"] as? Int { opponents[from]?.gameOver = true }
+        case "opponentLeft":
+            if let from = json["from"] as? Int { opponents[from]?.left = true }
+        default:
+            break
+        }
+    }
+}

--- a/TetrisiOS/Tetris/Sources/MultiplayerClient.swift
+++ b/TetrisiOS/Tetris/Sources/MultiplayerClient.swift
@@ -16,6 +16,7 @@ final class MultiplayerClient: ObservableObject {
     @Published var state: MatchState = .idle
     @Published var playerID = -1
     @Published var opponents: [Int: Opponent] = [:]
+    @Published var connectionLost = false
 
     var onGarbage: ((Int) -> Void)?
     var onMatched: (() -> Void)?
@@ -43,6 +44,7 @@ final class MultiplayerClient: ObservableObject {
         state = .idle
         playerID = -1
         opponents = [:]
+        connectionLost = false
     }
 
     func sendState(board: [[Int]], score: Int, lines: Int) {
@@ -72,7 +74,9 @@ final class MultiplayerClient: ObservableObject {
                 switch result {
                 case .failure:
                     if self.state != .idle {
-                        for id in self.opponents.keys { self.opponents[id]?.left = true }
+                        self.connectionLost = true
+                        self.task?.cancel(with: .abnormalClosure, reason: nil)
+                        self.task = nil
                     }
                 case .success(let message):
                     if case .string(let text) = message,

--- a/TetrisiOS/Tetris/Sources/MultiplayerClient.swift
+++ b/TetrisiOS/Tetris/Sources/MultiplayerClient.swift
@@ -104,11 +104,15 @@ final class MultiplayerClient: ObservableObject {
             onMatched?()
         case "state":
             guard let from = json["from"] as? Int else { return }
-            if let board = json["board"] as? [[Int]] { opponents[from]?.board = board }
-            if let score = json["score"] as? Int { opponents[from]?.score = score }
-            if let lines = json["lines"] as? Int { opponents[from]?.lines = lines }
+            if let board = json["board"] as? [[Int]],
+               board.count == GameEngine.height,
+               board.allSatisfy({ $0.count == GameEngine.width && $0.allSatisfy { (0...7).contains($0) } }) {
+                opponents[from]?.board = board
+            }
+            if let score = json["score"] as? Int, score >= 0 { opponents[from]?.score = score }
+            if let lines = json["lines"] as? Int, lines >= 0 { opponents[from]?.lines = lines }
         case "garbage":
-            if let count = json["count"] as? Int { onGarbage?(count) }
+            if let count = json["count"] as? Int, count > 0 { onGarbage?(min(count, 8)) }
         case "gameOver":
             if let from = json["from"] as? Int { opponents[from]?.gameOver = true }
         case "opponentLeft":

--- a/TetrisiOS/Tetris/Sources/TetrisApp.swift
+++ b/TetrisiOS/Tetris/Sources/TetrisApp.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+@main
+struct TetrisApp: App {
+    var body: some Scene {
+        WindowGroup {
+            GameView()
+                .preferredColorScheme(.dark)
+                .statusBarHidden()
+        }
+    }
+}

--- a/TetrisiOS/Tetris/Sources/Tetromino.swift
+++ b/TetrisiOS/Tetris/Sources/Tetromino.swift
@@ -40,9 +40,10 @@ struct Piece {
     /// Board-space cells occupied by the piece.
     var cells: [(Int, Int)] {
         let n = type.boxSize
+        let turns = type == .o ? 0 : rotation
         return type.baseCells.map { (cx, cy) in
             var px = cx, py = cy
-            for _ in 0..<rotation {
+            for _ in 0..<turns {
                 let t = px
                 px = n - 1 - py
                 py = t

--- a/TetrisiOS/Tetris/Sources/Tetromino.swift
+++ b/TetrisiOS/Tetris/Sources/Tetromino.swift
@@ -1,0 +1,90 @@
+import SwiftUI
+
+enum PieceType: CaseIterable {
+    case i, o, t, s, z, j, l
+
+    var color: Color {
+        switch self {
+        case .i: return Color(red: 0.20, green: 0.85, blue: 0.94)
+        case .o: return Color(red: 0.98, green: 0.83, blue: 0.20)
+        case .t: return Color(red: 0.72, green: 0.40, blue: 0.95)
+        case .s: return Color(red: 0.35, green: 0.88, blue: 0.45)
+        case .z: return Color(red: 0.96, green: 0.33, blue: 0.38)
+        case .j: return Color(red: 0.30, green: 0.50, blue: 0.98)
+        case .l: return Color(red: 0.98, green: 0.58, blue: 0.22)
+        }
+    }
+
+    /// Cells for rotation 0, in a 4x4 (I/O) or 3x3 grid, (x, y) with y down.
+    var baseCells: [(Int, Int)] {
+        switch self {
+        case .i: return [(0, 1), (1, 1), (2, 1), (3, 1)]
+        case .o: return [(1, 0), (2, 0), (1, 1), (2, 1)]
+        case .t: return [(1, 0), (0, 1), (1, 1), (2, 1)]
+        case .s: return [(1, 0), (2, 0), (0, 1), (1, 1)]
+        case .z: return [(0, 0), (1, 0), (1, 1), (2, 1)]
+        case .j: return [(0, 0), (0, 1), (1, 1), (2, 1)]
+        case .l: return [(2, 0), (0, 1), (1, 1), (2, 1)]
+        }
+    }
+
+    var boxSize: Int { self == .i || self == .o ? 4 : 3 }
+}
+
+struct Piece {
+    var type: PieceType
+    var rotation: Int  // 0..3
+    var x: Int
+    var y: Int
+
+    /// Board-space cells occupied by the piece.
+    var cells: [(Int, Int)] {
+        let n = type.boxSize
+        return type.baseCells.map { (cx, cy) in
+            var px = cx, py = cy
+            for _ in 0..<rotation {
+                let t = px
+                px = n - 1 - py
+                py = t
+            }
+            return (x + px, y + py)
+        }
+    }
+
+    static func spawn(_ type: PieceType, boardWidth: Int) -> Piece {
+        Piece(type: type, rotation: 0, x: (boardWidth - type.boxSize) / 2, y: type == .i ? -1 : 0)
+    }
+}
+
+/// SRS wall-kick data. Returns offsets to try for rotation from `from` to `to`.
+enum SRS {
+    static func kicks(type: PieceType, from: Int, to: Int) -> [(Int, Int)] {
+        if type == .o { return [(0, 0)] }
+        let table: [String: [(Int, Int)]]
+        if type == .i {
+            table = [
+                "0>1": [(0, 0), (-2, 0), (1, 0), (-2, -1), (1, 2)],
+                "1>0": [(0, 0), (2, 0), (-1, 0), (2, 1), (-1, -2)],
+                "1>2": [(0, 0), (-1, 0), (2, 0), (-1, 2), (2, -1)],
+                "2>1": [(0, 0), (1, 0), (-2, 0), (1, -2), (-2, 1)],
+                "2>3": [(0, 0), (2, 0), (-1, 0), (2, 1), (-1, -2)],
+                "3>2": [(0, 0), (-2, 0), (1, 0), (-2, -1), (1, 2)],
+                "3>0": [(0, 0), (1, 0), (-2, 0), (1, -2), (-2, 1)],
+                "0>3": [(0, 0), (-1, 0), (2, 0), (-1, 2), (2, -1)],
+            ]
+        } else {
+            table = [
+                "0>1": [(0, 0), (-1, 0), (-1, 1), (0, -2), (-1, -2)],
+                "1>0": [(0, 0), (1, 0), (1, -1), (0, 2), (1, 2)],
+                "1>2": [(0, 0), (1, 0), (1, -1), (0, 2), (1, 2)],
+                "2>1": [(0, 0), (-1, 0), (-1, 1), (0, -2), (-1, -2)],
+                "2>3": [(0, 0), (1, 0), (1, 1), (0, -2), (1, -2)],
+                "3>2": [(0, 0), (-1, 0), (-1, -1), (0, 2), (-1, 2)],
+                "3>0": [(0, 0), (-1, 0), (-1, -1), (0, 2), (-1, 2)],
+                "0>3": [(0, 0), (1, 0), (1, 1), (0, -2), (1, -2)],
+            ]
+        }
+        // SRS kick y is up-positive; our y is down-positive, so negate y.
+        return (table["\(from)>\(to)"] ?? [(0, 0)]).map { ($0.0, -$0.1) }
+    }
+}

--- a/TetrisiOS/TetrisTests/GameEngineTests.swift
+++ b/TetrisiOS/TetrisTests/GameEngineTests.swift
@@ -1,0 +1,150 @@
+import XCTest
+@testable import Tetris
+
+@MainActor
+final class GameEngineTests: XCTestCase {
+
+    private func freshEngine() -> GameEngine {
+        let engine = GameEngine()
+        engine.start()
+        return engine
+    }
+
+    func testSpawnQueueAndBagRandomizer() {
+        let engine = freshEngine()
+        XCTAssertNotNil(engine.current)
+        XCTAssertEqual(engine.nextQueue.count, 5)
+        // First 7 pieces (current + next 5 + refill) must come from a 7-bag:
+        // the current piece plus queue must have no duplicates beyond bag boundaries.
+        var seen = Set<PieceType>()
+        var pieces = [engine.current!.type]
+        pieces.append(contentsOf: engine.nextQueue)
+        for piece in pieces.prefix(7) {
+            XCTAssertFalse(seen.contains(piece), "7-bag must not repeat within first 7 pieces")
+            seen.insert(piece)
+        }
+    }
+
+    func testHardDropLocksAndSpawnsNext() {
+        let engine = freshEngine()
+        let firstType = engine.current!.type
+        let nextType = engine.nextQueue.first!
+        engine.hardDrop()
+        let settled = engine.board.flatMap { $0 }.compactMap { $0 }
+        XCTAssertEqual(settled.count, 4)
+        XCTAssertEqual(settled.first, firstType)
+        XCTAssertEqual(engine.current?.type, nextType)
+    }
+
+    func testSingleLineClearScoresAndCollapses() {
+        let engine = freshEngine()
+        // Fill bottom row except columns 3-6, drop a flat I piece into the gap.
+        for x in [0, 1, 2, 7, 8, 9] {
+            engine.board[GameEngine.height - 1][x] = .j
+        }
+        engine.current = Piece(type: .i, rotation: 0, x: 3, y: 0)
+        let scoreBefore = engine.score
+        engine.hardDrop()
+
+        let expectation = expectation(description: "line collapse")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { expectation.fulfill() }
+        wait(for: [expectation], timeout: 2)
+
+        XCTAssertEqual(engine.lines, 1)
+        XCTAssertTrue(engine.board[GameEngine.height - 1].allSatisfy { $0 == nil })
+        // 100 * level + hard-drop distance * 2
+        XCTAssertGreaterThanOrEqual(engine.score - scoreBefore, 100)
+    }
+
+    func testTetrisClearScores800() {
+        let engine = freshEngine()
+        for row in (GameEngine.height - 4)..<GameEngine.height {
+            for x in 0..<(GameEngine.width - 1) {
+                engine.board[row][x] = .j
+            }
+        }
+        // Vertical I piece in the last column.
+        engine.current = Piece(type: .i, rotation: 1, x: GameEngine.width - 3, y: 0)
+        engine.hardDrop()
+
+        let expectation = expectation(description: "tetris collapse")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { expectation.fulfill() }
+        wait(for: [expectation], timeout: 2)
+
+        XCTAssertEqual(engine.lines, 4)
+        XCTAssertTrue(engine.lastClearWasTetris)
+        XCTAssertGreaterThanOrEqual(engine.score, 800)
+        XCTAssertTrue(engine.board.allSatisfy { row in row.allSatisfy { $0 == nil } })
+    }
+
+    func testLevelAdvancesEveryTenLines() {
+        let engine = freshEngine()
+        engine.lines = 9
+        XCTAssertEqual(engine.level, 1)
+        for x in [0, 1, 2, 7, 8, 9] {
+            engine.board[GameEngine.height - 1][x] = .j
+        }
+        engine.current = Piece(type: .i, rotation: 0, x: 3, y: 0)
+        engine.hardDrop()
+        let expectation = expectation(description: "collapse")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { expectation.fulfill() }
+        wait(for: [expectation], timeout: 2)
+        XCTAssertEqual(engine.lines, 10)
+        XCTAssertEqual(engine.level, 2)
+    }
+
+    func testWallKickRotationNearWall() {
+        let engine = freshEngine()
+        // T piece flush against the left wall, rotation should kick it inward.
+        engine.current = Piece(type: .t, rotation: 1, x: -1, y: 5)
+        engine.rotate(clockwise: true)
+        let piece = engine.current!
+        XCTAssertEqual(piece.rotation, 2)
+        for (x, _) in piece.cells {
+            XCTAssertGreaterThanOrEqual(x, 0)
+        }
+    }
+
+    func testMovementBlockedByWalls() {
+        let engine = freshEngine()
+        engine.current = Piece(type: .o, rotation: 0, x: -1, y: 5)  // O occupies cols 0-1
+        XCTAssertFalse(engine.tryMove(dx: -1, dy: 0))
+        XCTAssertTrue(engine.tryMove(dx: 1, dy: 0))
+    }
+
+    func testHoldSwapsPieceOncePerDrop() {
+        let engine = freshEngine()
+        let firstType = engine.current!.type
+        let nextType = engine.nextQueue.first!
+        engine.hold()
+        XCTAssertEqual(engine.holdPiece, firstType)
+        XCTAssertEqual(engine.current?.type, nextType)
+        let typeBeforeSecondHold = engine.current?.type
+        engine.hold()  // Should be a no-op until next lock.
+        XCTAssertEqual(engine.current?.type, typeBeforeSecondHold)
+        XCTAssertEqual(engine.holdPiece, firstType)
+    }
+
+    func testGhostLandsOnStack() {
+        let engine = freshEngine()
+        for x in 0..<GameEngine.width {
+            engine.board[GameEngine.height - 1][x] = .j
+        }
+        engine.current = Piece(type: .o, rotation: 0, x: 0, y: 0)
+        let ghost = engine.ghost!
+        let maxY = ghost.cells.map(\.1).max()!
+        XCTAssertEqual(maxY, GameEngine.height - 2)
+    }
+
+    func testTopOutEndsGame() {
+        let engine = freshEngine()
+        for row in 0..<GameEngine.height {
+            for x in 0..<GameEngine.width where x != 9 {
+                engine.board[row][x] = .j
+            }
+        }
+        engine.current = Piece(type: .o, rotation: 0, x: 0, y: 0)
+        engine.hardDrop()
+        XCTAssertEqual(engine.phase, .gameOver)
+    }
+}

--- a/TetrisiOS/TetrisTests/GameEngineTests.swift
+++ b/TetrisiOS/TetrisTests/GameEngineTests.swift
@@ -144,7 +144,19 @@ final class GameEngineTests: XCTestCase {
             }
         }
         engine.current = Piece(type: .o, rotation: 0, x: 0, y: 0)
+        engine.nextQueue.insert(.o, at: 0)
         engine.hardDrop()
         XCTAssertEqual(engine.phase, .gameOver)
+    }
+
+    func testAddGarbageInsertsRowsWithHole() {
+        let engine = freshEngine()
+        engine.board[GameEngine.height - 1][0] = .j
+        engine.addGarbage(2)
+        let bottomTwo = Array(engine.board.suffix(2))
+        for row in bottomTwo {
+            XCTAssertEqual(row.filter { $0 == nil }.count, 1, "garbage row must have one hole")
+        }
+        XCTAssertEqual(engine.board[GameEngine.height - 3][0], .j, "stack must shift up")
     }
 }

--- a/TetrisiOS/project.yml
+++ b/TetrisiOS/project.yml
@@ -1,0 +1,36 @@
+name: Tetris
+options:
+  bundleIdPrefix: com.dabit3
+  deploymentTarget:
+    iOS: "17.0"
+targets:
+  Tetris:
+    type: application
+    platform: iOS
+    sources:
+      - Tetris/Sources
+    info:
+      path: Tetris/Info.plist
+      properties:
+        CFBundleDisplayName: Tetris
+        UILaunchScreen: {}
+        UISupportedInterfaceOrientations:
+          - UIInterfaceOrientationPortrait
+        UIUserInterfaceStyle: Dark
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.dabit3.tetris
+        TARGETED_DEVICE_FAMILY: "1"
+        SWIFT_VERSION: "5.9"
+        CODE_SIGNING_ALLOWED: "NO"
+  TetrisTests:
+    type: bundle.unit-test
+    platform: iOS
+    sources:
+      - TetrisTests
+    dependencies:
+      - target: Tetris
+    settings:
+      base:
+        SWIFT_VERSION: "5.9"
+        CODE_SIGNING_ALLOWED: "NO"

--- a/TetrisiOS/tools/relay.py
+++ b/TetrisiOS/tools/relay.py
@@ -32,8 +32,12 @@ async def handler(ws):
         room_members[room_id] = members
         for pid, sock in members.items():
             rooms[sock] = (room_id, pid)
+        for pid, sock in members.items():
             peers = [i for i in members if i != pid]
-            await sock.send(json.dumps({"type": "matched", "you": pid, "peers": peers}))
+            try:
+                await sock.send(json.dumps({"type": "matched", "you": pid, "peers": peers}))
+            except websockets.ConnectionClosed:
+                pass  # handler's finally block broadcasts opponentLeft for this pid
     try:
         async for message in ws:
             if ws not in rooms:

--- a/TetrisiOS/tools/relay.py
+++ b/TetrisiOS/tools/relay.py
@@ -1,0 +1,81 @@
+"""Local WebSocket relay for Tetris VS matches.
+
+Groups connecting clients into rooms of ROOM_SIZE and relays messages between
+peers, tagging each forwarded message with the sender's player id.
+
+Usage:
+    pip install websockets
+    python relay.py [port] [room_size]
+"""
+import asyncio
+import json
+import sys
+
+import websockets
+
+ROOM_SIZE = 3
+
+waiting = []
+rooms = {}  # ws -> (room_id, player_id)
+room_members = {}  # room_id -> {player_id: ws}
+next_room_id = 0
+
+
+async def handler(ws):
+    global next_room_id
+    waiting.append(ws)
+    await ws.send(json.dumps({"type": "waiting"}))
+    if len(waiting) >= ROOM_SIZE:
+        members = {i: waiting.pop(0) for i in range(ROOM_SIZE)}
+        room_id = next_room_id
+        next_room_id += 1
+        room_members[room_id] = members
+        for pid, sock in members.items():
+            rooms[sock] = (room_id, pid)
+            peers = [i for i in members if i != pid]
+            await sock.send(json.dumps({"type": "matched", "you": pid, "peers": peers}))
+    try:
+        async for message in ws:
+            if ws not in rooms:
+                continue
+            room_id, pid = rooms[ws]
+            try:
+                payload = json.loads(message)
+            except json.JSONDecodeError:
+                continue
+            payload["from"] = pid
+            text = json.dumps(payload)
+            for other_pid, sock in room_members.get(room_id, {}).items():
+                if other_pid != pid:
+                    try:
+                        await sock.send(text)
+                    except websockets.ConnectionClosed:
+                        pass
+    except websockets.ConnectionClosed:
+        pass
+    finally:
+        if ws in waiting:
+            waiting.remove(ws)
+        if ws in rooms:
+            room_id, pid = rooms.pop(ws)
+            members = room_members.get(room_id, {})
+            members.pop(pid, None)
+            for sock in members.values():
+                try:
+                    await sock.send(json.dumps({"type": "opponentLeft", "from": pid}))
+                except websockets.ConnectionClosed:
+                    pass
+            if not members:
+                room_members.pop(room_id, None)
+
+
+async def main(port):
+    async with websockets.serve(handler, "127.0.0.1", port):
+        print(f"Tetris relay listening on ws://127.0.0.1:{port} (rooms of {ROOM_SIZE})")
+        await asyncio.Future()
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 2:
+        ROOM_SIZE = int(sys.argv[2])
+    asyncio.run(main(int(sys.argv[1]) if len(sys.argv) > 1 else 8765))


### PR DESCRIPTION
## Summary
New self-contained `TetrisiOS/` directory containing a native iOS Tetris clone (SwiftUI, no dependencies), built and verified on the iPhone 15 Pro simulator (iOS 17.5).

- `GameEngine` (ObservableObject): guideline mechanics — SRS rotation with full JLSTZ/I wall-kick tables, 7-bag randomizer, 5-piece next queue, hold, ghost piece, 0.5s lock delay with 15 move-resets, guideline gravity curve `max(0.05, (0.8 - (lvl-1)*0.007)^(lvl-1))`, scoring 100/300/500/800×level + combo + drop bonuses, level-up every 10 lines, persistent high score.
- `BoardView`/`GameView`: SwiftUI `Canvas` renderer (beveled gradient blocks, grid, line-clear flash), HUD with hold/next panels, on-screen buttons, swipe/tap gestures, and hardware keyboard support (arrows, space, `z`/`c`/`p`), plus haptics.
- Project generated via XcodeGen (`project.yml`); app + `TetrisTests` targets.
- 10 XCTest unit tests pass on-simulator: single/Tetris line clears + collapse, scoring, level-up, SRS wall kick at wall, wall-blocked movement, hold once-per-drop, ghost landing, 7-bag uniqueness, top-out game over.

Gameplay (recorded on simulator):

![gameplay](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctOTFlZTA2ZGFhYjRlNGZkMGFiNjExMzU1MmRiOTY5YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctOTFlZTA2ZGFhYjRlNGZkMGFiNjExMzU1MmRiOTY5YmUvNmFlMTUyZDQtOWVhNC00ZTNkLThiMGMtOTg5MjE3MWEwMDc4IiwiaWF0IjoxNzg2NzI3ODM3LCJleHAiOjE3ODczMzI2MzcsImZpbGVuYW1lIjoidGV0cmlzLWNsaXAuZ2lmIn0._IGOLVJlCqp8-CGG5cThIh3zZJQDUFYJ9oEB7jLzAzw)

![midgame](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctOTFlZTA2ZGFhYjRlNGZkMGFiNjExMzU1MmRiOTY5YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctOTFlZTA2ZGFhYjRlNGZkMGFiNjExMzU1MmRiOTY5YmUvMTc5YjQyM2EtMTk5Mi00MTNmLTg5MWQtMTkyN2RjYzFkNWZlIiwiaWF0IjoxNzg2NzI3ODM4LCJleHAiOjE3ODczMzI2MzgsImZpbGVuYW1lIjoidGV0cmlzLW1pZGdhbWUucG5nIn0.kFgg0r4yREF8gDWM1-RYkLcUQuQKjWCBJmB33gsBVYs)


Link to Devin session: https://app.devin.ai/sessions/08b7aedb5ab149ba9e88ce6d2d4e89e2
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/50" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->