### PR TITLE
docs: weekly sync — document blacklist and cross-event flagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,18 @@ Dispense credit codes to event participants (hackathons, conferences, meetups). 
 4. If the verified sign-in email is on the list, they're assigned an unclaimed code (idempotent — the same email always gets the same code back).
 5. If not, they can't claim.
 
+### Fraud controls
+
+- **Cross-event duplicate flagging**: when emails are uploaded (CSV/XLSX or pasted), any address that already appears in another event's eligible list is not added directly. It goes to a "Flagged for review" section on the manage-event page, where the organizer must approve or reject each one individually. Both decisions are recorded in the audit log. Upload results report the number of flagged addresses.
+- **App-wide email blacklist**: global admins manage a blacklist at `/admin/blacklist`. A blacklisted address is rejected on every path that would add it to an event's eligible list after being blacklisted — uploads skip it (reported as `N rejected (blacklisted)` in the upload toast), and approving a flagged email or waitlist request for it fails with an error. Each rejected upload attempt is recorded and shown to event admins in a read-only "Blacklisted" card on the manage-event page. Addresses already on an event's list before being blacklisted are untouched; un-blacklisting an address clears its recorded hits.
+
 ## Routes
 
 - `/` — public list of events (newest first)
 - `/<slug>` — claim page for an event (requires signing in to verify email ownership)
 - `/admin` — admin dashboard (Clerk-protected): create events
-- `/admin/events/<id>` — manage an event: edit name/slug/description, emails, codes, see claim stats
+- `/admin/events/<id>` — manage an event: edit name/slug/description, emails, codes, see claim stats, review flagged emails
+- `/admin/blacklist` — app-wide email blacklist (global admins only)
 - `/sign-in` — Clerk sign-in page (kept same-origin so protected-route redirects don't break client navigations)
 
 ## Setup


### PR DESCRIPTION
## Summary
Weekly docs sync against PRs merged in the last 7 days (#45–#51). Two merged PRs changed user-facing behavior that the README didn't cover:

- #46 — cross-event duplicate signups are flagged for manual review instead of being added directly
- #51 — app-wide email blacklist managed by global admins at `/admin/blacklist`

README updates:
- New "Fraud controls" section under "How it works" describing flagging (approve/reject, audit log) and blacklist enforcement (uploads skipped, flagged/waitlist approvals blocked, per-event "Blacklisted" hits card, pre-existing entries untouched)
- Routes list: added `/admin/blacklist`, noted flagged-email review on `/admin/events/<id>`

No doc impact from #45 (reverts temporary schema-validation state), or #47/#48/#49 (theme-toggle icon visuals).

Link to Devin session: https://app.devin.ai/sessions/6a0a4981421f4f63a43585e40a0721ff
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/52" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->