### PR TITLE
Font stack (rev2): Lora

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -53,9 +53,8 @@
   --sidebar-accent-foreground: #2b2723;
   --sidebar-border: #e7e1d3;
   --sidebar-ring: #7a7266;
-  /* Heading face slot: kept on the body sans for now — font-variant branches
-     swap this to a distinct editorial face. */
-  --font-heading-family: var(--font-geist-sans);
+  /* Heading face slot: Lora, a distinct editorial serif for headings. */
+  --font-heading-family: var(--font-lora);
 }
 
 @theme inline {
@@ -67,8 +66,8 @@
   --color-foreground: var(--foreground);
   --color-muted: var(--muted);
   --color-muted-dim: var(--muted-dim);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: var(--font-work-sans);
+  --font-mono: var(--font-fira-code);
   /* Headings draw from a dedicated slot so a display face can be swapped in
      without touching component markup. */
   --font-heading: var(--font-heading-family);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Lora, Work_Sans, Fira_Code } from "next/font/google";
 import { ClerkProvider } from "@clerk/nextjs";
 import ConvexClientProvider from "@/components/ConvexClientProvider";
 import { ThemeProvider } from "@/components/ThemeProvider";
@@ -7,13 +7,18 @@ import { Toaster } from "@/components/ui/sonner";
 import { getAppName } from "@/lib/app-name";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const lora = Lora({
+  variable: "--font-lora",
   subsets: ["latin"],
 });
 
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
+const workSans = Work_Sans({
+  variable: "--font-work-sans",
+  subsets: ["latin"],
+});
+
+const firaCode = Fira_Code({
+  variable: "--font-fira-code",
   subsets: ["latin"],
 });
 
@@ -29,7 +34,7 @@ const clerkAppearance: React.ComponentProps<typeof ClerkProvider>["appearance"] 
     colorPrimary: "#c2410c",
     colorPrimaryForeground: "#ffffff",
     borderRadius: "1rem",
-    fontFamily: "var(--font-geist-sans), system-ui, sans-serif",
+    fontFamily: "var(--font-work-sans), system-ui, sans-serif",
   },
   options: {
     unsafe_disableDevelopmentModeWarnings: true,
@@ -49,7 +54,7 @@ export default function RootLayout({
     <ClerkProvider appearance={clerkAppearance}>
       <html
         lang="en"
-        className={`${geistSans.variable} ${geistMono.variable} h-full overscroll-none antialiased`}
+        className={`${lora.variable} ${workSans.variable} ${firaCode.variable} h-full overscroll-none antialiased`}
         suppressHydrationWarning
       >
         <body className="flex min-h-full flex-col overscroll-none">


### PR DESCRIPTION
## Summary
Font-stack variant of the Warm Editorial revision: swaps Geist/Geist Mono for Lora (headings via `--font-heading`), Work Sans (body), and Fira Code (mono/eyebrow).

- `app/layout.tsx`: loads `Lora`, `Work_Sans`, `Fira_Code` via next/font/google as `--font-lora` / `--font-work-sans` / `--font-fira-code` (latin subset, variable weights); Clerk `appearance.variables.fontFamily` follows Work Sans.
- `app/globals.css`: `--font-sans` → Work Sans, `--font-mono` → Fira Code, `--font-heading-family` → Lora.

Typography-only; no color, layout, or behavior changes.

Link to Devin session: https://app.devin.ai/sessions/dbe6e90ac4c04373ad0899f3797e9076
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/63" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->