### PR TITLE
Show claimed code on revisit instead of re-prompting for code type

### DIFF
--- a/components/ClaimPage.tsx
+++ b/components/ClaimPage.tsx
@@ -170,6 +170,17 @@ export default function ClaimPage({ slug }: { slug: string }) {
               copied={copied}
               onCopy={copyCode}
             />
+          ) : eligibility?.eligible && eligibility.claimed ? (
+            <Receipt
+              eventName={event.name}
+              instructions={event.claimInstructions}
+              creditAmount={eligibility.claimed.creditAmount}
+              code={eligibility.claimed.code}
+              codeType={eligibility.claimed.codeType}
+              alreadyClaimed
+              copied={copied}
+              onCopy={copyCode}
+            />
           ) : (
             <div className="perspective-distant">
               <div

--- a/convex/claims.ts
+++ b/convex/claims.ts
@@ -30,6 +30,23 @@ export const eligibility = query({
     if (!allowed) {
       return { eligible: false as const, reason: "not_listed" as const, email };
     }
+    const claimed = await ctx.db
+      .query("codes")
+      .withIndex("by_event_claimedBy", (q) =>
+        q.eq("eventId", event._id).eq("claimedBy", email)
+      )
+      .unique();
+    if (claimed) {
+      return {
+        eligible: true as const,
+        email,
+        claimed: {
+          code: claimed.code,
+          codeType: claimed.codeType,
+          creditAmount: event.creditAmount,
+        },
+      };
+    }
     return { eligible: true as const, email };
   },
 });


### PR DESCRIPTION
## Summary
Users who already claimed a code and revisit the event page were shown the code-type chooser + "Dispense my code" again; their code only reappeared after clicking through. Now the page recognizes an existing claim and renders the receipt immediately.

- `claims.eligibility` now also returns the viewer's existing claim: `{ eligible: true, email, claimed?: { code, codeType, creditAmount } }` (lookup via the same `by_event_claimedBy` index `claims.claim` uses).
- `ClaimPage` renders `<Receipt alreadyClaimed>` straight from `eligibility.claimed` when present, skipping the chooser/dispense UI. A fresh claim's `result` still takes precedence, so the just-dispensed receipt is unchanged.

Link to Devin session: https://app.devin.ai/sessions/009417d7b0744ba6a4a2d182a619694d
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/73" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->