### PR TITLE
Support two named code types per event with claim-time choice

### DIFF
--- a/app/my-codes/page.tsx
+++ b/app/my-codes/page.tsx
@@ -34,6 +34,7 @@ import {
   EmptyMedia,
   EmptyTitle,
 } from "@/components/ui/empty";
+import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 
 function formatCredits(amount: string) {
@@ -183,6 +184,11 @@ export default function MyCodesPage() {
                       {meta ? <CardDescription>{meta}</CardDescription> : null}
                     </CardHeader>
                   <CardContent className="flex-1 pt-2 pb-1">
+                    {item.codeType ? (
+                      <Badge variant="secondary" className="mb-2 text-[10px]">
+                        {item.codeType}
+                      </Badge>
+                    ) : null}
                     <div className="font-mono text-xl font-medium tracking-[0.04em] break-all select-all">
                       {item.code}
                     </div>

--- a/components/ClaimPage.tsx
+++ b/components/ClaimPage.tsx
@@ -51,6 +51,7 @@ type ClaimResult =
   | {
       ok: true;
       code: string;
+      codeType?: string;
       alreadyClaimed: boolean;
       creditAmount?: string;
     }
@@ -76,6 +77,7 @@ export default function ClaimPage({ slug }: { slug: string }) {
   const [result, setResult] = useState<ClaimResult | null>(null);
   const [copied, setCopied] = useState(false);
   const [showQr, setShowQr] = useState(false);
+  const [selectedType, setSelectedType] = useState<string | null>(null);
   const origin = useSyncExternalStore(
     subscribeNoop,
     () => window.location.origin,
@@ -84,11 +86,19 @@ export default function ClaimPage({ slug }: { slug: string }) {
 
   const signedInEmail = user?.primaryEmailAddress?.emailAddress;
 
+  // Two named pools means the user picks which one to draw from; a single
+  // (possibly unnamed) pool claims without a choice.
+  const codeTypes = (event?.codeTypes ?? []).filter((t) => t !== "");
+  const mustChoose = (event?.codeTypes.length ?? 0) > 1;
+
   async function handleClaim() {
     setSubmitting(true);
     setResult(null);
     try {
-      const res = await claim({ slug });
+      const res = await claim({
+        slug,
+        codeType: mustChoose && selectedType ? selectedType : undefined,
+      });
       setResult(res);
     } catch {
       setResult({ ok: false, error: "Something went wrong. Please try again." });
@@ -141,6 +151,7 @@ export default function ClaimPage({ slug }: { slug: string }) {
               eventName={event.name}
               creditAmount={result.creditAmount}
               code={result.code}
+              codeType={result.codeType}
               alreadyClaimed={result.alreadyClaimed}
               copied={copied}
               onCopy={copyCode}
@@ -237,10 +248,35 @@ export default function ClaimPage({ slug }: { slug: string }) {
                         <AlertTitle>{result.error}</AlertTitle>
                       </Alert>
                     ) : null}
+                    {mustChoose ? (
+                      <fieldset className="flex flex-col gap-2">
+                        <legend className="mb-2 text-xs font-medium text-muted-foreground">
+                          Choose your code type
+                        </legend>
+                        <div className="grid grid-cols-2 gap-2">
+                          {codeTypes.map((type) => (
+                            <Button
+                              key={type}
+                              type="button"
+                              variant="outline"
+                              aria-pressed={selectedType === type}
+                              onClick={() => setSelectedType(type)}
+                              className={cn(
+                                "h-auto min-h-10 whitespace-normal py-2",
+                                selectedType === type &&
+                                  "border-brand ring-1 ring-brand",
+                              )}
+                            >
+                              {type}
+                            </Button>
+                          ))}
+                        </div>
+                      </fieldset>
+                    ) : null}
                     <Button
                       variant="brand"
                       size="lg"
-                      disabled={submitting}
+                      disabled={submitting || (mustChoose && !selectedType)}
                       className="w-full"
                       onClick={handleClaim}
                       aria-busy={submitting}
@@ -361,6 +397,7 @@ function Receipt({
   eventName,
   creditAmount,
   code,
+  codeType,
   alreadyClaimed,
   copied,
   onCopy,
@@ -368,6 +405,7 @@ function Receipt({
   eventName: string;
   creditAmount?: string;
   code: string;
+  codeType?: string;
   alreadyClaimed: boolean;
   copied: boolean;
   onCopy: (code: string) => void;
@@ -409,7 +447,9 @@ function Receipt({
         ) : null}
 
         <div className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-300 py-2 motion-reduce:animate-none">
-          <div className="text-xs text-muted-dim">Your credit code</div>
+          <div className="text-xs text-muted-dim">
+            {codeType ? `Your “${codeType}” code` : "Your credit code"}
+          </div>
           <div className="mt-2 font-mono text-3xl font-medium tracking-[0.06em] break-all select-all sm:text-4xl">
             {code}
           </div>

--- a/components/ManageEvent.tsx
+++ b/components/ManageEvent.tsx
@@ -85,6 +85,7 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
 
   const [emailInput, setEmailInput] = useState("");
   const [codeInput, setCodeInput] = useState("");
+  const [codeName, setCodeName] = useState("");
   const [emailBusy, setEmailBusy] = useState(false);
   const [codeBusy, setCodeBusy] = useState(false);
 
@@ -187,7 +188,11 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
     if (list.length === 0) return;
     setCodeBusy(true);
     try {
-      const { added, skipped } = await addCodes({ eventId: id, codes: list });
+      const { added, skipped } = await addCodes({
+        eventId: id,
+        codes: list,
+        codeType: codeName.trim() || undefined,
+      });
       toast.success(`Added ${added} codes`, {
         description: skipped ? `Skipped ${skipped} (duplicates).` : undefined,
       });
@@ -210,9 +215,10 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
   function exportCodes() {
     if (!codes || !event) return;
     downloadCsv(`${event.slug}-codes.csv`, [
-      ["code", "claimed_by", "claimed_at"],
+      ["code", "type", "claimed_by", "claimed_at"],
       ...codes.map((c) => [
         c.code,
+        c.codeType ?? "",
         c.claimedBy ?? "",
         c.claimedAt ? new Date(c.claimedAt).toISOString() : "",
       ]),
@@ -564,11 +570,25 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
                   Export
                 </Button>
               ) : null}
-              <UploadButton busy={codeBusy} onFile={(f) => importFile(f, "codes", (items) => addCodes({ eventId: id, codes: items }), setCodeBusy)} />
+              <UploadButton busy={codeBusy} onFile={(f) => importFile(f, "codes", (items) => addCodes({ eventId: id, codes: items, codeType: codeName.trim() || undefined }), setCodeBusy)} />
             </CardAction>
           </CardHeader>
           <CardContent className="flex flex-col gap-4">
             <form onSubmit={handleAddCodes} className="flex flex-col gap-3">
+              <Field>
+                <FieldLabel htmlFor="code-name">Code name</FieldLabel>
+                <Input
+                  id="code-name"
+                  value={codeName}
+                  onChange={(e) => setCodeName(e.target.value)}
+                  placeholder="e.g. $50 credits"
+                  className="text-sm"
+                />
+                <FieldDescription>
+                  Optional with a single code type — required to tell two code
+                  types apart. Applies to pasted and uploaded codes.
+                </FieldDescription>
+              </Field>
               <Textarea
                 aria-label="Credit codes to add"
                 value={codeInput}
@@ -599,6 +619,7 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
               items={codes?.map((c) => ({
                 key: c._id,
                 label: c.code,
+                tag: c.codeType ?? undefined,
                 claimedBy: c.claimedBy ?? undefined,
                 onRemove: c.claimedBy
                   ? undefined
@@ -762,7 +783,13 @@ function RowList({
   emptyText,
   mono,
 }: {
-  items?: { key: string; label: string; claimedBy?: string; onRemove?: () => void }[];
+  items?: {
+    key: string;
+    label: string;
+    tag?: string;
+    claimedBy?: string;
+    onRemove?: () => void;
+  }[];
   emptyText: string;
   mono?: boolean;
 }) {
@@ -788,10 +815,20 @@ function RowList({
           key={item.key}
           className="flex min-h-10 items-center justify-between gap-3 px-1 py-1.5 transition-colors hover:bg-surface"
         >
-          <span
-            className={cn("truncate text-sm", mono && "font-mono text-xs")}
-          >
-            {item.label}
+          <span className="flex min-w-0 items-center gap-2">
+            <span
+              className={cn("truncate text-sm", mono && "font-mono text-xs")}
+            >
+              {item.label}
+            </span>
+            {item.tag ? (
+              <Badge
+                variant="outline"
+                className="max-w-24 shrink-0 truncate text-[10px] sm:max-w-40"
+              >
+                {item.tag}
+              </Badge>
+            ) : null}
           </span>
           {item.claimedBy ? (
             <Badge

--- a/convex/claims.ts
+++ b/convex/claims.ts
@@ -69,20 +69,24 @@ export const claim = mutation({
       .first();
     const unclaimed = reserved
       ? null
-      : await ctx.db
-          .query("codes")
-          .withIndex("by_event_claimedBy", (q) =>
-            q.eq("eventId", event._id).eq("claimedBy", undefined)
-          )
-          .filter((q) =>
-            requestedType !== undefined
-              ? q.and(
-                  q.eq(q.field("reservedFor"), undefined),
-                  q.eq(q.field("codeType"), requestedType)
-                )
-              : q.eq(q.field("reservedFor"), undefined)
-          )
-          .first();
+      : requestedType !== undefined
+        ? await ctx.db
+            .query("codes")
+            .withIndex("by_event_codeType_claimedBy", (q) =>
+              q
+                .eq("eventId", event._id)
+                .eq("codeType", requestedType)
+                .eq("claimedBy", undefined)
+            )
+            .filter((q) => q.eq(q.field("reservedFor"), undefined))
+            .first()
+        : await ctx.db
+            .query("codes")
+            .withIndex("by_event_claimedBy", (q) =>
+              q.eq("eventId", event._id).eq("claimedBy", undefined)
+            )
+            .filter((q) => q.eq(q.field("reservedFor"), undefined))
+            .first();
     const available = reserved ?? unclaimed;
     if (!available) {
       return {

--- a/convex/claims.ts
+++ b/convex/claims.ts
@@ -2,7 +2,7 @@ import { mutation } from "./_generated/server";
 import { v } from "convex/values";
 
 export const claim = mutation({
-  args: { slug: v.string() },
+  args: { slug: v.string(), codeType: v.optional(v.string()) },
   handler: async (ctx, args) => {
     // Codes are only dispensed to the signed-in user's verified email, so
     // knowing someone else's registered address is not enough to take their code.
@@ -50,10 +50,13 @@ export const claim = mutation({
       return {
         ok: true as const,
         code: alreadyClaimed.code,
+        codeType: alreadyClaimed.codeType,
         alreadyClaimed: true,
         creditAmount: event.creditAmount,
       };
     }
+
+    const requestedType = args.codeType?.trim() || undefined;
 
     // A code reserved for this email (via waitlist approval) takes priority;
     // otherwise take any unclaimed code that isn't reserved for someone else.
@@ -71,13 +74,23 @@ export const claim = mutation({
           .withIndex("by_event_claimedBy", (q) =>
             q.eq("eventId", event._id).eq("claimedBy", undefined)
           )
-          .filter((q) => q.eq(q.field("reservedFor"), undefined))
+          .filter((q) =>
+            requestedType !== undefined
+              ? q.and(
+                  q.eq(q.field("reservedFor"), undefined),
+                  q.eq(q.field("codeType"), requestedType)
+                )
+              : q.eq(q.field("reservedFor"), undefined)
+          )
           .first();
     const available = reserved ?? unclaimed;
     if (!available) {
       return {
         ok: false as const,
-        error: "All codes for this event have been claimed.",
+        error:
+          requestedType !== undefined
+            ? `All "${requestedType}" codes for this event have been claimed.`
+            : "All codes for this event have been claimed.",
       };
     }
 
@@ -89,6 +102,7 @@ export const claim = mutation({
     return {
       ok: true as const,
       code: available.code,
+      codeType: available.codeType,
       alreadyClaimed: false,
       creditAmount: event.creditAmount,
     };

--- a/convex/codes.ts
+++ b/convex/codes.ts
@@ -51,6 +51,13 @@ export const add = mutation({
       await ctx.db.insert("codes", { eventId: args.eventId, code, codeType });
       added++;
     }
+    // Keep the event's denormalized type list in sync so availability checks
+    // can probe per type instead of scanning the pool.
+    if (added > 0) {
+      await ctx.db.patch(args.eventId, {
+        codeTypes: [...resultingTypes].sort(),
+      });
+    }
     return { added, skipped };
   },
 });
@@ -103,5 +110,22 @@ export const remove = mutation({
       );
     }
     await ctx.db.delete(args.id);
+    // Drop the type from the event's denormalized list when its last code is
+    // removed.
+    const remaining = await ctx.db
+      .query("codes")
+      .withIndex("by_event_codeType_claimedBy", (q) =>
+        q.eq("eventId", code.eventId).eq("codeType", code.codeType)
+      )
+      .first();
+    if (!remaining) {
+      const event = await ctx.db.get(code.eventId);
+      const typeKey = code.codeType ?? "";
+      if (event?.codeTypes?.includes(typeKey)) {
+        await ctx.db.patch(code.eventId, {
+          codeTypes: event.codeTypes.filter((t) => t !== typeKey),
+        });
+      }
+    }
   },
 });

--- a/convex/codes.ts
+++ b/convex/codes.ts
@@ -14,13 +14,30 @@ export const list = query({
 });
 
 export const add = mutation({
-  args: { eventId: v.id("events"), codes: v.array(v.string()) },
+  args: {
+    eventId: v.id("events"),
+    codes: v.array(v.string()),
+    codeType: v.optional(v.string()),
+  },
   handler: async (ctx, args) => {
     await requireEventAdmin(ctx, args.eventId);
+    const codeType = args.codeType?.trim() || undefined;
     const existing = await ctx.db
       .query("codes")
       .withIndex("by_event", (q) => q.eq("eventId", args.eventId))
       .collect();
+    // Events support at most two code types, and both must be named so
+    // attendees can tell them apart on the claim page.
+    const resultingTypes = new Set(existing.map((c) => c.codeType ?? ""));
+    resultingTypes.add(codeType ?? "");
+    if (resultingTypes.size > 2) {
+      throw new Error("An event can have at most two code types.");
+    }
+    if (resultingTypes.size === 2 && resultingTypes.has("")) {
+      throw new Error(
+        "Both code types need a name so attendees can tell them apart. Name the unnamed codes or use the same name."
+      );
+    }
     const existingSet = new Set(existing.map((c) => c.code));
     let added = 0;
     let skipped = 0;
@@ -31,7 +48,7 @@ export const add = mutation({
         continue;
       }
       existingSet.add(code);
-      await ctx.db.insert("codes", { eventId: args.eventId, code });
+      await ctx.db.insert("codes", { eventId: args.eventId, code, codeType });
       added++;
     }
     return { added, skipped };
@@ -56,6 +73,7 @@ export const mine = query({
         return {
           _id: c._id,
           code: c.code,
+          codeType: c.codeType,
           claimedAt: c.claimedAt,
           event: event
             ? {

--- a/convex/events.ts
+++ b/convex/events.ts
@@ -47,26 +47,40 @@ export const getBySlug = query({
     if (!event) return null;
     // A code counts as available for the viewer when it is unclaimed and
     // either unreserved or reserved for the viewer's verified email, matching
-    // what claims.claim would actually hand out. Distinct available types are
-    // gathered by streaming the unclaimed pool and stopping as soon as both
-    // possible types are seen (an event has at most two, enforced on upload),
-    // so the read-set stays small for large pools. An unnamed pool is
-    // represented as ""; two pools are always both named.
+    // what claims.claim would actually hand out. The event carries its
+    // (at most two) distinct code types, so availability is one bounded probe
+    // per type instead of a scan of the pool. An unnamed pool is represented
+    // as ""; two pools are always both named. Events created before the type
+    // list existed have a single unnamed pool.
     const identity = await ctx.auth.getUserIdentity();
     const viewerEmail =
       identity?.emailVerified === true
         ? identity.email?.trim().toLowerCase()
         : undefined;
+    const candidateTypes = event.codeTypes ?? [""];
     const availableTypes = new Set<string>();
-    for await (const code of ctx.db
-      .query("codes")
-      .withIndex("by_event_claimedBy", (q) =>
-        q.eq("eventId", event._id).eq("claimedBy", undefined)
-      )) {
-      if (code.reservedFor === undefined || code.reservedFor === viewerEmail) {
-        availableTypes.add(code.codeType ?? "");
-        if (availableTypes.size === 2) break;
-      }
+    for (const typeKey of candidateTypes) {
+      const hit = await ctx.db
+        .query("codes")
+        .withIndex("by_event_codeType_claimedBy", (q) =>
+          q
+            .eq("eventId", event._id)
+            .eq("codeType", typeKey === "" ? undefined : typeKey)
+            .eq("claimedBy", undefined)
+        )
+        .filter((q) => q.eq(q.field("reservedFor"), undefined))
+        .first();
+      if (hit) availableTypes.add(typeKey);
+    }
+    if (viewerEmail) {
+      const reserved = await ctx.db
+        .query("codes")
+        .withIndex("by_event_reservedFor", (q) =>
+          q.eq("eventId", event._id).eq("reservedFor", viewerEmail)
+        )
+        .filter((q) => q.eq(q.field("claimedBy"), undefined))
+        .first();
+      if (reserved) availableTypes.add(reserved.codeType ?? "");
     }
     return {
       _id: event._id,

--- a/convex/events.ts
+++ b/convex/events.ts
@@ -45,28 +45,27 @@ export const getBySlug = query({
       .withIndex("by_slug", (q) => q.eq("slug", args.slug))
       .unique();
     if (!event) return null;
-    // One row is enough to know whether anything is left to dispense —
-    // claimers who already have a code can still retrieve it regardless.
     // A code counts as available for the viewer when it is unclaimed and
     // either unreserved or reserved for the viewer's verified email, matching
-    // what claims.claim would actually hand out.
+    // what claims.claim would actually hand out. Distinct available types are
+    // gathered by streaming the unclaimed pool and stopping as soon as both
+    // possible types are seen (an event has at most two, enforced on upload),
+    // so the read-set stays small for large pools. An unnamed pool is
+    // represented as ""; two pools are always both named.
     const identity = await ctx.auth.getUserIdentity();
     const viewerEmail =
       identity?.emailVerified === true
         ? identity.email?.trim().toLowerCase()
         : undefined;
-    const unclaimed = await ctx.db
+    const availableTypes = new Set<string>();
+    for await (const code of ctx.db
       .query("codes")
       .withIndex("by_event_claimedBy", (q) =>
         q.eq("eventId", event._id).eq("claimedBy", undefined)
-      )
-      .collect();
-    // Distinct types among codes the viewer could actually receive. An
-    // unnamed pool is represented as ""; two pools are always both named.
-    const availableTypes = new Set<string>();
-    for (const code of unclaimed) {
+      )) {
       if (code.reservedFor === undefined || code.reservedFor === viewerEmail) {
         availableTypes.add(code.codeType ?? "");
+        if (availableTypes.size === 2) break;
       }
     }
     return {

--- a/convex/events.ts
+++ b/convex/events.ts
@@ -55,21 +55,19 @@ export const getBySlug = query({
       identity?.emailVerified === true
         ? identity.email?.trim().toLowerCase()
         : undefined;
-    let available = await ctx.db
+    const unclaimed = await ctx.db
       .query("codes")
       .withIndex("by_event_claimedBy", (q) =>
         q.eq("eventId", event._id).eq("claimedBy", undefined)
       )
-      .filter((q) => q.eq(q.field("reservedFor"), undefined))
-      .first();
-    if (!available && viewerEmail) {
-      available = await ctx.db
-        .query("codes")
-        .withIndex("by_event_reservedFor", (q) =>
-          q.eq("eventId", event._id).eq("reservedFor", viewerEmail)
-        )
-        .filter((q) => q.eq(q.field("claimedBy"), undefined))
-        .first();
+      .collect();
+    // Distinct types among codes the viewer could actually receive. An
+    // unnamed pool is represented as ""; two pools are always both named.
+    const availableTypes = new Set<string>();
+    for (const code of unclaimed) {
+      if (code.reservedFor === undefined || code.reservedFor === viewerEmail) {
+        availableTypes.add(code.codeType ?? "");
+      }
     }
     return {
       _id: event._id,
@@ -78,7 +76,8 @@ export const getBySlug = query({
       slug: event.slug,
       description: event.description,
       eventDate: event.eventDate,
-      soldOut: available === null,
+      soldOut: availableTypes.size === 0,
+      codeTypes: [...availableTypes].sort(),
     };
   },
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -55,6 +55,7 @@ export default defineSchema({
   codes: defineTable({
     eventId: v.id("events"),
     code: v.string(),
+    codeType: v.optional(v.string()),
     claimedBy: v.optional(v.string()),
     claimedAt: v.optional(v.number()),
     reservedFor: v.optional(v.string()),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -20,6 +20,9 @@ export default defineSchema({
     description: v.optional(v.string()),
     creditAmount: v.optional(v.string()),
     eventDate: v.optional(v.string()),
+    // Distinct code types in this event's pool ("" = unnamed), maintained by
+    // codes.add/remove so availability checks don't scan the pool.
+    codeTypes: v.optional(v.array(v.string())),
   }).index("by_slug", ["slug"]),
 
   emails: defineTable({
@@ -62,6 +65,7 @@ export default defineSchema({
   })
     .index("by_event", ["eventId"])
     .index("by_event_claimedBy", ["eventId", "claimedBy"])
+    .index("by_event_codeType_claimedBy", ["eventId", "codeType", "claimedBy"])
     .index("by_event_reservedFor", ["eventId", "reservedFor"])
     .index("by_claimedBy", ["claimedBy"]),
 


### PR DESCRIPTION
## Summary
Events can now hold up to two pools of codes, each with an admin-given name, and attendees pick which one to claim when both are available.

- `codes` table gains optional `codeType`. `codes.add({ eventId, codes, codeType? })` enforces the rules: at most two distinct types per event, and when two types exist both must be named (single pool can stay unnamed).
- `events.getBySlug` now returns `codeTypes: string[]` — the distinct types still claimable by the viewer (unclaimed and unreserved-or-reserved-for-them); `soldOut = codeTypes.length === 0`.
- `claims.claim({ slug, codeType? })` filters the unclaimed pool by the requested type and returns the dispensed code's `codeType`; a per-type sold-out error (`All "X" codes ... claimed`) is returned when that pool is empty. A code reserved via waitlist approval still takes priority regardless of choice, and the one-claim-per-email rule is unchanged (claiming either type locks the email out of both).
- Admin manage page: new "Code name" field applies to both pasted and CSV/XLSX-uploaded codes; the code list and CSV export show each code's type.
- Claim page: when two types are available, a required two-button chooser appears before "Dispense my code"; the receipt and My Codes page show the claimed type.

Existing codes without a type behave as one unnamed pool; no migration needed.

Link to Devin session: https://app.devin.ai/sessions/e428b26e0ad44f288b0ab17387bcbca5
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/55" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->