### PR TITLE
Font stack (rev3): Bricolage Grotesque

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -64,11 +64,10 @@
   --color-foreground: var(--foreground);
   --color-muted: var(--muted);
   --color-muted-dim: var(--muted-dim);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
-  /* Headings share the body face — hierarchy comes from weight, size, and
-     tracking rather than a second display family. */
-  --font-heading: var(--font-geist-sans);
+  --font-sans: var(--font-inter-tight);
+  --font-mono: var(--font-plex-mono);
+  /* Headings get their own display face: Bricolage Grotesque. */
+  --font-heading: var(--font-bricolage);
   --color-brand: var(--brand);
   --color-brand-foreground: var(--brand-foreground);
   --color-highlight: var(--highlight);
@@ -247,6 +246,7 @@ input:-webkit-autofill:focus {
   h2,
   h3,
   h4 {
+    font-family: var(--font-heading), var(--font-sans), system-ui, sans-serif;
     font-weight: 800;
     letter-spacing: -0.02em;
   }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Bricolage_Grotesque, Inter_Tight, IBM_Plex_Mono } from "next/font/google";
 import { ClerkProvider } from "@clerk/nextjs";
 import ConvexClientProvider from "@/components/ConvexClientProvider";
 import { ThemeProvider } from "@/components/ThemeProvider";
@@ -7,14 +7,20 @@ import { Toaster } from "@/components/ui/sonner";
 import { getAppName } from "@/lib/app-name";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const bricolage = Bricolage_Grotesque({
+  variable: "--font-bricolage",
   subsets: ["latin"],
 });
 
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
+const interTight = Inter_Tight({
+  variable: "--font-inter-tight",
   subsets: ["latin"],
+});
+
+const plexMono = IBM_Plex_Mono({
+  variable: "--font-plex-mono",
+  subsets: ["latin"],
+  weight: ["400", "500", "700"],
 });
 
 export const metadata: Metadata = {
@@ -29,7 +35,7 @@ const clerkAppearance: React.ComponentProps<typeof ClerkProvider>["appearance"] 
     colorPrimary: "#7c3aed",
     colorPrimaryForeground: "#ffffff",
     borderRadius: "0.375rem",
-    fontFamily: "var(--font-geist-sans), system-ui, sans-serif",
+    fontFamily: "var(--font-inter-tight), system-ui, sans-serif",
   },
   options: {
     unsafe_disableDevelopmentModeWarnings: true,
@@ -49,7 +55,7 @@ export default function RootLayout({
     <ClerkProvider appearance={clerkAppearance}>
       <html
         lang="en"
-        className={`${geistSans.variable} ${geistMono.variable} h-full overscroll-none antialiased`}
+        className={`${bricolage.variable} ${interTight.variable} ${plexMono.variable} h-full overscroll-none antialiased`}
         suppressHydrationWarning
       >
         <body className="flex min-h-full flex-col overscroll-none">


### PR DESCRIPTION
## Summary
Font-stack variant of the rev-3 neo-brutalist design: Bricolage Grotesque (headings) + Inter Tight (body) + IBM Plex Mono (mono/eyebrow), replacing Geist/Geist Mono. Typography-only — no other design or logic changes.

- `app/layout.tsx`: loads the three faces via next/font/google (`--font-bricolage` / `--font-inter-tight` / `--font-plex-mono`; Bricolage & Inter Tight as variable fonts, Plex Mono at 400/500/700 only) and updates Clerk `appearance.variables.fontFamily` to Inter Tight.
- `app/globals.css`: remaps `--font-sans` / `--font-mono` / `--font-heading` in `@theme inline`; headings (`h1–h4`) now use `var(--font-heading)` since the stack has a distinct display face.

Link to Devin session: https://app.devin.ai/sessions/43c2857bb7dc454eade5197d82dad871
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/71" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->