### PR TITLE
Add admin preview of the claim flow

### DIFF
--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -2,9 +2,12 @@ import ClaimPage from "@/components/ClaimPage";
 
 export default async function EventPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ slug: string }>;
+  searchParams: Promise<{ preview?: string }>;
 }) {
   const { slug } = await params;
-  return <ClaimPage slug={slug} />;
+  const { preview } = await searchParams;
+  return <ClaimPage slug={slug} preview={preview !== undefined} />;
 }

--- a/components/ClaimPage.tsx
+++ b/components/ClaimPage.tsx
@@ -8,6 +8,7 @@ import {
   CalendarDays,
   Check,
   Copy,
+  Eye,
   LogIn,
   OctagonX,
   QrCode,
@@ -78,14 +79,20 @@ function subscribeNoop() {
   return () => {};
 }
 
-export default function ClaimPage({ slug }: { slug: string }) {
+export default function ClaimPage({
+  slug,
+  preview = false,
+}: {
+  slug: string;
+  preview?: boolean;
+}) {
   const event = useQuery(api.events.getBySlug, { slug });
   const claim = useMutation(api.claims.claim);
   const markInstructionsRead = useMutation(api.claims.markInstructionsRead);
   const { isLoading: authLoading, isAuthenticated } = useConvexAuth();
   const eligibility = useQuery(
     api.claims.eligibility,
-    isAuthenticated ? { slug } : "skip",
+    isAuthenticated ? { slug, preview: preview || undefined } : "skip",
   );
   const { user } = useUser();
   const [submitting, setSubmitting] = useState(false);
@@ -94,6 +101,7 @@ export default function ClaimPage({ slug }: { slug: string }) {
   const [showQr, setShowQr] = useState(false);
   const [selectedType, setSelectedType] = useState<string | null>(null);
   const [readOpen, setReadOpen] = useState(false);
+  const [previewRead, setPreviewRead] = useState(false);
   const origin = useSyncExternalStore(
     subscribeNoop,
     () => window.location.origin,
@@ -102,15 +110,24 @@ export default function ClaimPage({ slug }: { slug: string }) {
 
   const signedInEmail = user?.primaryEmailAddress?.emailAddress;
 
+  // Admin preview simulates a fresh eligible attendee entirely client-side:
+  // nothing is written, and no code leaves the pool.
+  const previewMode =
+    preview && eligibility?.eligible === true && "preview" in eligibility;
+
   // Events with redemption instructions require one confirmed read (stored
   // per attendee) before the claim UI unlocks; return visits skip the gate.
   const mustReadInstructions =
     !!event?.claimInstructions &&
     eligibility?.eligible === true &&
-    !eligibility.instructionsViewed;
+    (previewMode ? !previewRead : !eligibility.instructionsViewed);
 
   async function handleConfirmRead() {
     setReadOpen(false);
+    if (previewMode) {
+      setPreviewRead(true);
+      return;
+    }
     try {
       await markInstructionsRead({ slug });
     } catch {
@@ -124,6 +141,19 @@ export default function ClaimPage({ slug }: { slug: string }) {
   const mustChoose = (event?.codeTypes.length ?? 0) > 1;
 
   async function handleClaim() {
+    if (previewMode && event) {
+      const type =
+        (mustChoose && selectedType ? selectedType : event.codeTypes[0]) ||
+        undefined;
+      setResult({
+        ok: true,
+        code: "PREVIEW-CODE",
+        codeType: type,
+        alreadyClaimed: false,
+        creditAmount: event.codeTypeValues?.[type ?? ""] ?? event.creditAmount,
+      });
+      return;
+    }
     setSubmitting(true);
     setResult(null);
     try {
@@ -164,6 +194,15 @@ export default function ClaimPage({ slug }: { slug: string }) {
           className="pointer-events-none absolute inset-0 bg-dotgrid [mask-image:radial-gradient(ellipse_60%_60%_at_50%_45%,black,transparent)]"
         />
         <div className="relative w-full max-w-md">
+          {previewMode ? (
+            <Alert className="mb-4">
+              <Eye />
+              <AlertTitle>
+                Admin preview — you&apos;re seeing this as an eligible
+                attendee. No code is dispensed.
+              </AlertTitle>
+            </Alert>
+          ) : null}
           {event === undefined ? (
             <Skeleton className="h-80 rounded-xl" />
           ) : event === null ? (

--- a/components/ManageEvent.tsx
+++ b/components/ManageEvent.tsx
@@ -10,6 +10,7 @@ import {
   Ban,
   Check,
   Download,
+  Eye,
   Inbox,
   Plus,
   QrCode,
@@ -456,6 +457,20 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
             >
               <QrCode data-icon="inline-start" />
               Walk-up claim
+            </Button>
+            <Button
+              variant="outline"
+              render={
+                <Link
+                  href={`/${event.slug}?preview=1`}
+                  target="_blank"
+                  rel="noreferrer"
+                />
+              }
+              nativeButton={false}
+            >
+              <Eye data-icon="inline-start" />
+              Preview claim
             </Button>
           <Button
             variant="outline"

--- a/convex/admins.ts
+++ b/convex/admins.ts
@@ -30,6 +30,24 @@ export async function requireAdmin(ctx: QueryCtx | MutationCtx) {
 }
 
 // Global admins pass for any event; otherwise the caller's email must be on
+// the event's admin list.
+export async function isEventAdmin(
+  ctx: QueryCtx | MutationCtx,
+  eventId: Id<"events">
+) {
+  const { email, isAdmin } = await adminEmailStatus(ctx);
+  if (isAdmin) return true;
+  if (!email) return false;
+  const match = await ctx.db
+    .query("eventAdmins")
+    .withIndex("by_event_email", (q) =>
+      q.eq("eventId", eventId).eq("email", email)
+    )
+    .unique();
+  return match !== null;
+}
+
+// Global admins pass for any event; otherwise the caller's email must be on
 // the event's admin list. Returns the caller's email.
 export async function requireEventAdmin(
   ctx: QueryCtx | MutationCtx,
@@ -38,13 +56,9 @@ export async function requireEventAdmin(
   const { email, isAdmin } = await adminEmailStatus(ctx);
   if (isAdmin) return email;
   if (!email) throw new Error("Not authenticated");
-  const match = await ctx.db
-    .query("eventAdmins")
-    .withIndex("by_event_email", (q) =>
-      q.eq("eventId", eventId).eq("email", email)
-    )
-    .unique();
-  if (!match) throw new Error("Not an admin for this event");
+  if (!(await isEventAdmin(ctx, eventId))) {
+    throw new Error("Not an admin for this event");
+  }
   return email;
 }
 

--- a/convex/claims.ts
+++ b/convex/claims.ts
@@ -1,14 +1,16 @@
 import { mutation, query } from "./_generated/server";
 import { v } from "convex/values";
-import { requireEventAdmin } from "./admins";
+import { isEventAdmin, requireEventAdmin } from "./admins";
 import { logAudit } from "./auditLog";
 import { blockValue } from "./blockValues";
 import { dropTypeIfEmpty } from "./codes";
 
 // Whether the signed-in viewer is on the participant list for the event,
 // so the claim UI can hold back code options until eligibility is confirmed.
+// With `preview`, event admins see the flow as a fresh eligible attendee
+// (no claim on record, instructions unread); non-admins get normal behavior.
 export const eligibility = query({
-  args: { slug: v.string() },
+  args: { slug: v.string(), preview: v.optional(v.boolean()) },
   handler: async (ctx, args) => {
     const identity = await ctx.auth.getUserIdentity();
     if (!identity) {
@@ -31,6 +33,14 @@ export const eligibility = query({
         q.eq("eventId", event._id).eq("email", email)
       )
       .unique();
+    if (args.preview && (await isEventAdmin(ctx, event._id))) {
+      return {
+        eligible: true as const,
+        email,
+        instructionsViewed: false,
+        preview: true as const,
+      };
+    }
     if (!allowed) {
       return { eligible: false as const, reason: "not_listed" as const, email };
     }


### PR DESCRIPTION
## Summary
Event admins can now walk through the claim page as a simulated fresh attendee without touching real data. A new "Preview claim" button in ManageEvent opens `/{slug}?preview=1`.

- `claims.eligibility` takes `preview?: boolean`; when the caller is an event admin (new `isEventAdmin` helper, now also backing `requireEventAdmin`) it returns `{ eligible: true, instructionsViewed: false, preview: true }` — i.e. a fresh eligible attendee regardless of the admin's own participant/claim state. Non-admins passing `preview` get normal behavior, so this grants no new access.
- In preview mode, `ClaimPage` simulates everything client-side: the instructions gate is tracked in local state (no `markInstructionsRead` write), and "Dispense my code" produces a fake `PREVIEW-CODE` receipt with the selected block's value instead of calling `claims.claim` — no code leaves the pool and nothing is written. A banner ("Admin preview — you're seeing this as an eligible attendee. No code is dispensed.") is shown above the card.

Link to Devin session: https://app.devin.ai/sessions/009417d7b0744ba6a4a2d182a619694d
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/78" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->