### PR TITLE
Show redemption instructions before claiming for eligible users

### DIFF
--- a/components/ClaimPage.tsx
+++ b/components/ClaimPage.tsx
@@ -349,6 +349,12 @@ export default function ClaimPage({ slug }: { slug: string }) {
                         "Dispense my code"
                       )}
                     </Button>
+                    {event.claimInstructions ? (
+                      <RedeemInstructionsDialog
+                        eventName={event.name}
+                        instructions={event.claimInstructions}
+                      />
+                    ) : null}
                     {event.soldOut ? (
                       <p className="text-center text-xs text-muted-foreground">
                         All codes have been dispensed — if you already claimed,
@@ -389,6 +395,36 @@ export default function ClaimPage({ slug }: { slug: string }) {
       </main>
       <SiteFooter />
     </div>
+  );
+}
+
+function RedeemInstructionsDialog({
+  eventName,
+  instructions,
+}: {
+  eventName: string;
+  instructions: string;
+}) {
+  return (
+    <Dialog>
+      <DialogTrigger render={<Button variant="outline" size="lg" />}>
+        <BookOpen data-icon="inline-start" />
+        How to redeem
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="font-heading tracking-tight">
+            How to redeem your code
+          </DialogTitle>
+          <DialogDescription className="sr-only">
+            Redemption instructions for {eventName}
+          </DialogDescription>
+        </DialogHeader>
+        <p className="text-sm leading-relaxed whitespace-pre-wrap">
+          {instructions}
+        </p>
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -533,25 +569,10 @@ function Receipt({
             )}
           </Button>
           {instructions ? (
-            <Dialog>
-              <DialogTrigger render={<Button variant="outline" size="lg" />}>
-                <BookOpen data-icon="inline-start" />
-                How to redeem
-              </DialogTrigger>
-              <DialogContent className="sm:max-w-md">
-                <DialogHeader>
-                  <DialogTitle className="font-heading tracking-tight">
-                    How to redeem your code
-                  </DialogTitle>
-                  <DialogDescription className="sr-only">
-                    Redemption instructions for {eventName}
-                  </DialogDescription>
-                </DialogHeader>
-                <p className="text-sm leading-relaxed whitespace-pre-wrap">
-                  {instructions}
-                </p>
-              </DialogContent>
-            </Dialog>
+            <RedeemInstructionsDialog
+              eventName={eventName}
+              instructions={instructions}
+            />
           ) : null}
           <Button
             variant="ghost"


### PR DESCRIPTION
## Summary
Redemption instructions were only reachable after a code was dispensed (on the receipt). Eligible signed-in users now get the same "How to redeem" dialog button on the claim card — below "Dispense my code", before they pick a code type — so they can read the instructions before claiming.

- Extracted the receipt's inline instructions `Dialog` into `RedeemInstructionsDialog({ eventName, instructions })` and reused it in both places; rendered only when `event.claimInstructions` is set, and only in the eligible (authorized) branch — signed-out and not-on-the-list users don't see it.

Link to Devin session: https://app.devin.ai/sessions/009417d7b0744ba6a4a2d182a619694d
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/74" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->