### PR TITLE
Font stack (rev1): IBM Plex Sans

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -63,11 +63,11 @@
   --color-foreground: var(--foreground);
   --color-muted: var(--muted);
   --color-muted-dim: var(--muted-dim);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: var(--font-plex-sans);
+  --font-mono: var(--font-plex-mono);
   /* Headings share the body face — hierarchy comes from weight, size, and
      tracking rather than a second display family. */
-  --font-heading: var(--font-geist-sans);
+  --font-heading: var(--font-plex-sans);
   --color-brand: var(--brand);
   --color-brand-foreground: var(--brand-foreground);
   --color-sidebar-ring: var(--sidebar-ring);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,7 +16,7 @@ const plexSans = IBM_Plex_Sans({
 const plexMono = IBM_Plex_Mono({
   variable: "--font-plex-mono",
   subsets: ["latin"],
-  weight: ["400", "500"],
+  weight: ["400", "500", "600"],
 });
 
 export const metadata: Metadata = {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { IBM_Plex_Sans, IBM_Plex_Mono } from "next/font/google";
 import { ClerkProvider } from "@clerk/nextjs";
 import ConvexClientProvider from "@/components/ConvexClientProvider";
 import { ThemeProvider } from "@/components/ThemeProvider";
@@ -7,14 +7,16 @@ import { Toaster } from "@/components/ui/sonner";
 import { getAppName } from "@/lib/app-name";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const plexSans = IBM_Plex_Sans({
+  variable: "--font-plex-sans",
   subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
 });
 
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
+const plexMono = IBM_Plex_Mono({
+  variable: "--font-plex-mono",
   subsets: ["latin"],
+  weight: ["400", "500"],
 });
 
 export const metadata: Metadata = {
@@ -29,7 +31,7 @@ const clerkAppearance: React.ComponentProps<typeof ClerkProvider>["appearance"] 
     colorPrimary: "#00c853",
     colorPrimaryForeground: "#04220f",
     borderRadius: "0.15rem",
-    fontFamily: "var(--font-geist-sans), system-ui, sans-serif",
+    fontFamily: "var(--font-plex-sans), system-ui, sans-serif",
   },
   options: {
     unsafe_disableDevelopmentModeWarnings: true,
@@ -49,7 +51,7 @@ export default function RootLayout({
     <ClerkProvider appearance={clerkAppearance}>
       <html
         lang="en"
-        className={`${geistSans.variable} ${geistMono.variable} h-full overscroll-none antialiased`}
+        className={`${plexSans.variable} ${plexMono.variable} h-full overscroll-none antialiased`}
         suppressHydrationWarning
       >
         <body className="flex min-h-full flex-col overscroll-none">


### PR DESCRIPTION
## Summary
Typography-only variant of the Industrial Terminal design revision: swaps Geist/Geist Mono for IBM Plex Sans (body + headings) and IBM Plex Mono (mono/eyebrow).

- `app/layout.tsx`: `Geist`/`Geist_Mono` → `IBM_Plex_Sans` (weights 400/500/600/700) / `IBM_Plex_Mono` (400/500) via next/font/google, exposed as `--font-plex-sans` / `--font-plex-mono`; Clerk `appearance.variables.fontFamily` updated to match.
- `app/globals.css`: `@theme inline` `--font-sans` / `--font-mono` / `--font-heading` remapped to the Plex variables. Headings share the body face.

No other design or behavior changes.

Link to Devin session: https://app.devin.ai/sessions/b1cc52ff65104fb3a0256cfa14b3b7fb
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/66" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->