### PR TITLE
Font stack (rev2): Newsreader

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -53,9 +53,8 @@
   --sidebar-accent-foreground: #2b2723;
   --sidebar-border: #e7e1d3;
   --sidebar-ring: #7a7266;
-  /* Heading face slot: kept on the body sans for now — font-variant branches
-     swap this to a distinct editorial face. */
-  --font-heading-family: var(--font-geist-sans);
+  /* Heading face slot: Newsreader, the editorial serif for this variant. */
+  --font-heading-family: var(--font-newsreader);
 }
 
 @theme inline {
@@ -67,8 +66,8 @@
   --color-foreground: var(--foreground);
   --color-muted: var(--muted);
   --color-muted-dim: var(--muted-dim);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: var(--font-source-sans);
+  --font-mono: var(--font-plex-mono);
   /* Headings draw from a dedicated slot so a display face can be swapped in
      without touching component markup. */
   --font-heading: var(--font-heading-family);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Newsreader, Source_Sans_3, IBM_Plex_Mono } from "next/font/google";
 import { ClerkProvider } from "@clerk/nextjs";
 import ConvexClientProvider from "@/components/ConvexClientProvider";
 import { ThemeProvider } from "@/components/ThemeProvider";
@@ -7,14 +7,21 @@ import { Toaster } from "@/components/ui/sonner";
 import { getAppName } from "@/lib/app-name";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const newsreader = Newsreader({
+  variable: "--font-newsreader",
+  subsets: ["latin"],
+  weight: ["500", "600", "700"],
+});
+
+const sourceSans = Source_Sans_3({
+  variable: "--font-source-sans",
   subsets: ["latin"],
 });
 
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
+const plexMono = IBM_Plex_Mono({
+  variable: "--font-plex-mono",
   subsets: ["latin"],
+  weight: ["400", "500"],
 });
 
 export const metadata: Metadata = {
@@ -29,7 +36,7 @@ const clerkAppearance: React.ComponentProps<typeof ClerkProvider>["appearance"] 
     colorPrimary: "#c2410c",
     colorPrimaryForeground: "#ffffff",
     borderRadius: "1rem",
-    fontFamily: "var(--font-geist-sans), system-ui, sans-serif",
+    fontFamily: "var(--font-source-sans), system-ui, sans-serif",
   },
   options: {
     unsafe_disableDevelopmentModeWarnings: true,
@@ -49,7 +56,7 @@ export default function RootLayout({
     <ClerkProvider appearance={clerkAppearance}>
       <html
         lang="en"
-        className={`${geistSans.variable} ${geistMono.variable} h-full overscroll-none antialiased`}
+        className={`${newsreader.variable} ${sourceSans.variable} ${plexMono.variable} h-full overscroll-none antialiased`}
         suppressHydrationWarning
       >
         <body className="flex min-h-full flex-col overscroll-none">


### PR DESCRIPTION
## Summary
Font-stack variant of the warm-editorial design revision: Newsreader (headings via `--font-heading`), Source Sans 3 (body), IBM Plex Mono (mono/eyebrow).

- `app/layout.tsx`: replace Geist/Geist Mono with `Newsreader` (weights 500/600/700), `Source_Sans_3`, `IBM_Plex_Mono` (400/500) via next/font/google; Clerk `fontFamily` now `var(--font-source-sans)`.
- `app/globals.css`: `--font-heading-family: var(--font-newsreader)`; `--font-sans`/`--font-mono` remapped to the new variables.

Typography-only change on top of `devin/design-rev-2-warm-editorial`; no behavior or backend changes.

Link to Devin session: https://app.devin.ai/sessions/6445055918334685b8aaecad8cd7325d
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/64" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->