### PR TITLE
Design direction: Soft Neo-Minimal

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,57 +4,61 @@
 
 @custom-variant dark (&:is(.dark *));
 
-/* Light mode (default) — "Paper": a white page field with warm off-neutrals
-   in the tints and borders rather than the pure grey axis, and ink (#22211E)
-   instead of near-black so text stays short of a harsh 19:1. Surface is a
-   neutral grey one step off white — hovers and the receipt stub read as a
-   quiet press of the field rather than a cream block. The blue accent is
-   reserved for the claim flow only. */
+/* Light mode (default) — "Soft Neo-Minimal": an airy off-white page field
+   with cool light-gray surfaces, generous rounded corners, and gently
+   diffused shadows. Cards sit as white islands on the soft field; borders
+   are whisper-light so depth comes from tone and shadow rather than lines.
+   A pastel-tinted violet accent is used sparingly. */
 :root {
-  --surface: #f6f6f6;
-  --surface-hover: #f0f0f0;
-  --border: #eae7df;
-  --border-strong: #d5cfc2;
-  --muted: #f1efe8;
-  --muted-dim: #78716a;
-  --background: #ffffff;
-  --foreground: #22211e;
+  --surface: #ffffff;
+  --surface-hover: #f3f3f6;
+  --border: #e9e9ee;
+  --border-strong: #d8d8e0;
+  --muted: #efeff3;
+  --muted-dim: #83828e;
+  --background: #f6f6f8;
+  --foreground: #2a2a33;
   --card: #ffffff;
-  --card-foreground: #22211e;
+  --card-foreground: #2a2a33;
   --popover: #ffffff;
-  --popover-foreground: #22211e;
-  --primary: #22211e;
-  --primary-foreground: #faf9f5;
-  --secondary: #f1efe8;
-  --secondary-foreground: #22211e;
-  --muted-foreground: #57534a;
-  --accent: #f1efe8;
-  --accent-foreground: #22211e;
+  --popover-foreground: #2a2a33;
+  --primary: #2a2a33;
+  --primary-foreground: #fafafc;
+  --secondary: #efeff3;
+  --secondary-foreground: #2a2a33;
+  --muted-foreground: #5d5c68;
+  --accent: #efeff3;
+  --accent-foreground: #2a2a33;
   --destructive: oklch(0.577 0.245 27.325);
   --input: oklch(0 0 0 / 8%);
-  --brand: #2200ff;
+  --brand: #6d5ae8;
   --brand-foreground: #ffffff;
-  --ring: #44403a;
-  --selection: #e6e1d5;
-  --selection-foreground: #22211e;
-  /* Soft two-layer card shadow: invisible as "shadow", read as depth. Dark
-     mode zeroes it out and relies on surface contrast instead. */
+  --ring: #6d5ae8;
+  --selection: #e6e2fa;
+  --selection-foreground: #2a2a33;
+  /* Pastel gradient stops — used sparingly for accent washes. */
+  --pastel-a: #e8e4fb;
+  --pastel-b: #fbe8ec;
+  --pastel-c: #e2f0fb;
+  /* Gently diffused, larger-radius shadow: reads as ambient light rather
+     than a hard drop. Dark mode zeroes it out and relies on surface
+     contrast instead. */
   --shadow-card:
-    0 1px 2px rgb(34 33 30 / 0.04), 0 4px 12px -2px rgb(34 33 30 / 0.04);
+    0 1px 2px rgb(42 42 51 / 0.03), 0 8px 24px -6px rgb(42 42 51 / 0.07);
   --chart-1: oklch(0.269 0 0);
   --chart-2: oklch(0.439 0 0);
   --chart-3: oklch(0.556 0 0);
   --chart-4: oklch(0.708 0 0);
   --chart-5: oklch(0.87 0 0);
-  --radius: 0.625rem;
+  --radius: 1rem;
   --sidebar: #ffffff;
-  --sidebar-foreground: #22211e;
-  --sidebar-primary: #22211e;
-  --sidebar-primary-foreground: #faf9f5;
-  --sidebar-accent: #f1efe8;
-  --sidebar-accent-foreground: #22211e;
-  --sidebar-border: #e7e3da;
-  --sidebar-ring: #78716a;
+  --sidebar-foreground: #2a2a33;
+  --sidebar-primary: #2a2a33;
+  --sidebar-primary-foreground: #fafafc;
+  --sidebar-accent: #efeff3;
+  --sidebar-accent-foreground: #2a2a33;
+  --sidebar-border: #e9e9ee;
+  --sidebar-ring: #83828e;
 }
 
 @theme inline {
@@ -141,6 +145,17 @@ input:-webkit-autofill:focus {
   text-transform: uppercase;
 }
 
+/* Pastel-tinted accent gradient: the direction's one moment of color,
+   used sparingly (hero wash, brand chips). */
+@utility bg-pastel-gradient {
+  background-image: linear-gradient(
+    120deg,
+    var(--pastel-a),
+    var(--pastel-b) 50%,
+    var(--pastel-c)
+  );
+}
+
 /* Faint dot grid backdrop for hero surfaces. */
 @utility bg-dotgrid {
   background-image: radial-gradient(var(--border) 1px, transparent 1px);
@@ -184,50 +199,53 @@ input:-webkit-autofill:focus {
   }
 }
 
-/* Dark mode — "Paper" after dark: the near-black picks up a faint cool cast
-   while the text stays warm off-white, and contrast drops from 18:1 to ~16:1
-   to stop white type haloing on OLED. */
+/* Dark mode — Soft Neo-Minimal after dark: soft graphite rather than pure
+   black, with the same calm tonal layering as light mode; shadows are
+   zeroed and depth comes from surface contrast. */
 .dark {
-  --surface: #141416;
-  --surface-hover: #1a1a1d;
-  --border: #26262a;
-  --border-strong: #3a3a40;
-  --muted: #212125;
-  --muted-dim: #7a7772;
-  --background: #0c0c0e;
-  --foreground: #e8e6e1;
-  --card: #141416;
-  --card-foreground: #e8e6e1;
-  --popover: #1a1a1d;
-  --popover-foreground: #e8e6e1;
-  --primary: #e8e6e1;
-  --primary-foreground: #0c0c0e;
-  --secondary: #2b2b30;
-  --secondary-foreground: #e8e6e1;
-  --muted-foreground: #a8a5a0;
-  --accent: #2b2b30;
-  --accent-foreground: #e8e6e1;
+  --surface: #1b1b21;
+  --surface-hover: #212127;
+  --border: #2a2a31;
+  --border-strong: #3d3d47;
+  --muted: #26262d;
+  --muted-dim: #83828e;
+  --background: #131317;
+  --foreground: #e9e8ee;
+  --card: #1b1b21;
+  --card-foreground: #e9e8ee;
+  --popover: #212127;
+  --popover-foreground: #e9e8ee;
+  --primary: #e9e8ee;
+  --primary-foreground: #131317;
+  --secondary: #2c2c34;
+  --secondary-foreground: #e9e8ee;
+  --muted-foreground: #a9a8b3;
+  --accent: #2c2c34;
+  --accent-foreground: #e9e8ee;
   --destructive: oklch(0.704 0.191 22.216);
   --input: oklch(1 0 0 / 15%);
-  --brand: #2200ff;
-  --brand-foreground: #ffffff;
-  --ring: #c4c1bb;
-  --selection: #33333a;
-  --selection-foreground: #e8e6e1;
+  --brand: #8b7cf0;
+  --brand-foreground: #131317;
+  --ring: #8b7cf0;
+  --selection: #38344d;
+  --selection-foreground: #e9e8ee;
+  --pastel-a: #2f2b45;
+  --pastel-b: #3c2e37;
+  --pastel-c: #2a3542;
   --shadow-card: 0 0 rgb(0 0 0 / 0);
   --chart-1: oklch(0.87 0 0);
   --chart-2: oklch(0.556 0 0);
   --chart-3: oklch(0.439 0 0);
   --chart-4: oklch(0.371 0 0);
   --chart-5: oklch(0.269 0 0);
-  --sidebar: #141416;
-  --sidebar-foreground: #e8e6e1;
-  --sidebar-primary: #e8e6e1;
-  --sidebar-primary-foreground: #0c0c0e;
-  --sidebar-accent: #2b2b30;
-  --sidebar-accent-foreground: #e8e6e1;
-  --sidebar-border: #26262a;
-  --sidebar-ring: #7a7772;
+  --sidebar: #1b1b21;
+  --sidebar-foreground: #e9e8ee;
+  --sidebar-primary: #e9e8ee;
+  --sidebar-primary-foreground: #131317;
+  --sidebar-accent: #2c2c34;
+  --sidebar-accent-foreground: #e9e8ee;
+  --sidebar-border: #2a2a31;
+  --sidebar-ring: #83828e;
 }
 
 @layer base {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -26,9 +26,9 @@ export const metadata: Metadata = {
 // page background automatically.
 const clerkAppearance: React.ComponentProps<typeof ClerkProvider>["appearance"] = {
   variables: {
-    colorPrimary: "#2200ff",
+    colorPrimary: "#6d5ae8",
     colorPrimaryForeground: "#ffffff",
-    borderRadius: "0.625rem",
+    borderRadius: "1rem",
     fontFamily: "var(--font-geist-sans), system-ui, sans-serif",
   },
   options: {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -72,7 +72,7 @@ function EventRow({
       <Link
         href={`/${event.slug}`}
         className={cn(
-          "group flex items-center gap-6 px-2 py-7 transition-colors hover:bg-surface focus-visible:bg-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/60 sm:gap-10 sm:px-4",
+          "group flex items-center gap-6 rounded-2xl px-3 py-7 transition-all hover:bg-surface hover:shadow-(--shadow-card) focus-visible:bg-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/60 sm:gap-10 sm:px-5",
           past && "opacity-60 transition-opacity hover:opacity-100",
         )}
       >
@@ -183,7 +183,7 @@ export default function Home() {
               by project swaps it cleanly on theme change while the copy stays
               mounted. The scene's mouse interactivity listens on window, so
               the copy sitting above it doesn't block it. */}
-          <div className="relative h-[520px] overflow-hidden bg-background dark:bg-[#131313] sm:h-[486px]">
+          <div className="relative h-[520px] overflow-hidden bg-background dark:bg-[#131317] sm:h-[486px]">
             {heroProjectId ? (
               <div className="absolute inset-0" aria-hidden>
                 {/* Dev fetches fresh scene data on every load; deploys pin
@@ -199,10 +199,14 @@ export default function Home() {
                 />
               </div>
             ) : null}
-            {/* Soft scrim keeps the headline legible over the scenes; tune
-                or remove once the look settles. */}
+            {/* Soft scrim keeps the headline legible over the scenes; a
+                whisper of the pastel gradient warms the wash. */}
             <div
               className="absolute inset-0 bg-white/20 dark:bg-black/20"
+              aria-hidden
+            />
+            <div
+              className="bg-pastel-gradient absolute inset-0 opacity-30 mix-blend-soft-light"
               aria-hidden
             />
             {heroCopy}

--- a/components/AdminNav.tsx
+++ b/components/AdminNav.tsx
@@ -39,7 +39,7 @@ export default function AdminNav() {
             href={link.href}
             aria-current={active ? "page" : undefined}
             className={cn(
-              "rounded-md px-2.5 py-1.5 text-sm whitespace-nowrap transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60 sm:px-3",
+              "rounded-full px-2.5 py-1.5 text-sm whitespace-nowrap transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60 sm:px-3",
               active
                 ? "bg-muted text-foreground"
                 : "text-muted-foreground hover:text-foreground"
@@ -52,7 +52,7 @@ export default function AdminNav() {
       {/* Sits where the Admins link will land, so the nav doesn't widen
           (and push the user button) once `access` resolves. */}
       {isAuthenticated && access === undefined ? (
-        <Skeleton className="h-8 w-[4.5rem] rounded-md" />
+        <Skeleton className="h-8 w-[4.5rem] rounded-full" />
       ) : null}
     </nav>
   );

--- a/components/ClaimPage.tsx
+++ b/components/ClaimPage.tsx
@@ -589,7 +589,7 @@ function QrPanel({
         </div>
       </CardHeader>
       <CardContent className="flex flex-1 flex-col items-center justify-center gap-5 py-(--card-spacing)">
-        <div className="rounded-lg border border-border bg-background p-4 text-foreground">
+        <div className="rounded-2xl border border-border bg-background p-4 text-foreground">
           {url ? (
             <QRCodeSVG
               value={url}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/20 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 items-center justify-center rounded-full border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/20 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
@@ -23,15 +23,13 @@ const buttonVariants = cva(
       },
       size: {
         default:
-          "h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
-        xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
-        sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
-        lg: "h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+          "h-8 gap-1.5 px-3.5 has-data-[icon=inline-end]:pr-2.5 has-data-[icon=inline-start]:pl-2.5",
+        xs: "h-6 gap-1 px-2.5 text-xs has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 [&_svg:not([class*='size-'])]:size-3",
+        sm: "h-7 gap-1 px-3 text-[0.8rem] has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 [&_svg:not([class*='size-'])]:size-3.5",
+        lg: "h-9 gap-1.5 px-4 has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3",
         icon: "size-8",
-        "icon-xs":
-          "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
-        "icon-sm":
-          "size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg",
+        "icon-xs": "size-6 [&_svg:not([class*='size-'])]:size-3",
+        "icon-sm": "size-7",
         "icon-lg": "size-9",
       },
     },

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -12,7 +12,7 @@ function Card({
       data-slot="card"
       data-size={size}
       className={cn(
-        "group/card flex flex-col gap-(--card-spacing) overflow-hidden rounded-xl bg-card py-(--card-spacing) text-sm text-card-foreground shadow-(--shadow-card) ring-1 ring-foreground/10 [--card-spacing:--spacing(4)] has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:[--card-spacing:--spacing(3)] data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
+        "group/card flex flex-col gap-(--card-spacing) overflow-hidden rounded-2xl bg-card py-(--card-spacing) text-sm text-card-foreground shadow-(--shadow-card) ring-1 ring-foreground/5 [--card-spacing:--spacing(4)] has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:[--card-spacing:--spacing(3)] data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-2xl *:[img:last-child]:rounded-b-2xl",
         className
       )}
       {...props}
@@ -25,7 +25,7 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card-header"
       className={cn(
-        "group/card-header @container/card-header grid auto-rows-min items-start gap-1 rounded-t-xl px-(--card-spacing) has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-(--card-spacing)",
+        "group/card-header @container/card-header grid auto-rows-min items-start gap-1 rounded-t-2xl px-(--card-spacing) has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-(--card-spacing)",
         className
       )}
       {...props}
@@ -84,7 +84,7 @@ function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card-footer"
       className={cn(
-        "flex items-center rounded-b-xl border-t bg-muted/50 p-(--card-spacing)",
+        "flex items-center rounded-b-2xl border-t bg-muted/50 p-(--card-spacing)",
         className
       )}
       {...props}

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -9,7 +9,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-[color,background-color,border-color,box-shadow] outline-none scheme-light file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-dim hover:border-border-strong focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/20 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:scheme-dark dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        "h-8 w-full min-w-0 rounded-full border border-input bg-surface px-3.5 py-1 text-base transition-[color,background-color,border-color,box-shadow] outline-none scheme-light file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-dim hover:border-border-strong focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/20 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:scheme-dark dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
         className
       )}
       {...props}

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -7,7 +7,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
     <textarea
       data-slot="textarea"
       className={cn(
-        "flex field-sizing-content min-h-16 w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-base transition-[color,background-color,border-color,box-shadow] outline-none scheme-light placeholder:text-muted-dim hover:border-border-strong focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/20 disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:scheme-dark dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        "flex field-sizing-content min-h-16 w-full rounded-2xl border border-input bg-surface px-3.5 py-2 text-base transition-[color,background-color,border-color,box-shadow] outline-none scheme-light placeholder:text-muted-dim hover:border-border-strong focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/20 disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:scheme-dark dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
Explores a "Soft Neo-Minimal" design direction: airy modern minimalism — soft off-white page field with white card surfaces, larger rounded corners, gently diffused shadows, pill-shaped controls, and a pastel-tinted accent used sparingly.

Almost everything flows from token changes in `globals.css`:
- Light: `--background: #f6f6f8` (off-white field), `--surface/--card: #ffffff`, cool light-gray borders, `--radius: 0.625rem → 1rem`, softer larger-radius `--shadow-card`, brand/ring shift from `#2200ff` to soft violet `#6d5ae8`
- Dark: soft graphite (`#131317` base) instead of near-black, matching violet accent `#8b7cf0`
- New `--pastel-a/b/c` stops + `bg-pastel-gradient` utility (lavender→blush→sky), used as a whisper-light hero wash on the landing page

Component-level:
- `button.tsx`: all sizes become pills (`rounded-full`), slightly wider padding
- `input.tsx`/`textarea.tsx`: pill/rounded-2xl fields on `bg-surface`
- `card.tsx`: `rounded-xl → rounded-2xl`, `ring-foreground/10 → /5`
- `AdminNav`: pill nav links; Clerk appearance updated to match (violet primary, 1rem radius)
- Landing event rows: rounded hover cards with the soft shadow instead of flat strip hover

Landing, claim, and admin UIs are all token-driven, so they pick the direction up consistently.

Link to Devin session: https://app.devin.ai/sessions/9b52ece50c044bdb8b121bc0b663345b
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/79" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->