### PR TITLE
Font stack (rev3): Chivo

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -64,11 +64,11 @@
   --color-foreground: var(--foreground);
   --color-muted: var(--muted);
   --color-muted-dim: var(--muted-dim);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: var(--font-chivo-sans);
+  --font-mono: var(--font-chivo-mono);
   /* Headings share the body face — hierarchy comes from weight, size, and
      tracking rather than a second display family. */
-  --font-heading: var(--font-geist-sans);
+  --font-heading: var(--font-chivo-sans);
   --color-brand: var(--brand);
   --color-brand-foreground: var(--brand-foreground);
   --color-highlight: var(--highlight);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Chivo, Chivo_Mono } from "next/font/google";
 import { ClerkProvider } from "@clerk/nextjs";
 import ConvexClientProvider from "@/components/ConvexClientProvider";
 import { ThemeProvider } from "@/components/ThemeProvider";
@@ -7,13 +7,13 @@ import { Toaster } from "@/components/ui/sonner";
 import { getAppName } from "@/lib/app-name";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const chivoSans = Chivo({
+  variable: "--font-chivo-sans",
   subsets: ["latin"],
 });
 
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
+const chivoMono = Chivo_Mono({
+  variable: "--font-chivo-mono",
   subsets: ["latin"],
 });
 
@@ -29,7 +29,7 @@ const clerkAppearance: React.ComponentProps<typeof ClerkProvider>["appearance"] 
     colorPrimary: "#7c3aed",
     colorPrimaryForeground: "#ffffff",
     borderRadius: "0.375rem",
-    fontFamily: "var(--font-geist-sans), system-ui, sans-serif",
+    fontFamily: "var(--font-chivo-sans), system-ui, sans-serif",
   },
   options: {
     unsafe_disableDevelopmentModeWarnings: true,
@@ -49,7 +49,7 @@ export default function RootLayout({
     <ClerkProvider appearance={clerkAppearance}>
       <html
         lang="en"
-        className={`${geistSans.variable} ${geistMono.variable} h-full overscroll-none antialiased`}
+        className={`${chivoSans.variable} ${chivoMono.variable} h-full overscroll-none antialiased`}
         suppressHydrationWarning
       >
         <body className="flex min-h-full flex-col overscroll-none">


### PR DESCRIPTION
## Summary
Font-only variant of the rev-3 neo-brutalist design: swaps Geist/Geist Mono for Chivo/Chivo Mono (both variable fonts via `next/font/google`, latin subset).

- `app/layout.tsx`: `Chivo`/`Chivo_Mono` exposed as `--font-chivo-sans` / `--font-chivo-mono`; Clerk `appearance.variables.fontFamily` updated to match.
- `app/globals.css`: `@theme inline` `--font-sans` / `--font-mono` / `--font-heading` now reference the Chivo variables. Headings continue to share the body face (weight 800 via existing base rule; Chivo's variable axis covers it).

No color, layout, or behavior changes.

Link to Devin session: https://app.devin.ai/sessions/0d7e89d53d804264932c38c1b8293626
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/67" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->