### PR TITLE
Add optional post-claim redemption instructions

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -216,6 +216,7 @@ function NewEventDialog() {
   const [description, setDescription] = useState("");
   const [eventDate, setEventDate] = useState("");
   const [creditAmount, setCreditAmount] = useState("");
+  const [claimInstructions, setClaimInstructions] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
@@ -230,6 +231,7 @@ function NewEventDialog() {
         description: description || undefined,
         eventDate: eventDate || undefined,
         creditAmount: creditAmount || undefined,
+        claimInstructions: claimInstructions || undefined,
       });
       toast.success(`Event "${name}" created`);
       router.push(`/admin/events/${id}`);
@@ -310,6 +312,22 @@ function NewEventDialog() {
                 onChange={(e) => setCreditAmount(e.target.value)}
                 placeholder="$100"
               />
+            </Field>
+            <Field>
+              <FieldLabel htmlFor="event-instructions">
+                Redemption instructions
+              </FieldLabel>
+              <Textarea
+                id="event-instructions"
+                value={claimInstructions}
+                onChange={(e) => setClaimInstructions(e.target.value)}
+                placeholder="How to redeem the code after claiming"
+                rows={4}
+                className="resize-y"
+              />
+              <FieldDescription>
+                Optional — shown to attendees after they claim a code.
+              </FieldDescription>
             </Field>
           </FieldGroup>
           {error ? (

--- a/components/ClaimPage.tsx
+++ b/components/ClaimPage.tsx
@@ -4,6 +4,7 @@ import { useState, useSyncExternalStore } from "react";
 import Link from "next/link";
 import {
   ArrowUpRight,
+  BookOpen,
   CalendarDays,
   Check,
   Copy,
@@ -36,6 +37,14 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 import {
   Empty,
   EmptyDescription,
@@ -149,6 +158,7 @@ export default function ClaimPage({ slug }: { slug: string }) {
           ) : result?.ok ? (
             <Receipt
               eventName={event.name}
+              instructions={event.claimInstructions}
               creditAmount={result.creditAmount}
               code={result.code}
               codeType={result.codeType}
@@ -395,6 +405,7 @@ function QrPanel({
 
 function Receipt({
   eventName,
+  instructions,
   creditAmount,
   code,
   codeType,
@@ -403,6 +414,7 @@ function Receipt({
   onCopy,
 }: {
   eventName: string;
+  instructions?: string;
   creditAmount?: string;
   code: string;
   codeType?: string;
@@ -472,6 +484,27 @@ function Receipt({
               </>
             )}
           </Button>
+          {instructions ? (
+            <Dialog>
+              <DialogTrigger render={<Button variant="outline" size="lg" />}>
+                <BookOpen data-icon="inline-start" />
+                How to redeem
+              </DialogTrigger>
+              <DialogContent className="sm:max-w-md">
+                <DialogHeader>
+                  <DialogTitle className="font-heading tracking-tight">
+                    How to redeem your code
+                  </DialogTitle>
+                  <DialogDescription className="sr-only">
+                    Redemption instructions for {eventName}
+                  </DialogDescription>
+                </DialogHeader>
+                <p className="text-sm leading-relaxed whitespace-pre-wrap">
+                  {instructions}
+                </p>
+              </DialogContent>
+            </Dialog>
+          ) : null}
           <Button
             variant="ghost"
             size="sm"

--- a/components/ManageEvent.tsx
+++ b/components/ManageEvent.tsx
@@ -616,7 +616,7 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
               <UploadButton busy={emailBusy} onFile={(f) => importFile(f, "emails", (items) => addEmails({ eventId: id, emails: items }), setEmailBusy)} />
             </CardAction>
           </CardHeader>
-          <CardContent className="flex flex-col gap-4">
+          <CardContent className="flex flex-1 flex-col gap-4">
             <form onSubmit={handleAddEmails} className="flex flex-col gap-3">
               <Textarea
                 aria-label="Email addresses to add"
@@ -644,6 +644,7 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
               </Button>
             </form>
             <RowList
+              fill
               items={emails?.map((e) => ({
                 key: e._id,
                 label: e.email,
@@ -1073,6 +1074,7 @@ function RowList({
   items,
   emptyText,
   mono,
+  fill,
 }: {
   items?: {
     key: string;
@@ -1083,6 +1085,9 @@ function RowList({
   }[];
   emptyText: string;
   mono?: boolean;
+  // Grow to take the remaining height of a flex parent (scrolling inside)
+  // instead of capping at a fixed max height.
+  fill?: boolean;
 }) {
   if (!items) {
     return (
@@ -1100,7 +1105,12 @@ function RowList({
     );
   }
   return (
-    <ul className="max-h-72 divide-y divide-border overflow-y-auto border-y border-border">
+    <ul
+      className={cn(
+        "divide-y divide-border overflow-y-auto border-y border-border",
+        fill ? "h-0 min-h-56 flex-1" : "max-h-72"
+      )}
+    >
       {items.map((item) => (
         <li
           key={item.key}

--- a/components/ManageEvent.tsx
+++ b/components/ManageEvent.tsx
@@ -1162,6 +1162,9 @@ function EventDetailsForm({
   const [description, setDescription] = useState(event.description ?? "");
   const [eventDate, setEventDate] = useState(event.eventDate ?? "");
   const [creditAmount, setCreditAmount] = useState(event.creditAmount ?? "");
+  const [claimInstructions, setClaimInstructions] = useState(
+    event.claimInstructions ?? ""
+  );
   const [saving, setSaving] = useState(false);
 
   async function handleSave(e: React.FormEvent) {
@@ -1175,6 +1178,7 @@ function EventDetailsForm({
         description: description || undefined,
         eventDate: eventDate || undefined,
         creditAmount: creditAmount || undefined,
+        claimInstructions: claimInstructions || undefined,
       });
       setSlug(savedSlug);
       toast.success("Event saved");
@@ -1252,6 +1256,22 @@ function EventDetailsForm({
                 placeholder="$100"
               />
               <FieldDescription>Shown on the claim page.</FieldDescription>
+            </Field>
+            <Field className="sm:col-span-2">
+              <FieldLabel htmlFor="detail-instructions">
+                Redemption instructions
+              </FieldLabel>
+              <Textarea
+                id="detail-instructions"
+                value={claimInstructions}
+                onChange={(e) => setClaimInstructions(e.target.value)}
+                rows={4}
+                className="resize-y"
+              />
+              <FieldDescription>
+                Optional — when set, attendees see a &ldquo;How to
+                redeem&rdquo; button after claiming their code.
+              </FieldDescription>
             </Field>
           </FieldGroup>
           <div className="flex items-center justify-between gap-4">

--- a/convex/events.ts
+++ b/convex/events.ts
@@ -89,6 +89,7 @@ export const getBySlug = query({
       slug: event.slug,
       description: event.description,
       eventDate: event.eventDate,
+      claimInstructions: event.claimInstructions,
       soldOut: availableTypes.size === 0,
       codeTypes: [...availableTypes].sort(),
     };
@@ -109,6 +110,7 @@ export const get = query({
       description: event.description,
       creditAmount: event.creditAmount,
       eventDate: event.eventDate,
+      claimInstructions: event.claimInstructions,
     };
   },
 });
@@ -152,6 +154,7 @@ export const create = mutation({
     description: v.optional(v.string()),
     creditAmount: v.optional(v.string()),
     eventDate: v.optional(v.string()),
+    claimInstructions: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     await requireAdmin(ctx);
@@ -172,6 +175,7 @@ export const create = mutation({
       description: args.description?.trim() || undefined,
       creditAmount: args.creditAmount?.trim() || undefined,
       eventDate: normalizeEventDate(args.eventDate),
+      claimInstructions: args.claimInstructions?.trim() || undefined,
     });
     return { id, slug };
   },
@@ -185,6 +189,7 @@ export const update = mutation({
     description: v.optional(v.string()),
     creditAmount: v.optional(v.string()),
     eventDate: v.optional(v.string()),
+    claimInstructions: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     await requireEventAdmin(ctx, args.id);
@@ -203,6 +208,7 @@ export const update = mutation({
       description: args.description?.trim() || undefined,
       creditAmount: args.creditAmount?.trim() || undefined,
       eventDate: normalizeEventDate(args.eventDate),
+      claimInstructions: args.claimInstructions?.trim() || undefined,
     });
     return { slug };
   },

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -20,6 +20,8 @@ export default defineSchema({
     description: v.optional(v.string()),
     creditAmount: v.optional(v.string()),
     eventDate: v.optional(v.string()),
+    // Optional post-claim redemption instructions shown to attendees.
+    claimInstructions: v.optional(v.string()),
     // Distinct code types in this event's pool ("" = unnamed), maintained by
     // codes.add/remove so availability checks don't scan the pool.
     codeTypes: v.optional(v.array(v.string())),


### PR DESCRIPTION
## Summary
Admins can now optionally write "Redemption instructions" for an event (new `events.claimInstructions` field, settable in the New event dialog and the Event details card). When set, the claim-page receipt shows a "How to redeem" button after the user claims (or re-views) their code, opening an overlay with the instructions. When unset, the button doesn't render — no change for existing events.

- `events.create` / `events.update` accept optional `claimInstructions` (trimmed, empty → undefined)
- `events.getBySlug` / `events.get` return it; `Receipt` gets a new optional `instructions` prop and renders the Dialog only when present (instructions text preserved with `whitespace-pre-wrap`)

Link to Devin session: https://app.devin.ai/sessions/e428b26e0ad44f288b0ab17387bcbca5
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/58" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->