### PR TITLE
Require one confirmed read of redemption instructions before claiming

### DIFF
--- a/components/ClaimPage.tsx
+++ b/components/ClaimPage.tsx
@@ -80,6 +80,7 @@ function subscribeNoop() {
 export default function ClaimPage({ slug }: { slug: string }) {
   const event = useQuery(api.events.getBySlug, { slug });
   const claim = useMutation(api.claims.claim);
+  const markInstructionsRead = useMutation(api.claims.markInstructionsRead);
   const { isLoading: authLoading, isAuthenticated } = useConvexAuth();
   const eligibility = useQuery(
     api.claims.eligibility,
@@ -91,6 +92,7 @@ export default function ClaimPage({ slug }: { slug: string }) {
   const [copied, setCopied] = useState(false);
   const [showQr, setShowQr] = useState(false);
   const [selectedType, setSelectedType] = useState<string | null>(null);
+  const [readOpen, setReadOpen] = useState(false);
   const origin = useSyncExternalStore(
     subscribeNoop,
     () => window.location.origin,
@@ -98,6 +100,22 @@ export default function ClaimPage({ slug }: { slug: string }) {
   );
 
   const signedInEmail = user?.primaryEmailAddress?.emailAddress;
+
+  // Events with redemption instructions require one confirmed read (stored
+  // per attendee) before the claim UI unlocks; return visits skip the gate.
+  const mustReadInstructions =
+    !!event?.claimInstructions &&
+    eligibility?.eligible === true &&
+    !eligibility.instructionsViewed;
+
+  async function handleConfirmRead() {
+    setReadOpen(false);
+    try {
+      await markInstructionsRead({ slug });
+    } catch {
+      toast.error("Something went wrong. Please try again.");
+    }
+  }
 
   // Two named pools means the user picks which one to draw from; a single
   // (possibly unnamed) pool claims without a choice.
@@ -280,6 +298,62 @@ export default function ClaimPage({ slug }: { slug: string }) {
                           : `${eligibility.email ?? "This email"} is not on the participant list for this event. Sign in with the email you registered with.`}
                       </AlertTitle>
                     </Alert>
+                    <div className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
+                      <span className="min-w-0 truncate">
+                        Signed in as{" "}
+                        <span className="text-foreground">
+                          {signedInEmail ?? "verified user"}
+                        </span>
+                      </span>
+                      <SignOutButton redirectUrl={`/${slug}`}>
+                        <Button
+                          variant="ghost"
+                          size="xs"
+                          className="shrink-0 text-muted-foreground"
+                        >
+                          Switch
+                        </Button>
+                      </SignOutButton>
+                    </div>
+                  </div>
+                ) : mustReadInstructions ? (
+                  <div className="flex flex-col gap-5">
+                    <p className="text-sm leading-relaxed text-muted-foreground">
+                      You&apos;re on the list. Before your code is dispensed,
+                      take a moment to read how to redeem it.
+                    </p>
+                    <Dialog open={readOpen} onOpenChange={setReadOpen}>
+                      <DialogTrigger
+                        render={
+                          <Button variant="brand" size="lg" className="w-full" />
+                        }
+                      >
+                        <BookOpen data-icon="inline-start" />
+                        Read how to redeem
+                      </DialogTrigger>
+                      <DialogContent className="sm:max-w-md">
+                        <DialogHeader>
+                          <DialogTitle className="font-heading tracking-tight">
+                            How to redeem your code
+                          </DialogTitle>
+                          <DialogDescription className="sr-only">
+                            Redemption instructions for {event.name}
+                          </DialogDescription>
+                        </DialogHeader>
+                        <p className="text-sm leading-relaxed whitespace-pre-wrap">
+                          {event.claimInstructions}
+                        </p>
+                        <Button
+                          variant="brand"
+                          size="lg"
+                          className="w-full"
+                          onClick={handleConfirmRead}
+                        >
+                          <Check data-icon="inline-start" />
+                          Got it — continue to claim
+                        </Button>
+                      </DialogContent>
+                    </Dialog>
                     <div className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
                       <span className="min-w-0 truncate">
                         Signed in as{" "}

--- a/convex/claims.ts
+++ b/convex/claims.ts
@@ -36,10 +36,12 @@ export const eligibility = query({
         q.eq("eventId", event._id).eq("claimedBy", email)
       )
       .unique();
+    const instructionsViewed = allowed.instructionsViewedAt !== undefined;
     if (claimed) {
       return {
         eligible: true as const,
         email,
+        instructionsViewed,
         claimed: {
           code: claimed.code,
           codeType: claimed.codeType,
@@ -47,7 +49,32 @@ export const eligibility = query({
         },
       };
     }
-    return { eligible: true as const, email };
+    return { eligible: true as const, email, instructionsViewed };
+  },
+});
+
+// Records that the signed-in attendee confirmed reading the redemption
+// instructions, unlocking the claim UI for events that have instructions.
+export const markInstructionsRead = mutation({
+  args: { slug: v.string() },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) return;
+    const email = identity.email?.trim().toLowerCase();
+    if (!email || identity.emailVerified !== true) return;
+    const event = await ctx.db
+      .query("events")
+      .withIndex("by_slug", (q) => q.eq("slug", args.slug))
+      .unique();
+    if (!event) return;
+    const allowed = await ctx.db
+      .query("emails")
+      .withIndex("by_event_email", (q) =>
+        q.eq("eventId", event._id).eq("email", email)
+      )
+      .unique();
+    if (!allowed || allowed.instructionsViewedAt !== undefined) return;
+    await ctx.db.patch(allowed._id, { instructionsViewedAt: Date.now() });
   },
 });
 
@@ -103,6 +130,13 @@ export const claim = mutation({
         codeType: alreadyClaimed.codeType,
         alreadyClaimed: true,
         creditAmount: event.creditAmount,
+      };
+    }
+
+    if (event.claimInstructions && allowed.instructionsViewedAt === undefined) {
+      return {
+        ok: false as const,
+        error: "Read the redemption instructions before claiming your code.",
       };
     }
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -30,6 +30,9 @@ export default defineSchema({
   emails: defineTable({
     eventId: v.id("events"),
     email: v.string(),
+    // When the attendee confirmed reading the redemption instructions,
+    // required once (per event) before claiming when instructions exist.
+    instructionsViewedAt: v.optional(v.number()),
   })
     .index("by_event", ["eventId"])
     .index("by_event_email", ["eventId", "email"])


### PR DESCRIPTION
## Summary
For events with `claimInstructions`, eligible attendees must read the instructions once before the claim UI unlocks. The confirmation is stored server-side per attendee (`emails.instructionsViewedAt`), so return visits — even from another device — skip the gate; the "How to redeem" button remains available to re-read afterwards.

- Schema: `emails.instructionsViewedAt: v.optional(v.number())`.
- New mutation `claims.markInstructionsRead({ slug })` stamps the viewer's participant record (idempotent); `claims.eligibility` now returns `instructionsViewed`.
- `claims.claim` enforces the gate server-side (`"Read the redemption instructions before claiming your code."`) — but only for new claims; already-claimed users can always retrieve their code.
- `ClaimPage`: when `eligible && claimInstructions && !instructionsViewed`, the card shows a single brand "Read how to redeem" button opening the instructions dialog with a "Got it — continue to claim" confirm; confirming unlocks the chooser + "Dispense my code" reactively.

Link to Devin session: https://app.devin.ai/sessions/009417d7b0744ba6a4a2d182a619694d
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/75" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->