### PR TITLE
App-wide email blacklist managed by global admins

### DIFF
--- a/app/admin/blacklist/page.tsx
+++ b/app/admin/blacklist/page.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useState } from "react";
+import { Ban, ShieldAlert, X } from "lucide-react";
+import { toast } from "sonner";
+import { useMutation, useQuery } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import { Id } from "@/convex/_generated/dataModel";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Field, FieldLabel } from "@/components/ui/field";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from "@/components/ui/input-group";
+import { Empty, EmptyDescription, EmptyHeader } from "@/components/ui/empty";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Spinner } from "@/components/ui/spinner";
+
+export default function BlacklistPage() {
+  const access = useQuery(api.admins.accessLevel);
+  const entries = useQuery(
+    api.blacklist.list,
+    access?.isGlobalAdmin ? {} : "skip"
+  );
+  const addEmail = useMutation(api.blacklist.add);
+  const removeEmail = useMutation(api.blacklist.remove);
+
+  const [email, setEmail] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [removingId, setRemovingId] = useState<Id<"blacklistedEmails"> | null>(
+    null
+  );
+
+  async function handleAdd(e: React.FormEvent) {
+    e.preventDefault();
+    setSubmitting(true);
+    try {
+      await addEmail({ email });
+      toast.success(`${email.trim().toLowerCase()} is now blacklisted`);
+      setEmail("");
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to blacklist email"
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleRemove(id: Id<"blacklistedEmails">) {
+    setRemovingId(id);
+    try {
+      await removeEmail({ id });
+      toast.success("Removed from blacklist");
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to remove from blacklist"
+      );
+    } finally {
+      setRemovingId(null);
+    }
+  }
+
+  if (access && !access.isGlobalAdmin) {
+    return (
+      <div className="mx-auto max-w-2xl">
+        <Alert>
+          <ShieldAlert />
+          <AlertTitle>Global admins only</AlertTitle>
+          <AlertDescription>
+            Only global admins can manage the email blacklist. You have
+            event-level access — head back to your events.
+          </AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl">
+      <div className="mb-10">
+        <p className="eyebrow flex items-center gap-2 text-muted-foreground">
+          <span className="inline-block size-1.5 rounded-full bg-border-strong" />
+          Access control
+        </p>
+        <h1 className="mt-3 font-heading text-3xl font-semibold tracking-[-0.02em]">
+          Blacklist
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Blacklisted emails are rejected whenever they would be added to any
+          event — uploads, flagged-email approvals, and access-request
+          approvals all skip them.
+        </p>
+      </div>
+
+      <form onSubmit={handleAdd} className="mb-10">
+        <Field>
+          <FieldLabel htmlFor="blacklist-email">Blacklist an email</FieldLabel>
+          <InputGroup>
+            <InputGroupInput
+              id="blacklist-email"
+              type="email"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="bad-actor@example.com"
+              className="text-sm"
+            />
+            <InputGroupAddon align="inline-end">
+              <InputGroupButton
+                type="submit"
+                variant="default"
+                size="xs"
+                disabled={submitting}
+                aria-busy={submitting}
+              >
+                <Ban data-icon="inline-start" />
+                {submitting ? "Adding..." : "Blacklist"}
+              </InputGroupButton>
+            </InputGroupAddon>
+          </InputGroup>
+        </Field>
+      </form>
+
+      {entries === undefined ? (
+        <div className="flex flex-col gap-2">
+          <Skeleton className="h-12 rounded-md" />
+          <Skeleton className="h-12 rounded-md" />
+        </div>
+      ) : entries.length === 0 ? (
+        <Empty className="border border-dashed border-border-strong py-16">
+          <EmptyHeader>
+            <EmptyDescription>No blacklisted emails.</EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      ) : (
+        <ul className="divide-y divide-border border-y border-border">
+          {entries.map((entry) => (
+            <li
+              key={entry._id}
+              className="flex min-h-12 items-center justify-between gap-3 px-1 py-2 transition-colors hover:bg-surface"
+            >
+              <span className="flex min-w-0 flex-col">
+                <span className="truncate text-sm">{entry.email}</span>
+                {entry.addedBy ? (
+                  <span className="truncate text-xs text-muted-dim">
+                    Added by {entry.addedBy}
+                  </span>
+                ) : null}
+              </span>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                aria-label={`Remove ${entry.email} from blacklist`}
+                onClick={() => handleRemove(entry._id)}
+                disabled={removingId === entry._id}
+                aria-busy={removingId === entry._id}
+                className="shrink-0 text-muted-foreground"
+              >
+                {removingId === entry._id ? <Spinner /> : <X />}
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/components/AdminNav.tsx
+++ b/components/AdminNav.tsx
@@ -19,7 +19,10 @@ export default function AdminNav() {
   const links = [
     { href: "/admin", label: "Events" },
     ...(access?.isGlobalAdmin
-      ? [{ href: "/admin/admins", label: "Admins" }]
+      ? [
+          { href: "/admin/admins", label: "Admins" },
+          { href: "/admin/blacklist", label: "Blacklist" },
+        ]
       : []),
   ];
 

--- a/components/ManageEvent.tsx
+++ b/components/ManageEvent.tsx
@@ -453,7 +453,14 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
                       onClick={() =>
                         approveFlagged({ id: f._id })
                           .then(() => toast.success(`Approved ${f.email}`))
-                          .catch(() => toast.error("Failed to approve"))
+                          .catch((err) =>
+                            toast.error(
+                              err instanceof Error &&
+                                err.message.includes("blacklisted")
+                                ? `${f.email} is blacklisted and cannot be added`
+                                : "Failed to approve"
+                            )
+                          )
                       }
                     >
                       <Check data-icon="inline-start" />

--- a/components/ManageEvent.tsx
+++ b/components/ManageEvent.tsx
@@ -7,6 +7,7 @@ import {
   AlertTriangle,
   ArrowLeft,
   ArrowUpRight,
+  Ban,
   Check,
   Download,
   Inbox,
@@ -72,6 +73,7 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
   const event = useQuery(api.events.get, { id });
   const emails = useQuery(api.emails.list, { eventId: id });
   const flagged = useQuery(api.emails.listFlagged, { eventId: id });
+  const blacklistHits = useQuery(api.blacklist.listHits, { eventId: id });
   const codes = useQuery(api.codes.list, { eventId: id });
   const access = useQuery(api.admins.accessLevel);
   const addEmails = useMutation(api.emails.add);
@@ -150,18 +152,23 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
     if (list.length === 0) return;
     setEmailBusy(true);
     try {
-      const { added, skipped, flagged } = await addEmails({
+      const { added, skipped, flagged, blacklisted } = await addEmails({
         eventId: id,
         emails: list,
       });
       const description =
         [
+          blacklisted ? `${blacklisted} rejected (blacklisted).` : "",
           flagged ? `${flagged} flagged for review (found in past events).` : "",
           skipped ? `Skipped ${skipped} (duplicates/invalid).` : "",
         ]
           .filter(Boolean)
           .join(" ") || undefined;
-      if (added === 0 && flagged > 0) {
+      if (added === 0 && blacklisted > 0 && flagged === 0) {
+        toast.warning(`${blacklisted} emails rejected (blacklisted)`, {
+          description,
+        });
+      } else if (added === 0 && flagged > 0) {
         toast.warning(`${flagged} emails awaiting review`, { description });
       } else {
         toast.success(`Added ${added} emails`, { description });
@@ -217,7 +224,12 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
     kind: "emails" | "codes",
     send: (
       items: string[]
-    ) => Promise<{ added: number; skipped: number; flagged?: number }>,
+    ) => Promise<{
+      added: number;
+      skipped: number;
+      flagged?: number;
+      blacklisted?: number;
+    }>,
     setBusy: (busy: boolean) => void
   ) {
     setBusy(true);
@@ -239,6 +251,7 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
       let added = 0;
       let skipped = dropped;
       let flagged = 0;
+      let blacklisted = 0;
       for (let i = 0; i < items.length; i += UPLOAD_CHUNK_SIZE) {
         toast.loading(
           `Uploading ${Math.min(i + UPLOAD_CHUNK_SIZE, items.length)} / ${items.length}...`,
@@ -248,15 +261,22 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
         added += res.added;
         skipped += res.skipped;
         flagged += res.flagged ?? 0;
+        blacklisted += res.blacklisted ?? 0;
       }
       const description =
         [
+          blacklisted ? `${blacklisted} rejected (blacklisted).` : "",
           flagged ? `${flagged} flagged for review (found in past events).` : "",
           skipped ? `Skipped ${skipped} duplicates or invalid rows.` : "",
         ]
           .filter(Boolean)
           .join(" ") || undefined;
-      if (added === 0 && flagged > 0) {
+      if (added === 0 && blacklisted > 0 && flagged === 0) {
+        toast.warning(`${blacklisted} from ${file.name} rejected (blacklisted)`, {
+          id: toastId,
+          description,
+        });
+      } else if (added === 0 && flagged > 0) {
         toast.warning(`${flagged} from ${file.name} awaiting review`, {
           id: toastId,
           description,
@@ -356,6 +376,34 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
         event={event}
         canDelete={access?.isGlobalAdmin ?? false}
       />
+
+      {blacklistHits && blacklistHits.length > 0 ? (
+        <Card className="border-destructive/40">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Ban className="size-4 text-destructive" aria-hidden />
+              Blacklisted
+              <Badge variant="secondary">{blacklistHits.length}</Badge>
+            </CardTitle>
+            <CardDescription>
+              These uploaded emails are on the app-wide blacklist and were
+              rejected. Only global admins can manage the blacklist.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ul className="max-h-96 divide-y divide-border overflow-y-auto border-y border-border">
+              {blacklistHits.map((hit) => (
+                <li
+                  key={hit._id}
+                  className="flex min-h-10 items-center px-1 py-2 transition-colors hover:bg-surface"
+                >
+                  <span className="truncate text-sm">{hit.email}</span>
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+      ) : null}
 
       {flagged && flagged.entries.length > 0 ? (
         <Card className="border-amber-500/40">

--- a/components/WalkUpClaim.tsx
+++ b/components/WalkUpClaim.tsx
@@ -65,10 +65,17 @@ export default function WalkUpClaim({ id }: { id: Id<"events"> }) {
     if (!trimmed) return;
     setSubmitting(true);
     try {
-      const { added, skipped, flagged } = await addEmails({
+      const { added, skipped, flagged, blacklisted } = await addEmails({
         eventId: id,
         emails: [trimmed],
       });
+      if (blacklisted > 0) {
+        toast.error(`${trimmed} is blacklisted`, {
+          description:
+            "This email is on the app-wide blacklist and cannot claim a code.",
+        });
+        return;
+      }
       if (flagged > 0) {
         toast.warning(`${trimmed} needs organizer approval`, {
           description:

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -10,6 +10,7 @@
 
 import type * as admins from "../admins.js";
 import type * as auditLog from "../auditLog.js";
+import type * as blacklist from "../blacklist.js";
 import type * as claims from "../claims.js";
 import type * as codes from "../codes.js";
 import type * as emails from "../emails.js";
@@ -27,6 +28,7 @@ import type {
 declare const fullApi: ApiFromModules<{
   admins: typeof admins;
   auditLog: typeof auditLog;
+  blacklist: typeof blacklist;
   claims: typeof claims;
   codes: typeof codes;
   emails: typeof emails;

--- a/convex/blacklist.ts
+++ b/convex/blacklist.ts
@@ -1,0 +1,96 @@
+import { mutation, query, type MutationCtx, type QueryCtx } from "./_generated/server";
+import type { Id } from "./_generated/dataModel";
+import { v } from "convex/values";
+import { adminEmailStatus, requireAdmin, requireEventAdmin } from "./admins";
+
+// App-wide blacklist managed exclusively by global admins. Blacklisted
+// addresses are rejected whenever they would be added to any event's
+// eligible list.
+export async function isBlacklisted(
+  ctx: QueryCtx | MutationCtx,
+  email: string
+) {
+  const match = await ctx.db
+    .query("blacklistedEmails")
+    .withIndex("by_email", (q) => q.eq("email", email))
+    .unique();
+  return match !== null;
+}
+
+// Records that a blacklisted address was rejected while being added to an
+// event, so event admins can see which uploaded emails were blocked.
+export async function recordBlacklistHit(
+  ctx: MutationCtx,
+  eventId: Id<"events">,
+  email: string
+) {
+  const existing = await ctx.db
+    .query("blacklistHits")
+    .withIndex("by_event_email", (q) =>
+      q.eq("eventId", eventId).eq("email", email)
+    )
+    .unique();
+  if (!existing) {
+    await ctx.db.insert("blacklistHits", { eventId, email });
+  }
+}
+
+export const list = query({
+  args: {},
+  handler: async (ctx) => {
+    await requireAdmin(ctx);
+    return await ctx.db.query("blacklistedEmails").collect();
+  },
+});
+
+export const add = mutation({
+  args: { email: v.string() },
+  handler: async (ctx, args) => {
+    await requireAdmin(ctx);
+    const email = args.email.trim().toLowerCase();
+    if (!email || !email.includes("@")) {
+      throw new Error("Enter a valid email address");
+    }
+    const existing = await ctx.db
+      .query("blacklistedEmails")
+      .withIndex("by_email", (q) => q.eq("email", email))
+      .unique();
+    if (existing) throw new Error(`${email} is already blacklisted`);
+    const { email: actorEmail } = await adminEmailStatus(ctx);
+    await ctx.db.insert("blacklistedEmails", {
+      email,
+      addedBy: actorEmail ?? undefined,
+    });
+  },
+});
+
+export const remove = mutation({
+  args: { id: v.id("blacklistedEmails") },
+  handler: async (ctx, args) => {
+    await requireAdmin(ctx);
+    const entry = await ctx.db.get(args.id);
+    if (!entry) return;
+    await ctx.db.delete(args.id);
+    // Clear the rejection records so events stop showing the address as
+    // blacklisted once it's off the list.
+    const hits = await ctx.db
+      .query("blacklistHits")
+      .withIndex("by_email", (q) => q.eq("email", entry.email))
+      .collect();
+    for (const hit of hits) {
+      await ctx.db.delete(hit._id);
+    }
+  },
+});
+
+// Blacklisted addresses rejected while being added to this event.
+export const listHits = query({
+  args: { eventId: v.id("events") },
+  handler: async (ctx, args) => {
+    await requireEventAdmin(ctx, args.eventId);
+    return await ctx.db
+      .query("blacklistHits")
+      .withIndex("by_event", (q) => q.eq("eventId", args.eventId))
+      .collect();
+  },
+});

--- a/convex/blacklist.ts
+++ b/convex/blacklist.ts
@@ -61,6 +61,16 @@ export const add = mutation({
       email,
       addedBy: actorEmail ?? undefined,
     });
+    // Pending duplicate-review flags for the address can never be approved
+    // now, so convert them into per-event blacklist rejections.
+    const pendingFlags = await ctx.db
+      .query("flaggedEmails")
+      .withIndex("by_email", (q) => q.eq("email", email))
+      .collect();
+    for (const flag of pendingFlags) {
+      await ctx.db.delete(flag._id);
+      await recordBlacklistHit(ctx, flag.eventId, email);
+    }
   },
 });
 

--- a/convex/emails.ts
+++ b/convex/emails.ts
@@ -44,6 +44,17 @@ export const add = mutation({
       }
       if (await isBlacklisted(ctx, email)) {
         await recordBlacklistHit(ctx, args.eventId, email);
+        // A pending review flag can never be approved for a blacklisted
+        // address, so it's superseded by the rejection record.
+        const pendingFlag = await ctx.db
+          .query("flaggedEmails")
+          .withIndex("by_event_email", (q) =>
+            q.eq("eventId", args.eventId).eq("email", email)
+          )
+          .unique();
+        if (pendingFlag) {
+          await ctx.db.delete(pendingFlag._id);
+        }
         blacklisted++;
         continue;
       }

--- a/convex/emails.ts
+++ b/convex/emails.ts
@@ -2,6 +2,7 @@ import { mutation, query } from "./_generated/server";
 import { v } from "convex/values";
 import type { Id } from "./_generated/dataModel";
 import { adminEmailStatus, requireEventAdmin } from "./admins";
+import { isBlacklisted, recordBlacklistHit } from "./blacklist";
 import { logAudit } from "./auditLog";
 
 export const list = query({
@@ -22,6 +23,7 @@ export const add = mutation({
     let added = 0;
     let skipped = 0;
     let flagged = 0;
+    let blacklisted = 0;
     const seen = new Set<string>();
     for (const raw of args.emails) {
       const email = raw.trim().toLowerCase();
@@ -30,6 +32,11 @@ export const add = mutation({
         continue;
       }
       seen.add(email);
+      if (await isBlacklisted(ctx, email)) {
+        await recordBlacklistHit(ctx, args.eventId, email);
+        blacklisted++;
+        continue;
+      }
       const existing = await ctx.db
         .query("emails")
         .withIndex("by_event_email", (q) =>
@@ -86,7 +93,7 @@ export const add = mutation({
       }
       added++;
     }
-    return { added, skipped, flagged };
+    return { added, skipped, flagged, blacklisted };
   },
 });
 
@@ -167,6 +174,9 @@ export const approveFlagged = mutation({
     if (!event) {
       await ctx.db.delete(args.id);
       return;
+    }
+    if (await isBlacklisted(ctx, flagged.email)) {
+      throw new Error(`${flagged.email} is blacklisted and cannot be added`);
     }
     const existing = await ctx.db
       .query("emails")

--- a/convex/emails.ts
+++ b/convex/emails.ts
@@ -32,11 +32,6 @@ export const add = mutation({
         continue;
       }
       seen.add(email);
-      if (await isBlacklisted(ctx, email)) {
-        await recordBlacklistHit(ctx, args.eventId, email);
-        blacklisted++;
-        continue;
-      }
       const existing = await ctx.db
         .query("emails")
         .withIndex("by_event_email", (q) =>
@@ -45,6 +40,11 @@ export const add = mutation({
         .unique();
       if (existing) {
         skipped++;
+        continue;
+      }
+      if (await isBlacklisted(ctx, email)) {
+        await recordBlacklistHit(ctx, args.eventId, email);
+        blacklisted++;
         continue;
       }
       // Emails already signed up for other events are held for manual

--- a/convex/events.ts
+++ b/convex/events.ts
@@ -210,6 +210,11 @@ export const remove = mutation({
       .withIndex("by_event", (q) => q.eq("eventId", args.id))
       .collect();
     for (const entry of flagged) await ctx.db.delete(entry._id);
+    const blacklistHits = await ctx.db
+      .query("blacklistHits")
+      .withIndex("by_event", (q) => q.eq("eventId", args.id))
+      .collect();
+    for (const hit of blacklistHits) await ctx.db.delete(hit._id);
     const codes = await ctx.db
       .query("codes")
       .withIndex("by_event", (q) => q.eq("eventId", args.id))

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -30,6 +30,19 @@ export default defineSchema({
     .index("by_event_email", ["eventId", "email"])
     .index("by_email", ["email"]),
 
+  blacklistedEmails: defineTable({
+    email: v.string(),
+    addedBy: v.optional(v.string()),
+  }).index("by_email", ["email"]),
+
+  blacklistHits: defineTable({
+    eventId: v.id("events"),
+    email: v.string(),
+  })
+    .index("by_event", ["eventId"])
+    .index("by_event_email", ["eventId", "email"])
+    .index("by_email", ["email"]),
+
   flaggedEmails: defineTable({
     eventId: v.id("events"),
     email: v.string(),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -49,7 +49,8 @@ export default defineSchema({
     matchedEventIds: v.array(v.id("events")),
   })
     .index("by_event", ["eventId"])
-    .index("by_event_email", ["eventId", "email"]),
+    .index("by_event_email", ["eventId", "email"])
+    .index("by_email", ["email"]),
 
   codes: defineTable({
     eventId: v.id("events"),

--- a/convex/waitlist.ts
+++ b/convex/waitlist.ts
@@ -2,6 +2,7 @@ import { mutation, query } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { v } from "convex/values";
 import { requireEventAdmin } from "./admins";
+import { isBlacklisted, recordBlacklistHit } from "./blacklist";
 import { logAudit } from "./auditLog";
 
 // Attendees not on an event's whitelist can request access. Requests are
@@ -172,6 +173,13 @@ export const approve = mutation({
         reserved: priorReservation !== null,
         alreadyClaimed: priorClaim !== null,
       };
+    }
+
+    if (await isBlacklisted(ctx, request.email)) {
+      await recordBlacklistHit(ctx, request.eventId, request.email);
+      throw new Error(
+        `${request.email} is blacklisted and cannot be approved`
+      );
     }
 
     const whitelisted = await ctx.db

--- a/convex/waitlist.ts
+++ b/convex/waitlist.ts
@@ -2,7 +2,7 @@ import { mutation, query } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { v } from "convex/values";
 import { requireEventAdmin } from "./admins";
-import { isBlacklisted, recordBlacklistHit } from "./blacklist";
+import { isBlacklisted } from "./blacklist";
 import { logAudit } from "./auditLog";
 
 // Attendees not on an event's whitelist can request access. Requests are
@@ -176,7 +176,6 @@ export const approve = mutation({
     }
 
     if (await isBlacklisted(ctx, request.email)) {
-      await recordBlacklistHit(ctx, request.eventId, request.email);
       throw new Error(
         `${request.email} is blacklisted and cannot be approved`
       );


### PR DESCRIPTION
## Summary
Adds an app-wide email blacklist. Only global admins (`requireAdmin`) can add/remove entries via a new `/admin/blacklist` page (linked in `AdminNav` for global admins only).

Enforcement — a blacklisted address is rejected on every path that would add it to an event's eligible list after being blacklisted:
- `emails.add`: skipped and counted in a new `blacklisted` return field; each rejection is recorded in a new `blacklistHits` table (`{eventId, email}`)
- `emails.approveFlagged` and `waitlist.approve`: throw `"<email> is blacklisted and cannot be added/approved"`

New tables: `blacklistedEmails {email, addedBy}` and `blacklistHits {eventId, email}` (hit rows are deleted when an address is un-blacklisted).

Event UI (`ManageEvent`): a "Blacklisted" card lists uploaded addresses that were rejected for that event (via `blacklist.listHits`, visible to event admins, read-only), and upload toasts report `N rejected (blacklisted)`.

Note: entries already on an event's list before being blacklisted are untouched, per the requirement that only additions *after* blacklisting are rejected.

Link to Devin session: https://app.devin.ai/sessions/33eb8109567e4a3ba9d73f8c457780e7
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/51" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->