### PR TITLE
Per-code-block values instead of event-level credit amount

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -215,7 +215,6 @@ function NewEventDialog() {
   const [slug, setSlug] = useState("");
   const [description, setDescription] = useState("");
   const [eventDate, setEventDate] = useState("");
-  const [creditAmount, setCreditAmount] = useState("");
   const [claimInstructions, setClaimInstructions] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
@@ -230,7 +229,6 @@ function NewEventDialog() {
         slug: slug || undefined,
         description: description || undefined,
         eventDate: eventDate || undefined,
-        creditAmount: creditAmount || undefined,
         claimInstructions: claimInstructions || undefined,
       });
       toast.success(`Event "${name}" created`);
@@ -303,15 +301,6 @@ function NewEventDialog() {
               <FieldDescription>
                 Optional — shown on the home and claim pages.
               </FieldDescription>
-            </Field>
-            <Field>
-              <FieldLabel htmlFor="event-credit">Credit amount</FieldLabel>
-              <Input
-                id="event-credit"
-                value={creditAmount}
-                onChange={(e) => setCreditAmount(e.target.value)}
-                placeholder="$100"
-              />
             </Field>
             <Field>
               <FieldLabel htmlFor="event-instructions">

--- a/app/my-codes/page.tsx
+++ b/app/my-codes/page.tsx
@@ -37,9 +37,12 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 
-function formatCredits(amount: string) {
-  const trimmed = amount.trim();
-  return /^\d/.test(trimmed) ? `$${trimmed}` : trimmed;
+// Block values are free text: numeric values ("100") render as dollar
+// credits ("$100 in credits"); anything else ("Team plan", "$200") renders
+// as-is.
+function formatValue(value: string) {
+  const trimmed = value.trim();
+  return /^\d/.test(trimmed) ? `$${trimmed} in credits` : trimmed;
 }
 
 interface EventInfo {
@@ -53,7 +56,7 @@ interface EventInfo {
 function eventMeta(event: EventInfo) {
   const parts: string[] = [];
   if (event.eventDate) parts.push(formatEventDate(event.eventDate));
-  if (event.creditAmount) parts.push(`${formatCredits(event.creditAmount)} in credits`);
+  if (event.creditAmount) parts.push(formatValue(event.creditAmount));
   return parts.length > 0 ? parts.join(" · ") : null;
 }
 

--- a/components/ClaimPage.tsx
+++ b/components/ClaimPage.tsx
@@ -66,11 +66,12 @@ type ClaimResult =
     }
   | { ok: false; error: string };
 
-// creditAmount is free text; prefix "$" only when it starts with a number
-// so already-prefixed values ("$100") or other currencies stay untouched.
-function formatCredits(amount: string) {
-  const trimmed = amount.trim();
-  return /^\d/.test(trimmed) ? `$${trimmed}` : trimmed;
+// Block values are free text: numeric values ("100") render as dollar
+// credits ("$100 in credits"); anything else ("Team plan", "$200") renders
+// as-is.
+function formatValue(value: string) {
+  const trimmed = value.trim();
+  return /^\d/.test(trimmed) ? `$${trimmed} in credits` : trimmed;
 }
 
 function subscribeNoop() {
@@ -329,7 +330,7 @@ export default function ClaimPage({ slug }: { slug: string }) {
                         }
                       >
                         <BookOpen data-icon="inline-start" />
-                        Read how to redeem
+                        Read redemption instructions to claim.
                       </DialogTrigger>
                       <DialogContent className="sm:max-w-md">
                         <DialogHeader>
@@ -386,22 +387,30 @@ export default function ClaimPage({ slug }: { slug: string }) {
                           Choose your code type
                         </legend>
                         <div className="grid grid-cols-2 gap-2">
-                          {codeTypes.map((type) => (
-                            <Button
-                              key={type}
-                              type="button"
-                              variant="outline"
-                              aria-pressed={selectedType === type}
-                              onClick={() => setSelectedType(type)}
-                              className={cn(
-                                "h-auto min-h-10 whitespace-normal py-2",
-                                selectedType === type &&
-                                  "border-brand ring-1 ring-brand",
-                              )}
-                            >
-                              {type}
-                            </Button>
-                          ))}
+                          {codeTypes.map((type) => {
+                            const value = event.codeTypeValues?.[type];
+                            return (
+                              <Button
+                                key={type}
+                                type="button"
+                                variant="outline"
+                                aria-pressed={selectedType === type}
+                                onClick={() => setSelectedType(type)}
+                                className={cn(
+                                  "h-auto min-h-10 flex-col gap-0.5 whitespace-normal py-2",
+                                  selectedType === type &&
+                                    "border-brand ring-1 ring-brand",
+                                )}
+                              >
+                                <span>{type}</span>
+                                {value ? (
+                                  <span className="text-xs font-normal text-muted-foreground">
+                                    {formatValue(value)}
+                                  </span>
+                                ) : null}
+                              </Button>
+                            );
+                          })}
                         </div>
                       </fieldset>
                     ) : null}
@@ -602,7 +611,7 @@ function Receipt({
           </h1>
           {creditAmount ? (
             <p className="mt-1 text-sm text-muted-foreground">
-              {formatCredits(creditAmount)} in credits
+              {formatValue(creditAmount)}
             </p>
           ) : null}
         </div>

--- a/components/ManageEvent.tsx
+++ b/components/ManageEvent.tsx
@@ -84,11 +84,13 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
   const addCodes = useMutation(api.codes.add);
   const removeCode = useMutation(api.codes.remove);
   const renameCodeType = useMutation(api.codes.renameType);
+  const setTypeValue = useMutation(api.codes.setTypeValue);
 
   const [emailInput, setEmailInput] = useState("");
   const [codeInput, setCodeInput] = useState("");
   const [blockTarget, setBlockTarget] = useState<string | null>(null);
   const [newBlockName, setNewBlockName] = useState("");
+  const [newBlockValue, setNewBlockValue] = useState("");
   const [firstBlockName, setFirstBlockName] = useState("");
   const [emailBusy, setEmailBusy] = useState(false);
   const [codeBusy, setCodeBusy] = useState(false);
@@ -251,6 +253,7 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
   function resetBlockForm(codeType: string | undefined) {
     setBlockTarget(`existing:${codeType ?? ""}`);
     setNewBlockName("");
+    setNewBlockValue("");
     setFirstBlockName("");
   }
 
@@ -265,6 +268,7 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
         eventId: id,
         codes: list,
         codeType,
+        value: isNewBlock ? newBlockValue.trim() || undefined : undefined,
       });
       toast.success(`Added ${added} codes`, {
         description: skipped ? `Skipped ${skipped} (duplicates).` : undefined,
@@ -300,7 +304,12 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
           codeType = await resolveTargetType();
           resolved = true;
         }
-        return addCodes({ eventId: id, codes: items, codeType });
+        return addCodes({
+          eventId: id,
+          codes: items,
+          codeType,
+          value: isNewBlock ? newBlockValue.trim() || undefined : undefined,
+        });
       },
       setCodeBusy
     );
@@ -680,6 +689,10 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
           <CardContent className="flex flex-col gap-4">
             <CodeBlocks
               codes={codes}
+              values={event.codeTypeValues}
+              onSetValue={(codeType, value) =>
+                setTypeValue({ eventId: id, codeType, value })
+              }
               onRename={async (from, to) => {
                 await renameCodeType({ eventId: id, from, to });
                 // Keep the selection (and the filtered list) on the block
@@ -744,6 +757,22 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
                     {hasBlocks
                       ? "Required — attendees choose between the two blocks by name."
                       : "Optional with a single code block. Applies to pasted and uploaded codes."}
+                  </FieldDescription>
+                </Field>
+              ) : null}
+              {!hasBlocks || isNewBlock ? (
+                <Field>
+                  <FieldLabel htmlFor="new-block-value">Value</FieldLabel>
+                  <Input
+                    id="new-block-value"
+                    value={newBlockValue}
+                    onChange={(e) => setNewBlockValue(e.target.value)}
+                    placeholder="e.g. 100 or Team plan"
+                    className="text-sm"
+                  />
+                  <FieldDescription>
+                    Optional — shown on the claim page. Numbers get a
+                    &ldquo;$&rdquo; prefix; anything else is shown as-is.
                   </FieldDescription>
                 </Field>
               ) : null}
@@ -812,10 +841,17 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
 
 function CodeBlocks({
   codes,
+  values,
   onRename,
+  onSetValue,
 }: {
   codes: Doc<"codes">[] | undefined;
+  values: Record<string, string> | undefined;
   onRename: (from: string | undefined, to: string) => Promise<unknown>;
+  onSetValue: (
+    codeType: string | undefined,
+    value: string | undefined
+  ) => Promise<unknown>;
 }) {
   // Map insertion order follows creation time, so blocks list in the order
   // they were first created rather than alphabetically.
@@ -834,7 +870,9 @@ function CodeBlocks({
             key={type || "__unnamed"}
             type={type}
             count={count}
+            value={values?.[type]}
             onRename={onRename}
+            onSetValue={onSetValue}
           />
         ))}
     </div>
@@ -844,34 +882,55 @@ function CodeBlocks({
 function CodeBlockRow({
   type,
   count,
+  value,
   onRename,
+  onSetValue,
 }: {
   type: string;
   count: number;
+  value?: string;
   onRename: (from: string | undefined, to: string) => Promise<unknown>;
+  onSetValue: (
+    codeType: string | undefined,
+    value: string | undefined
+  ) => Promise<unknown>;
 }) {
   const [editing, setEditing] = useState(false);
   const [name, setName] = useState(type);
+  const [valueInput, setValueInput] = useState(value ?? "");
   const [busy, setBusy] = useState(false);
 
-  async function handleRename(e: React.FormEvent) {
+  async function handleSave(e: React.FormEvent) {
     e.preventDefault();
     const to = name.trim();
-    if (!to || to === type) {
+    const newValue = valueInput.trim();
+    const renaming = to !== "" && to !== type;
+    const valueChanged = newValue !== (value ?? "");
+    if (!renaming && !valueChanged) {
       setEditing(false);
       setName(type);
+      setValueInput(value ?? "");
       return;
     }
     setBusy(true);
     try {
-      await onRename(type || undefined, to);
-      toast.success(
-        type ? `Renamed “${type}” to “${to}”` : `Named code block “${to}”`
-      );
+      if (renaming) {
+        await onRename(type || undefined, to);
+        toast.success(
+          type ? `Renamed “${type}” to “${to}”` : `Named code block “${to}”`
+        );
+      }
+      if (valueChanged) {
+        await onSetValue(
+          (renaming ? to : type) || undefined,
+          newValue || undefined
+        );
+        toast.success(newValue ? "Block value saved" : "Block value cleared");
+      }
       setEditing(false);
     } catch (err) {
       toast.error(
-        err instanceof Error ? err.message : "Failed to rename code block"
+        err instanceof Error ? err.message : "Failed to update code block"
       );
     } finally {
       setBusy(false);
@@ -881,13 +940,23 @@ function CodeBlockRow({
   return (
     <div className="flex min-h-9 flex-wrap items-center gap-2 rounded-lg border border-border bg-surface px-3 py-1.5">
       {editing ? (
-        <form onSubmit={handleRename} className="flex flex-1 items-center gap-2">
+        <form
+          onSubmit={handleSave}
+          className="flex flex-1 flex-wrap items-center gap-2"
+        >
           <Input
             autoFocus
             aria-label="Code block name"
             value={name}
             onChange={(e) => setName(e.target.value)}
             placeholder="e.g. $50 credits"
+            className="h-7 max-w-48 text-sm"
+          />
+          <Input
+            aria-label="Code block value"
+            value={valueInput}
+            onChange={(e) => setValueInput(e.target.value)}
+            placeholder="Value, e.g. 100 or Team plan"
             className="h-7 max-w-48 text-sm"
           />
           <Button type="submit" size="xs" variant="secondary" disabled={busy}>
@@ -902,6 +971,7 @@ function CodeBlockRow({
             onClick={() => {
               setEditing(false);
               setName(type);
+              setValueInput(value ?? "");
             }}
           >
             Cancel
@@ -915,13 +985,18 @@ function CodeBlockRow({
           <span className="text-xs text-muted-dim tabular-nums">
             {count} code{count === 1 ? "" : "s"}
           </span>
+          {value ? (
+            <span className="max-w-40 truncate text-xs text-muted-foreground">
+              {value}
+            </span>
+          ) : null}
           <Button
             size="xs"
             variant="ghost"
             className="ml-auto text-muted-foreground"
             onClick={() => setEditing(true)}
           >
-            {type ? "Rename" : "Name this block"}
+            Edit
           </Button>
         </>
       )}
@@ -1172,7 +1247,6 @@ function EventDetailsForm({
   const [slug, setSlug] = useState(event.slug);
   const [description, setDescription] = useState(event.description ?? "");
   const [eventDate, setEventDate] = useState(event.eventDate ?? "");
-  const [creditAmount, setCreditAmount] = useState(event.creditAmount ?? "");
   const [claimInstructions, setClaimInstructions] = useState(
     event.claimInstructions ?? ""
   );
@@ -1188,7 +1262,6 @@ function EventDetailsForm({
         slug,
         description: description || undefined,
         eventDate: eventDate || undefined,
-        creditAmount: creditAmount || undefined,
         claimInstructions: claimInstructions || undefined,
       });
       setSlug(savedSlug);
@@ -1257,16 +1330,6 @@ function EventDetailsForm({
               <FieldDescription>
                 Optional — shown on the home and claim pages.
               </FieldDescription>
-            </Field>
-            <Field>
-              <FieldLabel htmlFor="detail-credit">Credit amount</FieldLabel>
-              <Input
-                id="detail-credit"
-                value={creditAmount}
-                onChange={(e) => setCreditAmount(e.target.value)}
-                placeholder="$100"
-              />
-              <FieldDescription>Shown on the claim page.</FieldDescription>
             </Field>
             <Field className="sm:col-span-2">
               <FieldLabel htmlFor="detail-instructions">

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -11,6 +11,7 @@
 import type * as admins from "../admins.js";
 import type * as auditLog from "../auditLog.js";
 import type * as blacklist from "../blacklist.js";
+import type * as blockValues from "../blockValues.js";
 import type * as claims from "../claims.js";
 import type * as codes from "../codes.js";
 import type * as emails from "../emails.js";
@@ -29,6 +30,7 @@ declare const fullApi: ApiFromModules<{
   admins: typeof admins;
   auditLog: typeof auditLog;
   blacklist: typeof blacklist;
+  blockValues: typeof blockValues;
   claims: typeof claims;
   codes: typeof codes;
   emails: typeof emails;

--- a/convex/blockValues.ts
+++ b/convex/blockValues.ts
@@ -1,0 +1,8 @@
+// The value shown for a code is its block's value, falling back to the
+// legacy event-wide creditAmount for events created before per-block values.
+export function blockValue(
+  event: { codeTypeValues?: Record<string, string>; creditAmount?: string },
+  codeType: string | undefined
+): string | undefined {
+  return event.codeTypeValues?.[codeType ?? ""] ?? event.creditAmount;
+}

--- a/convex/claims.ts
+++ b/convex/claims.ts
@@ -1,5 +1,6 @@
 import { mutation, query } from "./_generated/server";
 import { v } from "convex/values";
+import { blockValue } from "./blockValues";
 
 // Whether the signed-in viewer is on the participant list for the event,
 // so the claim UI can hold back code options until eligibility is confirmed.
@@ -45,7 +46,7 @@ export const eligibility = query({
         claimed: {
           code: claimed.code,
           codeType: claimed.codeType,
-          creditAmount: event.creditAmount,
+          creditAmount: blockValue(event, claimed.codeType),
         },
       };
     }
@@ -129,7 +130,7 @@ export const claim = mutation({
         code: alreadyClaimed.code,
         codeType: alreadyClaimed.codeType,
         alreadyClaimed: true,
-        creditAmount: event.creditAmount,
+        creditAmount: blockValue(event, alreadyClaimed.codeType),
       };
     }
 
@@ -192,7 +193,7 @@ export const claim = mutation({
       code: available.code,
       codeType: available.codeType,
       alreadyClaimed: false,
-      creditAmount: event.creditAmount,
+      creditAmount: blockValue(event, available.codeType),
     };
   },
 });

--- a/convex/codes.ts
+++ b/convex/codes.ts
@@ -1,6 +1,7 @@
 import { mutation, query } from "./_generated/server";
 import { v } from "convex/values";
 import { requireEventAdmin } from "./admins";
+import { blockValue } from "./blockValues";
 
 export const list = query({
   args: { eventId: v.id("events") },
@@ -18,6 +19,7 @@ export const add = mutation({
     eventId: v.id("events"),
     codes: v.array(v.string()),
     codeType: v.optional(v.string()),
+    value: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     await requireEventAdmin(ctx, args.eventId);
@@ -64,8 +66,41 @@ export const add = mutation({
       ];
       if (!ordered.includes(codeType ?? "")) ordered.push(codeType ?? "");
       await ctx.db.patch(args.eventId, { codeTypes: ordered });
+      const value = args.value?.trim();
+      if (value) {
+        const event = await ctx.db.get(args.eventId);
+        await ctx.db.patch(args.eventId, {
+          codeTypeValues: {
+            ...(event?.codeTypeValues ?? {}),
+            [codeType ?? ""]: value,
+          },
+        });
+      }
     }
     return { added, skipped };
+  },
+});
+
+// Sets or clears the free-text value shown for a code block.
+export const setTypeValue = mutation({
+  args: {
+    eventId: v.id("events"),
+    codeType: v.optional(v.string()),
+    value: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    await requireEventAdmin(ctx, args.eventId);
+    const event = await ctx.db.get(args.eventId);
+    if (!event) throw new Error("Event not found");
+    const key = args.codeType?.trim() || "";
+    const value = args.value?.trim();
+    const values = { ...(event.codeTypeValues ?? {}) };
+    if (value) {
+      values[key] = value;
+    } else {
+      delete values[key];
+    }
+    await ctx.db.patch(args.eventId, { codeTypeValues: values });
   },
 });
 
@@ -100,7 +135,14 @@ export const renameType = mutation({
     const codeTypes = [...new Set(ordered)].filter(
       (t) => targets.length > 0 || t !== (from ?? "")
     );
-    await ctx.db.patch(args.eventId, { codeTypes });
+    // Carry the block's value over to its new name.
+    const values = { ...(event?.codeTypeValues ?? {}) };
+    const fromKey = from ?? "";
+    if (targets.length > 0 && fromKey in values && !(to in values)) {
+      values[to] = values[fromKey];
+    }
+    delete values[fromKey];
+    await ctx.db.patch(args.eventId, { codeTypes, codeTypeValues: values });
     return { renamed: targets.length };
   },
 });
@@ -130,7 +172,7 @@ export const mine = query({
                 _id: event._id,
                 name: event.name,
                 slug: event.slug,
-                creditAmount: event.creditAmount,
+                creditAmount: blockValue(event, c.codeType),
                 eventDate: event.eventDate,
               }
             : null,
@@ -165,8 +207,11 @@ export const remove = mutation({
       const event = await ctx.db.get(code.eventId);
       const typeKey = code.codeType ?? "";
       if (event?.codeTypes?.includes(typeKey)) {
+        const values = { ...(event.codeTypeValues ?? {}) };
+        delete values[typeKey];
         await ctx.db.patch(code.eventId, {
           codeTypes: event.codeTypes.filter((t) => t !== typeKey),
+          codeTypeValues: values,
         });
       }
     }

--- a/convex/events.ts
+++ b/convex/events.ts
@@ -90,6 +90,7 @@ export const getBySlug = query({
       description: event.description,
       eventDate: event.eventDate,
       claimInstructions: event.claimInstructions,
+      codeTypeValues: event.codeTypeValues,
       soldOut: availableTypes.size === 0,
       // Preserve the event's stored (creation) order of code types.
       codeTypes: [
@@ -113,6 +114,7 @@ export const get = query({
       slug: event.slug,
       description: event.description,
       creditAmount: event.creditAmount,
+      codeTypeValues: event.codeTypeValues,
       eventDate: event.eventDate,
       claimInstructions: event.claimInstructions,
     };
@@ -156,7 +158,6 @@ export const create = mutation({
     name: v.string(),
     slug: v.optional(v.string()),
     description: v.optional(v.string()),
-    creditAmount: v.optional(v.string()),
     eventDate: v.optional(v.string()),
     claimInstructions: v.optional(v.string()),
   },
@@ -177,7 +178,6 @@ export const create = mutation({
       name: args.name.trim(),
       slug,
       description: args.description?.trim() || undefined,
-      creditAmount: args.creditAmount?.trim() || undefined,
       eventDate: normalizeEventDate(args.eventDate),
       claimInstructions: args.claimInstructions?.trim() || undefined,
     });
@@ -191,7 +191,6 @@ export const update = mutation({
     name: v.string(),
     slug: v.string(),
     description: v.optional(v.string()),
-    creditAmount: v.optional(v.string()),
     eventDate: v.optional(v.string()),
     claimInstructions: v.optional(v.string()),
   },
@@ -210,7 +209,6 @@ export const update = mutation({
       name: args.name.trim(),
       slug,
       description: args.description?.trim() || undefined,
-      creditAmount: args.creditAmount?.trim() || undefined,
       eventDate: normalizeEventDate(args.eventDate),
       claimInstructions: args.claimInstructions?.trim() || undefined,
     });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -18,6 +18,7 @@ export default defineSchema({
     name: v.string(),
     slug: v.string(),
     description: v.optional(v.string()),
+    // Legacy event-wide value; superseded by per-block codeTypeValues.
     creditAmount: v.optional(v.string()),
     eventDate: v.optional(v.string()),
     // Optional post-claim redemption instructions shown to attendees.
@@ -25,6 +26,9 @@ export default defineSchema({
     // Distinct code types in this event's pool ("" = unnamed), maintained by
     // codes.add/remove so availability checks don't scan the pool.
     codeTypes: v.optional(v.array(v.string())),
+    // Optional free-text value per code block, keyed by type ("" = unnamed),
+    // e.g. "100" or "Team plan". Rendered with a "$" prefix only when numeric.
+    codeTypeValues: v.optional(v.record(v.string(), v.string())),
   }).index("by_slug", ["slug"]),
 
   emails: defineTable({


### PR DESCRIPTION
## Summary
Coupon value now lives on each code block instead of the event, since blocks can represent different things ("100" credits vs "Team plan").

- Schema: `events.codeTypeValues?: Record<string, string>` (keyed by block name, `""` = unnamed). `events.creditAmount` is kept as a legacy fallback via a shared helper:
  ```ts
  blockValue(event, codeType) = event.codeTypeValues?.[codeType ?? ""] ?? event.creditAmount
  ```
- `codes.add` accepts an optional `value` for the block, new `codes.setTypeValue` edits/clears it, `codes.renameType` carries the value to the new name, and removing a block's last code drops its value.
- `claims.claim` / `claims.eligibility` / `codes.mine` now return the claimed code's block value (`creditAmount` field name unchanged for clients).
- Rendering rule everywhere (receipt, my-codes, claim-page chooser): value is free text; only values starting with a digit get a `$` prefix (`"100"` → "$100 in credits", `"$200"` and `"Team plan"` render as-is).
- Admin: event create/edit forms no longer ask for a credit amount; the value is set when adding a code block (new "Value" field) or via the block row's Edit (rename + value in one form). `events.create/update` dropped the `creditAmount` arg.
- Claim page: block chooser buttons show each block's value; instruction-gate button copy changed to "Read redemption instructions to claim."


Link to Devin session: https://app.devin.ai/sessions/009417d7b0744ba6a4a2d182a619694d
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/76" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->