### PR TITLE
Font stack (rev2): Fraunces

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -53,9 +53,8 @@
   --sidebar-accent-foreground: #2b2723;
   --sidebar-border: #e7e1d3;
   --sidebar-ring: #7a7266;
-  /* Heading face slot: kept on the body sans for now — font-variant branches
-     swap this to a distinct editorial face. */
-  --font-heading-family: var(--font-geist-sans);
+  /* Heading face slot: Fraunces, a warm editorial serif with optical sizing. */
+  --font-heading-family: var(--font-fraunces);
 }
 
 @theme inline {
@@ -67,7 +66,7 @@
   --color-foreground: var(--foreground);
   --color-muted: var(--muted);
   --color-muted-dim: var(--muted-dim);
-  --font-sans: var(--font-geist-sans);
+  --font-sans: var(--font-inter);
   --font-mono: var(--font-geist-mono);
   /* Headings draw from a dedicated slot so a display face can be swapped in
      without touching component markup. */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Fraunces, Geist_Mono, Inter } from "next/font/google";
 import { ClerkProvider } from "@clerk/nextjs";
 import ConvexClientProvider from "@/components/ConvexClientProvider";
 import { ThemeProvider } from "@/components/ThemeProvider";
@@ -7,9 +7,15 @@ import { Toaster } from "@/components/ui/sonner";
 import { getAppName } from "@/lib/app-name";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const inter = Inter({
+  variable: "--font-inter",
   subsets: ["latin"],
+});
+
+const fraunces = Fraunces({
+  variable: "--font-fraunces",
+  subsets: ["latin"],
+  axes: ["opsz", "SOFT", "WONK"],
 });
 
 const geistMono = Geist_Mono({
@@ -29,7 +35,7 @@ const clerkAppearance: React.ComponentProps<typeof ClerkProvider>["appearance"] 
     colorPrimary: "#c2410c",
     colorPrimaryForeground: "#ffffff",
     borderRadius: "1rem",
-    fontFamily: "var(--font-geist-sans), system-ui, sans-serif",
+    fontFamily: "var(--font-inter), system-ui, sans-serif",
   },
   options: {
     unsafe_disableDevelopmentModeWarnings: true,
@@ -49,7 +55,7 @@ export default function RootLayout({
     <ClerkProvider appearance={clerkAppearance}>
       <html
         lang="en"
-        className={`${geistSans.variable} ${geistMono.variable} h-full overscroll-none antialiased`}
+        className={`${inter.variable} ${fraunces.variable} ${geistMono.variable} h-full overscroll-none antialiased`}
         suppressHydrationWarning
       >
         <body className="flex min-h-full flex-col overscroll-none">


### PR DESCRIPTION
## Summary
Typography-only variant of the warm-editorial revision: Fraunces (headings) + Inter (body) + Geist Mono (mono/eyebrow).

- `app/layout.tsx`: replace `Geist` with `Inter` (`--font-inter`) and add `Fraunces` (`--font-fraunces`, latin subset, variable weight with `opsz`/`SOFT`/`WONK` axes); Geist Mono unchanged. Clerk `appearance.variables.fontFamily` updated to `var(--font-inter)`.
- `app/globals.css`: `--font-sans: var(--font-inter)`; heading slot `--font-heading-family: var(--font-fraunces)` so all existing `font-heading` usages pick up Fraunces. `--font-mono` untouched.

No changes outside typography; `npm run lint` and `npx tsc --noEmit` pass.

Link to Devin session: https://app.devin.ai/sessions/2cd79cfe52514eb8969913df2b33fd0b
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/65" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->