### PR TITLE
Hide claim/code options until eligibility is verified

### DIFF
--- a/components/ClaimPage.tsx
+++ b/components/ClaimPage.tsx
@@ -81,6 +81,10 @@ export default function ClaimPage({ slug }: { slug: string }) {
   const event = useQuery(api.events.getBySlug, { slug });
   const claim = useMutation(api.claims.claim);
   const { isLoading: authLoading, isAuthenticated } = useConvexAuth();
+  const eligibility = useQuery(
+    api.claims.eligibility,
+    isAuthenticated ? { slug } : "skip",
+  );
   const { user } = useUser();
   const [submitting, setSubmitting] = useState(false);
   const [result, setResult] = useState<ClaimResult | null>(null);
@@ -249,6 +253,39 @@ export default function ClaimPage({ slug }: { slug: string }) {
                         yours is still here.
                       </p>
                     ) : null}
+                  </div>
+                ) : eligibility === undefined ? (
+                  <div className="flex flex-col gap-3">
+                    <Skeleton className="h-12 rounded-md" />
+                    <Skeleton className="h-10 rounded-lg" />
+                  </div>
+                ) : !eligibility.eligible ? (
+                  <div className="flex flex-col gap-5">
+                    <Alert variant="destructive">
+                      <OctagonX />
+                      <AlertTitle>
+                        {eligibility.reason === "unverified"
+                          ? "Your account has no verified email address. Sign in with the email you registered with."
+                          : `${eligibility.email ?? "This email"} is not on the participant list for this event. Sign in with the email you registered with.`}
+                      </AlertTitle>
+                    </Alert>
+                    <div className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
+                      <span className="min-w-0 truncate">
+                        Signed in as{" "}
+                        <span className="text-foreground">
+                          {signedInEmail ?? "verified user"}
+                        </span>
+                      </span>
+                      <SignOutButton redirectUrl={`/${slug}`}>
+                        <Button
+                          variant="ghost"
+                          size="xs"
+                          className="shrink-0 text-muted-foreground"
+                        >
+                          Switch
+                        </Button>
+                      </SignOutButton>
+                    </div>
                   </div>
                 ) : (
                   <div className="flex flex-col gap-5">

--- a/convex/claims.ts
+++ b/convex/claims.ts
@@ -1,5 +1,38 @@
-import { mutation } from "./_generated/server";
+import { mutation, query } from "./_generated/server";
 import { v } from "convex/values";
+
+// Whether the signed-in viewer is on the participant list for the event,
+// so the claim UI can hold back code options until eligibility is confirmed.
+export const eligibility = query({
+  args: { slug: v.string() },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) {
+      return { eligible: false as const, reason: "unauthenticated" as const };
+    }
+    const email = identity.email?.trim().toLowerCase();
+    if (!email || identity.emailVerified !== true) {
+      return { eligible: false as const, reason: "unverified" as const };
+    }
+    const event = await ctx.db
+      .query("events")
+      .withIndex("by_slug", (q) => q.eq("slug", args.slug))
+      .unique();
+    if (!event) {
+      return { eligible: false as const, reason: "not_found" as const };
+    }
+    const allowed = await ctx.db
+      .query("emails")
+      .withIndex("by_event_email", (q) =>
+        q.eq("eventId", event._id).eq("email", email)
+      )
+      .unique();
+    if (!allowed) {
+      return { eligible: false as const, reason: "not_listed" as const, email };
+    }
+    return { eligible: true as const, email };
+  },
+});
 
 export const claim = mutation({
   args: { slug: v.string(), codeType: v.optional(v.string()) },


### PR DESCRIPTION
## Summary
The claim page previously showed the code-type chooser and "Dispense my code" button to any signed-in user; ineligible users only learned they couldn't claim after clicking. Now the code options stay hidden until the server confirms the viewer can actually claim.

- New `claims.eligibility` query: returns `{ eligible: true, email }` when the signed-in user's verified email is on the event's participant list (same `by_event_email` check `claims.claim` enforces), otherwise `{ eligible: false, reason: "unverified" | "not_listed" | ... }`.
- `ClaimPage` runs the query once authenticated (`"skip"` otherwise): shows skeletons while it loads, and for ineligible users renders the destructive alert ("not on the participant list" / "no verified email") plus the signed-in/Switch footer — no code-type buttons or dispense button.

Link to Devin session: https://app.devin.ai/sessions/009417d7b0744ba6a4a2d182a619694d
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/72" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->