### PR TITLE
Fall back to legacy event credit amount in claim chooser

### DIFF
--- a/components/ClaimPage.tsx
+++ b/components/ClaimPage.tsx
@@ -388,7 +388,9 @@ export default function ClaimPage({ slug }: { slug: string }) {
                         </legend>
                         <div className="grid grid-cols-2 gap-2">
                           {codeTypes.map((type) => {
-                            const value = event.codeTypeValues?.[type];
+                            const value =
+                              event.codeTypeValues?.[type] ??
+                              event.creditAmount;
                             return (
                               <Button
                                 key={type}

--- a/convex/events.ts
+++ b/convex/events.ts
@@ -90,6 +90,7 @@ export const getBySlug = query({
       description: event.description,
       eventDate: event.eventDate,
       claimInstructions: event.claimInstructions,
+      creditAmount: event.creditAmount,
       codeTypeValues: event.codeTypeValues,
       soldOut: availableTypes.size === 0,
       // Preserve the event's stored (creation) order of code types.


### PR DESCRIPTION
## Summary
Follow-up to #76, addressing the Devin Review finding: the claim-page code-type chooser read only `event.codeTypeValues?.[type]`, so legacy events with an event-wide `creditAmount` (and no per-block values) showed no value on the chooser buttons even though the receipt did. `events.getBySlug` now exposes `creditAmount`, and the chooser uses `codeTypeValues?.[type] ?? creditAmount` — the same fallback `blockValue` applies server-side.


Link to Devin session: https://app.devin.ai/sessions/009417d7b0744ba6a4a2d182a619694d
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/77" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->