### PR TITLE
Font stack (rev1): Space Grotesk

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -63,11 +63,11 @@
   --color-foreground: var(--foreground);
   --color-muted: var(--muted);
   --color-muted-dim: var(--muted-dim);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: var(--font-space-grotesk);
+  --font-mono: var(--font-space-mono);
   /* Headings share the body face — hierarchy comes from weight, size, and
      tracking rather than a second display family. */
-  --font-heading: var(--font-geist-sans);
+  --font-heading: var(--font-space-grotesk);
   --color-brand: var(--brand);
   --color-brand-foreground: var(--brand-foreground);
   --color-sidebar-ring: var(--sidebar-ring);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Space_Grotesk, Space_Mono } from "next/font/google";
 import { ClerkProvider } from "@clerk/nextjs";
 import ConvexClientProvider from "@/components/ConvexClientProvider";
 import { ThemeProvider } from "@/components/ThemeProvider";
@@ -7,14 +7,16 @@ import { Toaster } from "@/components/ui/sonner";
 import { getAppName } from "@/lib/app-name";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const spaceGrotesk = Space_Grotesk({
+  variable: "--font-space-grotesk",
   subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
 });
 
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
+const spaceMono = Space_Mono({
+  variable: "--font-space-mono",
   subsets: ["latin"],
+  weight: ["400", "700"],
 });
 
 export const metadata: Metadata = {
@@ -29,7 +31,7 @@ const clerkAppearance: React.ComponentProps<typeof ClerkProvider>["appearance"] 
     colorPrimary: "#00c853",
     colorPrimaryForeground: "#04220f",
     borderRadius: "0.15rem",
-    fontFamily: "var(--font-geist-sans), system-ui, sans-serif",
+    fontFamily: "var(--font-space-grotesk), system-ui, sans-serif",
   },
   options: {
     unsafe_disableDevelopmentModeWarnings: true,
@@ -49,7 +51,7 @@ export default function RootLayout({
     <ClerkProvider appearance={clerkAppearance}>
       <html
         lang="en"
-        className={`${geistSans.variable} ${geistMono.variable} h-full overscroll-none antialiased`}
+        className={`${spaceGrotesk.variable} ${spaceMono.variable} h-full overscroll-none antialiased`}
         suppressHydrationWarning
       >
         <body className="flex min-h-full flex-col overscroll-none">


### PR DESCRIPTION
## Summary
Typography-only variant of the Industrial Terminal design revision: swaps Geist/Geist Mono for Space Grotesk (body + headings) and Space Mono (mono/eyebrow).

- `app/layout.tsx`: loads `Space_Grotesk` (400/500/600/700) as `--font-space-grotesk` and `Space_Mono` (400/700) as `--font-space-mono` via next/font/google; Clerk `appearance.variables.fontFamily` updated to match.
- `app/globals.css`: `--font-sans`/`--font-heading` → `var(--font-space-grotesk)`, `--font-mono` → `var(--font-space-mono)` in the `@theme inline` block. Headings share the body face.

No changes to colors, layout, or behavior. `npm run lint` and `npx tsc --noEmit` pass.

Link to Devin session: https://app.devin.ai/sessions/37b937b9161646f3933ed64aeb28e696
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/69" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->