### PR TITLE
Add explicit second-code-block flow to the Codes card

### DIFF
--- a/components/ManageEvent.tsx
+++ b/components/ManageEvent.tsx
@@ -11,6 +11,7 @@ import {
   Check,
   Download,
   Inbox,
+  Plus,
   QrCode,
   ShieldCheck,
   Ticket,
@@ -86,9 +87,33 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
 
   const [emailInput, setEmailInput] = useState("");
   const [codeInput, setCodeInput] = useState("");
-  const [codeName, setCodeName] = useState("");
+  const [blockTarget, setBlockTarget] = useState<string | null>(null);
+  const [newBlockName, setNewBlockName] = useState("");
+  const [firstBlockName, setFirstBlockName] = useState("");
   const [emailBusy, setEmailBusy] = useState(false);
   const [codeBusy, setCodeBusy] = useState(false);
+
+  // Existing code blocks ("" = unnamed) drive the add form: codes go into a
+  // selected existing block, or into a new named block when only one exists.
+  const blockTypes = [...new Set((codes ?? []).map((c) => c.codeType ?? ""))]
+    .sort();
+  const targetOptions = [
+    ...blockTypes,
+    ...(blockTypes.length < 2 ? ["__new"] : []),
+  ];
+  const effectiveTarget =
+    blockTarget !== null && targetOptions.includes(blockTarget)
+      ? blockTarget
+      : (blockTypes[0] ?? "__new");
+  const isNewBlock = effectiveTarget === "__new";
+  const hasBlocks = blockTypes.length > 0;
+  // A second block requires both blocks to be named, so creating one next to
+  // an unnamed block also asks for the existing block's name.
+  const needsFirstBlockName =
+    isNewBlock && hasBlocks && blockTypes.includes("");
+  const codeFormReady =
+    (!isNewBlock || !hasBlocks || newBlockName.trim().length > 0) &&
+    (!needsFirstBlockName || firstBlockName.trim().length > 0);
 
   // Computed before the early returns so the count-up hook can run
   // unconditionally; 0 while the codes query is still in flight.
@@ -183,26 +208,71 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
     }
   }
 
+  // Resolves which block incoming codes belong to, naming the existing
+  // unnamed block first when a second block is being created next to it.
+  async function resolveTargetType(): Promise<string | undefined> {
+    if (!isNewBlock) return effectiveTarget || undefined;
+    if (needsFirstBlockName) {
+      await renameCodeType({ eventId: id, to: firstBlockName.trim() });
+    }
+    return newBlockName.trim() || undefined;
+  }
+
+  function resetBlockForm(codeType: string | undefined) {
+    setBlockTarget(codeType ?? "");
+    setNewBlockName("");
+    setFirstBlockName("");
+  }
+
   async function handleAddCodes(e: React.FormEvent) {
     e.preventDefault();
     const list = codeInput.split(/[\n,;\s]+/).filter(Boolean);
-    if (list.length === 0) return;
+    if (list.length === 0 || !codeFormReady) return;
     setCodeBusy(true);
     try {
+      const codeType = await resolveTargetType();
       const { added, skipped } = await addCodes({
         eventId: id,
         codes: list,
-        codeType: codeName.trim() || undefined,
+        codeType,
       });
       toast.success(`Added ${added} codes`, {
         description: skipped ? `Skipped ${skipped} (duplicates).` : undefined,
       });
       setCodeInput("");
+      resetBlockForm(codeType);
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Failed to add codes");
     } finally {
       setCodeBusy(false);
     }
+  }
+
+  async function handleCodeFile(file: File) {
+    if (!codeFormReady) {
+      toast.error(
+        needsFirstBlockName && !firstBlockName.trim()
+          ? "Name the existing block before uploading a second block."
+          : "Name the new block before uploading its codes."
+      );
+      return;
+    }
+    let codeType: string | undefined;
+    try {
+      codeType = await resolveTargetType();
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to prepare code block"
+      );
+      return;
+    }
+    await importFile(
+      file,
+      "codes",
+      (items) => addCodes({ eventId: id, codes: items, codeType }),
+      setCodeBusy
+    );
+    resetBlockForm(codeType);
   }
 
   function exportEmails() {
@@ -571,7 +641,7 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
                   Export
                 </Button>
               ) : null}
-              <UploadButton busy={codeBusy} onFile={(f) => importFile(f, "codes", (items) => addCodes({ eventId: id, codes: items, codeType: codeName.trim() || undefined }), setCodeBusy)} />
+              <UploadButton busy={codeBusy} onFile={handleCodeFile} />
             </CardAction>
           </CardHeader>
           <CardContent className="flex flex-col gap-4">
@@ -582,21 +652,79 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
               }
             />
             <form onSubmit={handleAddCodes} className="flex flex-col gap-3">
-              <Field>
-                <FieldLabel htmlFor="code-name">Code name</FieldLabel>
-                <Input
-                  id="code-name"
-                  value={codeName}
-                  onChange={(e) => setCodeName(e.target.value)}
-                  placeholder="e.g. $50 credits"
-                  className="text-sm"
-                />
-                <FieldDescription>
-                  Optional with a single code block — to add a second block,
-                  name both blocks so attendees can tell them apart. Applies
-                  to pasted and uploaded codes.
-                </FieldDescription>
-              </Field>
+              {hasBlocks ? (
+                <Field>
+                  <FieldLabel>Add codes to</FieldLabel>
+                  <div className="flex flex-wrap gap-2">
+                    {blockTypes.map((t) => (
+                      <Button
+                        key={t || "__unnamed"}
+                        type="button"
+                        size="sm"
+                        variant={
+                          effectiveTarget === t ? "secondary" : "outline"
+                        }
+                        onClick={() => setBlockTarget(t)}
+                      >
+                        {t || "Unnamed block"}
+                      </Button>
+                    ))}
+                    {blockTypes.length < 2 ? (
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant={isNewBlock ? "secondary" : "outline"}
+                        onClick={() => setBlockTarget("__new")}
+                      >
+                        <Plus data-icon="inline-start" />
+                        Second code block
+                      </Button>
+                    ) : null}
+                  </div>
+                  <FieldDescription>
+                    {blockTypes.length < 2
+                      ? "Events can have up to two code blocks — attendees pick one by name when there are two."
+                      : "This event has both code blocks — pasted and uploaded codes go into the selected one."}
+                  </FieldDescription>
+                </Field>
+              ) : null}
+              {!hasBlocks || isNewBlock ? (
+                <Field>
+                  <FieldLabel htmlFor="new-block-name">
+                    {hasBlocks ? "Second block name" : "Code name"}
+                  </FieldLabel>
+                  <Input
+                    id="new-block-name"
+                    value={newBlockName}
+                    onChange={(e) => setNewBlockName(e.target.value)}
+                    placeholder="e.g. $50 credits"
+                    className="text-sm"
+                  />
+                  <FieldDescription>
+                    {hasBlocks
+                      ? "Required — attendees choose between the two blocks by name."
+                      : "Optional with a single code block. Applies to pasted and uploaded codes."}
+                  </FieldDescription>
+                </Field>
+              ) : null}
+              {needsFirstBlockName ? (
+                <Field>
+                  <FieldLabel htmlFor="first-block-name">
+                    Name the existing block
+                  </FieldLabel>
+                  <Input
+                    id="first-block-name"
+                    value={firstBlockName}
+                    onChange={(e) => setFirstBlockName(e.target.value)}
+                    placeholder="e.g. $25 credits"
+                    className="text-sm"
+                  />
+                  <FieldDescription>
+                    Your current codes are unnamed — give them a name so
+                    attendees can tell the two blocks apart.
+                  </FieldDescription>
+                </Field>
+              ) : null}
               <Textarea
                 aria-label="Credit codes to add"
                 value={codeInput}
@@ -609,7 +737,7 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
                 type="submit"
                 variant="secondary"
                 className="self-start"
-                disabled={codeBusy || !codeInput.trim()}
+                disabled={codeBusy || !codeInput.trim() || !codeFormReady}
                 aria-busy={codeBusy}
               >
                 {codeBusy ? (

--- a/components/ManageEvent.tsx
+++ b/components/ManageEvent.tsx
@@ -66,6 +66,12 @@ import {
 import { Progress } from "@/components/ui/progress";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
 
 const UPLOAD_CHUNK_SIZE = 500;
@@ -218,6 +224,25 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
     return newBlockName.trim() || undefined;
   }
 
+  function codeRows(type?: string) {
+    return codes
+      ?.filter((c) => type === undefined || (c.codeType ?? "") === type)
+      .map((c) => ({
+        key: c._id,
+        label: c.code,
+        tag: type === undefined ? (c.codeType ?? undefined) : undefined,
+        claimedBy: c.claimedBy ?? undefined,
+        onRemove: c.claimedBy
+          ? undefined
+          : () =>
+              removeCode({ id: c._id }).catch((err) =>
+                toast.error(
+                  err instanceof Error ? err.message : "Failed to remove code"
+                )
+              ),
+      }));
+  }
+
   function resetBlockForm(codeType: string | undefined) {
     setBlockTarget(codeType ?? "");
     setNewBlockName("");
@@ -257,22 +282,24 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
       );
       return;
     }
+    // The rename of an unnamed existing block is deferred until the file has
+    // actually produced codes to import, so an empty or unreadable upload
+    // leaves the current block untouched.
     let codeType: string | undefined;
-    try {
-      codeType = await resolveTargetType();
-    } catch (err) {
-      toast.error(
-        err instanceof Error ? err.message : "Failed to prepare code block"
-      );
-      return;
-    }
+    let resolved = false;
     await importFile(
       file,
       "codes",
-      (items) => addCodes({ eventId: id, codes: items, codeType }),
+      async (items) => {
+        if (!resolved) {
+          codeType = await resolveTargetType();
+          resolved = true;
+        }
+        return addCodes({ eventId: id, codes: items, codeType });
+      },
       setCodeBusy
     );
-    resetBlockForm(codeType);
+    if (resolved) resetBlockForm(codeType);
   }
 
   function exportEmails() {
@@ -750,26 +777,28 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
                 )}
               </Button>
             </form>
-            <RowList
-              mono
-              items={codes?.map((c) => ({
-                key: c._id,
-                label: c.code,
-                tag: c.codeType ?? undefined,
-                claimedBy: c.claimedBy ?? undefined,
-                onRemove: c.claimedBy
-                  ? undefined
-                  : () =>
-                      removeCode({ id: c._id }).catch((err) =>
-                        toast.error(
-                          err instanceof Error
-                            ? err.message
-                            : "Failed to remove code"
-                        )
-                      ),
-              }))}
-              emptyText="No codes yet."
-            />
+            {blockTypes.length > 1 ? (
+              <Tabs defaultValue={blockTypes[0]}>
+                <TabsList>
+                  {blockTypes.map((t) => (
+                    <TabsTrigger key={t || "__unnamed"} value={t}>
+                      {t || "Unnamed"}
+                    </TabsTrigger>
+                  ))}
+                </TabsList>
+                {blockTypes.map((t) => (
+                  <TabsContent key={t || "__unnamed"} value={t}>
+                    <RowList
+                      mono
+                      items={codeRows(t)}
+                      emptyText="No codes in this block yet."
+                    />
+                  </TabsContent>
+                ))}
+              </Tabs>
+            ) : (
+              <RowList mono items={codeRows()} emptyText="No codes yet." />
+            )}
           </CardContent>
         </Card>
       </div>

--- a/components/ManageEvent.tsx
+++ b/components/ManageEvent.tsx
@@ -103,15 +103,20 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
   // selected existing block, or into a new named block when only one exists.
   const blockTypes = [...new Set((codes ?? []).map((c) => c.codeType ?? ""))]
     .sort();
+  // Target values are namespaced ("existing:<type>" / "new") so a block
+  // whose name matches a sentinel can't be confused with new-block creation.
   const targetOptions = [
-    ...blockTypes,
-    ...(blockTypes.length < 2 ? ["__new"] : []),
+    ...blockTypes.map((t) => `existing:${t}`),
+    ...(blockTypes.length < 2 ? ["new"] : []),
   ];
   const effectiveTarget =
     blockTarget !== null && targetOptions.includes(blockTarget)
       ? blockTarget
-      : (blockTypes[0] ?? "__new");
-  const isNewBlock = effectiveTarget === "__new";
+      : (targetOptions[0] ?? "new");
+  const isNewBlock = effectiveTarget === "new";
+  const selectedType = isNewBlock
+    ? null
+    : effectiveTarget.slice("existing:".length);
   const hasBlocks = blockTypes.length > 0;
   // A second block requires both blocks to be named, so creating one next to
   // an unnamed block also asks for the existing block's name.
@@ -217,7 +222,7 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
   // Resolves which block incoming codes belong to, naming the existing
   // unnamed block first when a second block is being created next to it.
   async function resolveTargetType(): Promise<string | undefined> {
-    if (!isNewBlock) return effectiveTarget || undefined;
+    if (!isNewBlock) return selectedType || undefined;
     if (needsFirstBlockName) {
       await renameCodeType({ eventId: id, to: firstBlockName.trim() });
     }
@@ -244,7 +249,7 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
   }
 
   function resetBlockForm(codeType: string | undefined) {
-    setBlockTarget(codeType ?? "");
+    setBlockTarget(`existing:${codeType ?? ""}`);
     setNewBlockName("");
     setFirstBlockName("");
   }
@@ -689,9 +694,11 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
                         type="button"
                         size="sm"
                         variant={
-                          effectiveTarget === t ? "secondary" : "outline"
+                          !isNewBlock && selectedType === t
+                            ? "secondary"
+                            : "outline"
                         }
-                        onClick={() => setBlockTarget(t)}
+                        onClick={() => setBlockTarget(`existing:${t}`)}
                       >
                         {t || "Unnamed block"}
                       </Button>
@@ -701,7 +708,7 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
                         type="button"
                         size="sm"
                         variant={isNewBlock ? "secondary" : "outline"}
-                        onClick={() => setBlockTarget("__new")}
+                        onClick={() => setBlockTarget("new")}
                       >
                         <Plus data-icon="inline-start" />
                         Second code block

--- a/components/ManageEvent.tsx
+++ b/components/ManageEvent.tsx
@@ -785,7 +785,9 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
               </Button>
             </form>
             {blockTypes.length > 1 ? (
-              <Tabs defaultValue={blockTypes[0]}>
+              // Keyed on the block names so a rename remounts the tabs and
+              // re-applies defaultValue instead of leaving a stale selection.
+              <Tabs key={blockTypes.join("\u0000")} defaultValue={blockTypes[0]}>
                 <TabsList>
                   {blockTypes.map((t) => (
                     <TabsTrigger key={t || "__unnamed"} value={t}>

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -1,0 +1,82 @@
+"use client"
+
+import { Tabs as TabsPrimitive } from "@base-ui/react/tabs"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+function Tabs({
+  className,
+  orientation = "horizontal",
+  ...props
+}: TabsPrimitive.Root.Props) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      data-orientation={orientation}
+      className={cn(
+        "group/tabs flex gap-2 data-horizontal:flex-col",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const tabsListVariants = cva(
+  "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-horizontal/tabs:h-8 group-data-vertical/tabs:h-fit group-data-vertical/tabs:flex-col data-[variant=line]:rounded-none",
+  {
+    variants: {
+      variant: {
+        default: "bg-muted",
+        line: "gap-1 bg-transparent",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function TabsList({
+  className,
+  variant = "default",
+  ...props
+}: TabsPrimitive.List.Props & VariantProps<typeof tabsListVariants>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      data-variant={variant}
+      className={cn(tabsListVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function TabsTrigger({ className, ...props }: TabsPrimitive.Tab.Props) {
+  return (
+    <TabsPrimitive.Tab
+      data-slot="tabs-trigger"
+      className={cn(
+        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-1.5 py-0.5 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-vertical/tabs:w-full group-data-vertical/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 has-data-[icon=inline-end]:pr-1 has-data-[icon=inline-start]:pl-1 aria-disabled:pointer-events-none aria-disabled:opacity-50 dark:text-muted-foreground dark:hover:text-foreground group-data-[variant=default]/tabs-list:data-active:shadow-sm group-data-[variant=line]/tabs-list:data-active:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent",
+        "data-active:bg-background data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 dark:data-active:text-foreground",
+        "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-horizontal/tabs:after:inset-x-0 group-data-horizontal/tabs:after:bottom-[-5px] group-data-horizontal/tabs:after:h-0.5 group-data-vertical/tabs:after:inset-y-0 group-data-vertical/tabs:after:-right-1 group-data-vertical/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsContent({ className, ...props }: TabsPrimitive.Panel.Props) {
+  return (
+    <TabsPrimitive.Panel
+      data-slot="tabs-content"
+      className={cn("flex-1 text-sm outline-none", className)}
+      {...props}
+    />
+  )
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants }


### PR DESCRIPTION
## Summary
Follow-up to #56: adding a second block was possible but not discoverable — you had to know to retype a different name into the single "Code name" field. The Codes card is now block-aware:

- With existing codes, an "Add codes to" selector shows a button per block plus a "+ Second code block" option (hidden once two blocks exist). Pasted and uploaded codes go into the selected block.
- Choosing "Second code block" reveals a required "Second block name" field — and, if the existing block is unnamed, a "Name the existing block" field too. Submitting calls `codes.renameType` for the existing block first, then `codes.add` with the new name, so the two-named-blocks invariant is satisfied in one step. For uploads the rename is deferred until the file actually yields codes, so an empty/invalid file leaves the existing block untouched.
- With no codes yet, the form is unchanged (optional "Code name").
- The submit button and the CSV/XLSX upload both enforce the same readiness checks (`codeFormReady`).
- The codes list is now tabbed per block: with two blocks, each block gets its own tab showing only its codes (added `components/ui/tabs.tsx` via shadcn); with 0–1 blocks the plain list is unchanged.
- Block-target values are namespaced (`existing:<type>` / `new`) so a block name can't collide with the new-block sentinel.

Link to Devin session: https://app.devin.ai/sessions/e428b26e0ad44f288b0ab17387bcbca5
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/57" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->