### PR TITLE
Allow naming an existing code block so a second block can be added

### DIFF
--- a/components/ManageEvent.tsx
+++ b/components/ManageEvent.tsx
@@ -82,6 +82,7 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
   const rejectFlagged = useMutation(api.emails.rejectFlagged);
   const addCodes = useMutation(api.codes.add);
   const removeCode = useMutation(api.codes.remove);
+  const renameCodeType = useMutation(api.codes.renameType);
 
   const [emailInput, setEmailInput] = useState("");
   const [codeInput, setCodeInput] = useState("");
@@ -574,6 +575,12 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
             </CardAction>
           </CardHeader>
           <CardContent className="flex flex-col gap-4">
+            <CodeBlocks
+              codes={codes}
+              onRename={(from, to) =>
+                renameCodeType({ eventId: id, from, to })
+              }
+            />
             <form onSubmit={handleAddCodes} className="flex flex-col gap-3">
               <Field>
                 <FieldLabel htmlFor="code-name">Code name</FieldLabel>
@@ -585,8 +592,9 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
                   className="text-sm"
                 />
                 <FieldDescription>
-                  Optional with a single code type — required to tell two code
-                  types apart. Applies to pasted and uploaded codes.
+                  Optional with a single code block — to add a second block,
+                  name both blocks so attendees can tell them apart. Applies
+                  to pasted and uploaded codes.
                 </FieldDescription>
               </Field>
               <Textarea
@@ -639,6 +647,123 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
       </div>
 
       <EventAdminsCard eventId={id} />
+    </div>
+  );
+}
+
+function CodeBlocks({
+  codes,
+  onRename,
+}: {
+  codes: Doc<"codes">[] | undefined;
+  onRename: (from: string | undefined, to: string) => Promise<unknown>;
+}) {
+  const blocks = new Map<string, number>();
+  for (const c of codes ?? []) {
+    const key = c.codeType ?? "";
+    blocks.set(key, (blocks.get(key) ?? 0) + 1);
+  }
+  if (blocks.size === 0) return null;
+  return (
+    <div className="flex flex-col gap-2">
+      {[...blocks.entries()]
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([type, count]) => (
+          <CodeBlockRow
+            key={type || "__unnamed"}
+            type={type}
+            count={count}
+            onRename={onRename}
+          />
+        ))}
+    </div>
+  );
+}
+
+function CodeBlockRow({
+  type,
+  count,
+  onRename,
+}: {
+  type: string;
+  count: number;
+  onRename: (from: string | undefined, to: string) => Promise<unknown>;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [name, setName] = useState(type);
+  const [busy, setBusy] = useState(false);
+
+  async function handleRename(e: React.FormEvent) {
+    e.preventDefault();
+    const to = name.trim();
+    if (!to || to === type) {
+      setEditing(false);
+      setName(type);
+      return;
+    }
+    setBusy(true);
+    try {
+      await onRename(type || undefined, to);
+      toast.success(
+        type ? `Renamed “${type}” to “${to}”` : `Named code block “${to}”`
+      );
+      setEditing(false);
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to rename code block"
+      );
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="flex min-h-9 flex-wrap items-center gap-2 rounded-lg border border-border bg-surface px-3 py-1.5">
+      {editing ? (
+        <form onSubmit={handleRename} className="flex flex-1 items-center gap-2">
+          <Input
+            autoFocus
+            aria-label="Code block name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="e.g. $50 credits"
+            className="h-7 max-w-48 text-sm"
+          />
+          <Button type="submit" size="xs" variant="secondary" disabled={busy}>
+            {busy ? <Spinner data-icon="inline-start" /> : null}
+            Save
+          </Button>
+          <Button
+            type="button"
+            size="xs"
+            variant="ghost"
+            className="text-muted-foreground"
+            onClick={() => {
+              setEditing(false);
+              setName(type);
+            }}
+          >
+            Cancel
+          </Button>
+        </form>
+      ) : (
+        <>
+          <Badge variant={type ? "secondary" : "outline"}>
+            {type || "Unnamed"}
+          </Badge>
+          <span className="text-xs text-muted-dim tabular-nums">
+            {count} code{count === 1 ? "" : "s"}
+          </span>
+          <Button
+            size="xs"
+            variant="ghost"
+            className="ml-auto text-muted-foreground"
+            onClick={() => setEditing(true)}
+          >
+            {type ? "Rename" : "Name this block"}
+          </Button>
+        </>
+      )}
     </div>
   );
 }

--- a/convex/codes.ts
+++ b/convex/codes.ts
@@ -35,7 +35,7 @@ export const add = mutation({
     }
     if (resultingTypes.size === 2 && resultingTypes.has("")) {
       throw new Error(
-        "Both code types need a name so attendees can tell them apart. Name the unnamed codes or use the same name."
+        "Both code blocks need a name so attendees can tell them apart. Name the existing block (next to its badge above the form), then add the new block."
       );
     }
     const existingSet = new Set(existing.map((c) => c.code));
@@ -59,6 +59,36 @@ export const add = mutation({
       });
     }
     return { added, skipped };
+  },
+});
+
+export const renameType = mutation({
+  args: {
+    eventId: v.id("events"),
+    from: v.optional(v.string()),
+    to: v.string(),
+  },
+  handler: async (ctx, args) => {
+    await requireEventAdmin(ctx, args.eventId);
+    const to = args.to.trim();
+    if (!to) {
+      throw new Error("Enter a name for the code block.");
+    }
+    const from = args.from?.trim() || undefined;
+    const targets = await ctx.db
+      .query("codes")
+      .withIndex("by_event", (q) => q.eq("eventId", args.eventId))
+      .filter((q) => q.eq(q.field("codeType"), from))
+      .collect();
+    for (const code of targets) {
+      await ctx.db.patch(code._id, { codeType: to });
+    }
+    const event = await ctx.db.get(args.eventId);
+    const types = new Set(event?.codeTypes ?? []);
+    types.delete(from ?? "");
+    if (targets.length > 0) types.add(to);
+    await ctx.db.patch(args.eventId, { codeTypes: [...types].sort() });
+    return { renamed: targets.length };
   },
 });
 


### PR DESCRIPTION
## Summary
Follow-up to #55. Adding a second block to an event whose existing codes were uploaded without a name was a dead end: `codes.add` rejects two blocks when one is unnamed, and there was no way to name codes after upload. So in practice events couldn't go from the default single unnamed block to two blocks.

- New `codes.renameType({ eventId, from?, to })` mutation: renames every code of one type (`from: undefined` = the unnamed block) and syncs `events.codeTypes`. Renaming one named block to the other's name merges them.
- Admin Codes card now lists each code block (badge + count) with an inline rename — "Name this block" for the unnamed default — so the flow is: name the existing block, then add the second named block.
- The `codes.add` validation error now points to that rename control instead of a dead end.

Link to Devin session: https://app.devin.ai/sessions/e428b26e0ad44f288b0ab17387bcbca5
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/56" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->