### PR TITLE
Editorial Luxe design direction

### DIFF
--- a/app/admin/admins/page.tsx
+++ b/app/admin/admins/page.tsx
@@ -88,7 +88,7 @@ export default function AdminsPage() {
           <span className="inline-block size-1.5 rounded-full bg-border-strong" />
           Access control
         </p>
-        <h1 className="mt-3 font-heading text-3xl font-semibold tracking-[-0.02em]">
+        <h1 className="mt-3 font-heading text-4xl font-medium tracking-[-0.01em]">
           Admins
         </h1>
         <p className="mt-2 text-sm text-muted-foreground">

--- a/app/admin/blacklist/page.tsx
+++ b/app/admin/blacklist/page.tsx
@@ -86,7 +86,7 @@ export default function BlacklistPage() {
           <span className="inline-block size-1.5 rounded-full bg-border-strong" />
           Access control
         </p>
-        <h1 className="mt-3 font-heading text-3xl font-semibold tracking-[-0.02em]">
+        <h1 className="mt-3 font-heading text-4xl font-medium tracking-[-0.01em]">
           Blacklist
         </h1>
         <p className="mt-2 text-sm text-muted-foreground">

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -125,7 +125,7 @@ export default function AdminDashboard() {
             <span className="inline-block size-1.5 rounded-full bg-border-strong" />
             Control room
           </p>
-          <h1 className="mt-3 font-heading text-3xl font-semibold tracking-[-0.02em]">
+          <h1 className="mt-3 font-heading text-4xl font-medium tracking-[-0.01em]">
             Events
           </h1>
           <p className="mt-2 text-sm text-muted-foreground">
@@ -160,7 +160,7 @@ export default function AdminDashboard() {
       ) : (
         <>
           <div className="flex items-baseline justify-between">
-            <h2 className="text-sm font-medium text-muted-foreground">
+            <h2 className="eyebrow text-muted-foreground">
               Active events
             </h2>
             <span className="font-mono text-xs text-muted-dim tabular-nums">
@@ -181,7 +181,7 @@ export default function AdminDashboard() {
           {past.length > 0 ? (
             <>
               <div className="mt-12 flex items-baseline justify-between">
-                <h2 className="text-sm font-medium text-muted-foreground">
+                <h2 className="eyebrow text-muted-foreground">
                   Past events
                 </h2>
                 <span className="font-mono text-xs text-muted-dim tabular-nums">

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,39 +4,38 @@
 
 @custom-variant dark (&:is(.dark *));
 
-/* Light mode (default) — "Paper": a white page field with warm off-neutrals
-   in the tints and borders rather than the pure grey axis, and ink (#22211E)
-   instead of near-black so text stays short of a harsh 19:1. Surface is a
-   neutral grey one step off white — hovers and the receipt stub read as a
-   quiet press of the field rather than a cream block. The blue accent is
-   reserved for the claim flow only. */
+/* Light mode (default) — "Editorial Luxe": a muted ivory page field with
+   charcoal ink, thin hairline rules in warm greige, and a single restrained
+   accent — a deep sienna reserved for the claim flow. Surfaces sit a quiet
+   half-step off the ivory so hovers read as a press of the paper rather
+   than a colored block. */
 :root {
-  --surface: #f6f6f6;
-  --surface-hover: #f0f0f0;
-  --border: #eae7df;
-  --border-strong: #d5cfc2;
-  --muted: #f1efe8;
-  --muted-dim: #78716a;
-  --background: #ffffff;
-  --foreground: #22211e;
-  --card: #ffffff;
-  --card-foreground: #22211e;
-  --popover: #ffffff;
-  --popover-foreground: #22211e;
-  --primary: #22211e;
-  --primary-foreground: #faf9f5;
-  --secondary: #f1efe8;
-  --secondary-foreground: #22211e;
-  --muted-foreground: #57534a;
-  --accent: #f1efe8;
-  --accent-foreground: #22211e;
+  --surface: #f3f0e8;
+  --surface-hover: #edeade;
+  --border: #e5e0d2;
+  --border-strong: #cfc7b4;
+  --muted: #efebe0;
+  --muted-dim: #857e70;
+  --background: #f9f7f1;
+  --foreground: #26241f;
+  --card: #fdfcf8;
+  --card-foreground: #26241f;
+  --popover: #fdfcf8;
+  --popover-foreground: #26241f;
+  --primary: #26241f;
+  --primary-foreground: #f9f7f1;
+  --secondary: #efebe0;
+  --secondary-foreground: #26241f;
+  --muted-foreground: #5c564a;
+  --accent: #efebe0;
+  --accent-foreground: #26241f;
   --destructive: oklch(0.577 0.245 27.325);
   --input: oklch(0 0 0 / 8%);
-  --brand: #2200ff;
-  --brand-foreground: #ffffff;
-  --ring: #44403a;
-  --selection: #e6e1d5;
-  --selection-foreground: #22211e;
+  --brand: #8a3b2e;
+  --brand-foreground: #fdfcf8;
+  --ring: #46413a;
+  --selection: #e8e2d2;
+  --selection-foreground: #26241f;
   /* Soft two-layer card shadow: invisible as "shadow", read as depth. Dark
      mode zeroes it out and relies on surface contrast instead. */
   --shadow-card:
@@ -46,15 +45,15 @@
   --chart-3: oklch(0.556 0 0);
   --chart-4: oklch(0.708 0 0);
   --chart-5: oklch(0.87 0 0);
-  --radius: 0.625rem;
-  --sidebar: #ffffff;
-  --sidebar-foreground: #22211e;
-  --sidebar-primary: #22211e;
-  --sidebar-primary-foreground: #faf9f5;
-  --sidebar-accent: #f1efe8;
-  --sidebar-accent-foreground: #22211e;
-  --sidebar-border: #e7e3da;
-  --sidebar-ring: #78716a;
+  --radius: 0.25rem;
+  --sidebar: #fdfcf8;
+  --sidebar-foreground: #26241f;
+  --sidebar-primary: #26241f;
+  --sidebar-primary-foreground: #f9f7f1;
+  --sidebar-accent: #efebe0;
+  --sidebar-accent-foreground: #26241f;
+  --sidebar-border: #e5e0d2;
+  --sidebar-ring: #857e70;
 }
 
 @theme inline {
@@ -68,9 +67,10 @@
   --color-muted-dim: var(--muted-dim);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
-  /* Headings share the body face — hierarchy comes from weight, size, and
-     tracking rather than a second display family. */
-  --font-heading: var(--font-geist-sans);
+  --font-serif: var(--font-source-serif);
+  /* Headings set in the editorial serif; hierarchy comes from the contrast
+     between the serif display face and the sans body. */
+  --font-heading: var(--font-source-serif);
   --color-brand: var(--brand);
   --color-brand-foreground: var(--brand-foreground);
   --color-sidebar-ring: var(--sidebar-ring);
@@ -132,13 +132,20 @@ input:-webkit-autofill:focus {
   transition: background-color 9999999s ease-in-out 0s;
 }
 
-/* Micro-label: the recurring uppercase mono eyebrow used across the app. */
+/* Micro-label: the recurring uppercase letterspaced eyebrow used across the
+   app — set in the sans, tracked wide, in the editorial manner. */
 @utility eyebrow {
-  font-family: var(--font-mono), monospace;
+  font-family: var(--font-sans), system-ui, sans-serif;
   font-size: 10px;
   font-weight: 500;
-  letter-spacing: 0.18em;
+  letter-spacing: 0.24em;
   text-transform: uppercase;
+}
+
+/* Hairline rule: a half-pixel-feeling horizontal rule for editorial
+   section breaks. */
+@utility rule-hairline {
+  border-top: 1px solid var(--border);
 }
 
 /* Faint dot grid backdrop for hero surfaces. */
@@ -184,50 +191,50 @@ input:-webkit-autofill:focus {
   }
 }
 
-/* Dark mode — "Paper" after dark: the near-black picks up a faint cool cast
-   while the text stays warm off-white, and contrast drops from 18:1 to ~16:1
-   to stop white type haloing on OLED. */
+/* Dark mode — "Editorial Luxe" after dark: warm charcoal rather than cool
+   near-black, ivory type, and the same restrained sienna accent lifted a
+   step for contrast on the dark ground. */
 .dark {
-  --surface: #141416;
-  --surface-hover: #1a1a1d;
-  --border: #26262a;
-  --border-strong: #3a3a40;
-  --muted: #212125;
-  --muted-dim: #7a7772;
-  --background: #0c0c0e;
-  --foreground: #e8e6e1;
-  --card: #141416;
-  --card-foreground: #e8e6e1;
-  --popover: #1a1a1d;
-  --popover-foreground: #e8e6e1;
-  --primary: #e8e6e1;
-  --primary-foreground: #0c0c0e;
-  --secondary: #2b2b30;
-  --secondary-foreground: #e8e6e1;
-  --muted-foreground: #a8a5a0;
-  --accent: #2b2b30;
-  --accent-foreground: #e8e6e1;
+  --surface: #201e1a;
+  --surface-hover: #262420;
+  --border: #2e2b26;
+  --border-strong: #44403a;
+  --muted: #282520;
+  --muted-dim: #8a8478;
+  --background: #171512;
+  --foreground: #ece7dc;
+  --card: #201e1a;
+  --card-foreground: #ece7dc;
+  --popover: #262420;
+  --popover-foreground: #ece7dc;
+  --primary: #ece7dc;
+  --primary-foreground: #171512;
+  --secondary: #322f29;
+  --secondary-foreground: #ece7dc;
+  --muted-foreground: #aca69a;
+  --accent: #322f29;
+  --accent-foreground: #ece7dc;
   --destructive: oklch(0.704 0.191 22.216);
   --input: oklch(1 0 0 / 15%);
-  --brand: #2200ff;
-  --brand-foreground: #ffffff;
-  --ring: #c4c1bb;
-  --selection: #33333a;
-  --selection-foreground: #e8e6e1;
+  --brand: #b0553f;
+  --brand-foreground: #fdfcf8;
+  --ring: #c8c2b4;
+  --selection: #3a362e;
+  --selection-foreground: #ece7dc;
   --shadow-card: 0 0 rgb(0 0 0 / 0);
   --chart-1: oklch(0.87 0 0);
   --chart-2: oklch(0.556 0 0);
   --chart-3: oklch(0.439 0 0);
   --chart-4: oklch(0.371 0 0);
   --chart-5: oklch(0.269 0 0);
-  --sidebar: #141416;
-  --sidebar-foreground: #e8e6e1;
-  --sidebar-primary: #e8e6e1;
-  --sidebar-primary-foreground: #0c0c0e;
-  --sidebar-accent: #2b2b30;
-  --sidebar-accent-foreground: #e8e6e1;
-  --sidebar-border: #26262a;
-  --sidebar-ring: #7a7772;
+  --sidebar: #201e1a;
+  --sidebar-foreground: #ece7dc;
+  --sidebar-primary: #ece7dc;
+  --sidebar-primary-foreground: #171512;
+  --sidebar-accent: #322f29;
+  --sidebar-accent-foreground: #ece7dc;
+  --sidebar-border: #2e2b26;
+  --sidebar-ring: #8a8478;
 }
 
 @layer base {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Geist, Geist_Mono, Source_Serif_4 } from "next/font/google";
 import { ClerkProvider } from "@clerk/nextjs";
 import ConvexClientProvider from "@/components/ConvexClientProvider";
 import { ThemeProvider } from "@/components/ThemeProvider";
@@ -17,6 +17,14 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
+// Editorial serif for headings and display type; the sans stays for body
+// and UI chrome.
+const sourceSerif = Source_Serif_4({
+  variable: "--font-source-serif",
+  subsets: ["latin"],
+  style: ["normal", "italic"],
+});
+
 export const metadata: Metadata = {
   title: getAppName(),
   description: "Claim credits for hackathons, conferences, and meetups.",
@@ -26,7 +34,7 @@ export const metadata: Metadata = {
 // page background automatically.
 const clerkAppearance: React.ComponentProps<typeof ClerkProvider>["appearance"] = {
   variables: {
-    colorPrimary: "#2200ff",
+    colorPrimary: "#8a3b2e",
     colorPrimaryForeground: "#ffffff",
     borderRadius: "0.625rem",
     fontFamily: "var(--font-geist-sans), system-ui, sans-serif",
@@ -49,7 +57,7 @@ export default function RootLayout({
     <ClerkProvider appearance={clerkAppearance}>
       <html
         lang="en"
-        className={`${geistSans.variable} ${geistMono.variable} h-full overscroll-none antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} ${sourceSerif.variable} h-full overscroll-none antialiased`}
         suppressHydrationWarning
       >
         <body className="flex min-h-full flex-col overscroll-none">

--- a/app/my-codes/page.tsx
+++ b/app/my-codes/page.tsx
@@ -111,7 +111,7 @@ export default function MyCodesPage() {
       <main id="main-content" className="flex-1">
         <section className="mx-auto w-full max-w-5xl px-4 py-12 sm:px-6 sm:py-14">
           <div className="mb-10">
-            <h1 className="font-heading text-3xl font-semibold tracking-[-0.02em]">
+            <h1 className="font-heading text-3xl font-medium tracking-[-0.01em]">
               My codes
             </h1>
             <p className="mt-2 text-sm text-muted-foreground">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,13 +1,10 @@
 "use client";
 
-import { useSyncExternalStore } from "react";
 import Link from "next/link";
 import { ArrowUpRight, BadgeCheck, Ticket } from "lucide-react";
-import { useTheme } from "next-themes";
 import { useConvexAuth, useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { daysUntilEvent, formatEventDate } from "@/lib/event-date";
-import UnicornSceneEmbed from "@/components/UnicornSceneEmbed";
 import SiteHeader from "@/components/SiteHeader";
 import SiteFooter from "@/components/SiteFooter";
 import { Badge } from "@/components/ui/badge";
@@ -20,30 +17,6 @@ import {
   EmptyDescription,
 } from "@/components/ui/empty";
 import { cn } from "@/lib/utils";
-
-// The hero background is a theme-paired Unicorn Studio WebGL scene
-// (experiment). A Unicorn project publishes exactly one authored design and
-// the SDK has no color-scheme awareness, so a light-authored project shows
-// its light design in dark mode too — each theme therefore needs its own
-// project ID here.
-const UNICORN_PROJECTS = {
-  light: "wEz2vCJgsynwCYSb3HgR",
-  dark: "aEdLurlqLEmU1DUjAaUz",
-} as const;
-
-// Bump this whenever a scene is republished in Unicorn Studio. Deployed
-// builds read scene data through Unicorn's CDN, which caches for months and
-// doesn't reliably purge on republish; the update param below is part of the
-// CDN cache key, so bumping the version makes deploys fetch the new design.
-// Dev skips the param (and the CDN): without it the SDK cache-busts every
-// load, so republishes show up on a plain refresh.
-const UNICORN_CACHE_VERSION = 2;
-
-const isProdBuild = process.env.NODE_ENV === "production";
-
-// Stable no-op subscription for the hydration gate below: the snapshot never
-// changes on the client, we only care that the server snapshot is false.
-const emptySubscribe = () => () => {};
 
 interface EventItem {
   _id: string;
@@ -117,23 +90,6 @@ export default function Home() {
     mine?.map((item) => item.event?._id).filter(Boolean) ?? [],
   );
 
-  // The scene choice needs JS (the server doesn't know the theme, while the
-  // hydration render already does), so gate it behind hydration to keep both
-  // trees identical; the copy and scrim flip with pure dark: variants and
-  // render correctly from the first paint. Until hydration the plain
-  // theme-tinted shell stands in for both themes.
-  const { resolvedTheme } = useTheme();
-  const hydrated = useSyncExternalStore(
-    emptySubscribe,
-    () => true,
-    () => false,
-  );
-  const heroProjectId = hydrated
-    ? resolvedTheme === "light"
-      ? UNICORN_PROJECTS.light
-      : UNICORN_PROJECTS.dark
-    : undefined;
-
   // Dated events that have passed sink into their own dimmed group; undated
   // events are treated as current. Active events order soonest-first, with
   // undated ones following in their arrival (newest created) order; past
@@ -152,66 +108,37 @@ export default function Home() {
     events?.filter((e) => e.eventDate && daysUntilEvent(e.eventDate) < 0) ?? []
   ).sort((a, b) => (b.eventDate ?? "").localeCompare(a.eventDate ?? ""));
 
-  // Shared hero copy: crisp DOM stacked above the theme's scene. pt-15.25
-  // offsets the translucent header bar the hero slides under, keeping the
-  // copy centered in the visible area.
-  const heroCopy = (
-    <div className="relative mx-auto flex h-full w-full max-w-5xl flex-col justify-center px-4 pt-15.25 sm:px-6">
-      <p className="eyebrow animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 text-black/60 dark:text-white/60 motion-reduce:animate-none">
-        Event credit distribution
-      </p>
-      <h1 className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-100 mt-6 max-w-2xl font-heading text-5xl leading-[0.95] font-semibold tracking-[-0.03em] text-balance text-black dark:text-white motion-reduce:animate-none sm:text-7xl">
-        Claim your credits.
-      </h1>
-      <p className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-200 mt-6 max-w-md text-sm leading-relaxed text-black/70 dark:text-white/70 motion-reduce:animate-none">
-        Select your event, enter the email you registered with, and your credit
-        code is dispensed on the spot.
-      </p>
-    </div>
-  );
-
   return (
     <div className="flex min-h-screen flex-col">
       <SiteHeader />
       <main id="main-content" className="flex-1">
-        <section className="-mt-15.25 border-b border-border/65">
-          {/* The section pulls up behind the translucent header bar
-              (-mt-15.25) so the background runs to the top of the page; the
-              hero is 61px taller to compensate and the scene shows through
-              the bar's frosted fill. The theme's Unicorn Studio scene renders
-              behind the copy and a soft theme-matched scrim; keying the scene
-              by project swaps it cleanly on theme change while the copy stays
-              mounted. The scene's mouse interactivity listens on window, so
-              the copy sitting above it doesn't block it. */}
-          <div className="relative h-[520px] overflow-hidden bg-background dark:bg-[#131313] sm:h-[486px]">
-            {heroProjectId ? (
-              <div className="absolute inset-0" aria-hidden>
-                {/* Dev fetches fresh scene data on every load; deploys pin
-                    the CDN to UNICORN_CACHE_VERSION — see the constant. */}
-                <UnicornSceneEmbed
-                  key={heroProjectId}
-                  projectId={
-                    isProdBuild
-                      ? `${heroProjectId}?update=${UNICORN_CACHE_VERSION}`
-                      : heroProjectId
-                  }
-                  production={isProdBuild}
-                />
-              </div>
-            ) : null}
-            {/* Soft scrim keeps the headline legible over the scenes; tune
-                or remove once the look settles. */}
-            <div
-              className="absolute inset-0 bg-white/20 dark:bg-black/20"
-              aria-hidden
-            />
-            {heroCopy}
+        {/* Editorial masthead hero: pure typography on the ivory field — a
+            wide-tracked eyebrow, an oversized serif headline with an italic
+            turn, a short serif standfirst, and hairline rules above and
+            below in the manner of a magazine opener. */}
+        <section className="border-b border-border">
+          <div className="mx-auto w-full max-w-5xl px-4 pt-20 pb-16 sm:px-6 sm:pt-32 sm:pb-24">
+            <div className="rule-hairline flex items-baseline justify-between pt-4">
+              <p className="eyebrow animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 text-muted-foreground motion-reduce:animate-none">
+                Event credit distribution
+              </p>
+              <span className="hidden font-mono text-[10px] tracking-[0.18em] text-muted-dim uppercase sm:inline">
+                No. 01
+              </span>
+            </div>
+            <h1 className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-100 mt-10 max-w-3xl font-heading text-6xl leading-[1.02] font-medium tracking-[-0.015em] text-balance motion-reduce:animate-none sm:text-8xl">
+              Claim your <em className="italic">credits</em>.
+            </h1>
+            <p className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-200 mt-8 max-w-md font-heading text-lg leading-relaxed text-muted-foreground motion-reduce:animate-none">
+              Select your event, sign in with the email you registered with,
+              and your credit code is dispensed on the spot.
+            </p>
           </div>
         </section>
 
         <section className="mx-auto w-full max-w-5xl px-4 py-14 sm:px-6 sm:py-20">
           <div className="flex items-baseline justify-between">
-            <h2 className="text-sm font-medium text-muted-foreground">
+            <h2 className="eyebrow text-muted-foreground">
               Active events
             </h2>
             {events ? (
@@ -274,7 +201,7 @@ export default function Home() {
               {past.length > 0 ? (
                 <>
                   <div className="mt-14 flex items-baseline justify-between">
-                    <h2 className="text-sm font-medium text-muted-foreground">
+                    <h2 className="eyebrow text-muted-foreground">
                       Past events
                     </h2>
                     <span className="font-mono text-xs text-muted-dim tabular-nums">

--- a/app/sign-in/[[...sign-in]]/page.tsx
+++ b/app/sign-in/[[...sign-in]]/page.tsx
@@ -16,7 +16,7 @@ export default function SignInPage() {
         />
         <div className="relative flex flex-col items-center gap-3 text-center">
           <p className="eyebrow text-muted-foreground">Operator access</p>
-          <h1 className="font-heading text-3xl font-semibold tracking-[-0.02em]">
+          <h1 className="font-heading text-3xl font-medium tracking-[-0.01em]">
             Sign in to the control room
           </h1>
         </div>

--- a/components/ClaimPage.tsx
+++ b/components/ClaimPage.tsx
@@ -253,7 +253,7 @@ export default function ClaimPage({
             >
               <CardHeader className="gap-4 pt-(--card-spacing)">
                 <div className="flex items-start justify-between gap-3">
-                  <CardTitle className="font-heading text-3xl font-semibold tracking-[-0.02em] text-balance">
+                  <CardTitle className="font-heading text-3xl font-medium tracking-[-0.01em] text-balance">
                     {event.name}
                   </CardTitle>
                   <Button
@@ -572,7 +572,7 @@ function QrPanel({
         <div className="flex items-start justify-between gap-3">
           <div className="flex flex-col gap-2">
             <span className="eyebrow text-muted-foreground">Scan to claim</span>
-            <CardTitle className="font-heading text-2xl font-semibold tracking-[-0.02em] text-balance">
+            <CardTitle className="font-heading text-2xl font-medium tracking-[-0.01em] text-balance">
               {eventName}
             </CardTitle>
           </div>

--- a/components/HeaderBar.tsx
+++ b/components/HeaderBar.tsx
@@ -1,14 +1,13 @@
-// Site-wide sticky nav bar: a frosted, borderless strip that's present from
-// first paint. Page content (like the home hero scene) runs underneath and
-// shows through the half-strength fill and blur — no scroll state, so it
-// renders on the server with zero client JS.
+// Site-wide sticky nav bar: a frosted strip finished with a hairline rule,
+// present from first paint — no scroll state, so it renders on the server
+// with zero client JS.
 export default function HeaderBar({
   children,
 }: {
   children: React.ReactNode;
 }) {
   return (
-    <header className="sticky top-0 z-40 bg-background/30 backdrop-blur-md">
+    <header className="sticky top-0 z-40 border-b border-border bg-background/75 backdrop-blur-md">
       {children}
     </header>
   );

--- a/components/ManageEvent.tsx
+++ b/components/ManageEvent.tsx
@@ -447,7 +447,7 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
           All events
         </Button>
         <div className="mt-3 flex flex-wrap items-end justify-between gap-4">
-          <h1 className="font-heading text-3xl font-semibold tracking-[-0.02em]">
+          <h1 className="font-heading text-3xl font-medium tracking-[-0.01em]">
             {event.name}
           </h1>
           <div className="flex flex-wrap items-center gap-2">
@@ -507,7 +507,7 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
             ) : null}
           </div>
           {codes ? (
-            <div className="font-heading text-3xl font-semibold tracking-tight tabular-nums">
+            <div className="font-heading text-3xl font-medium tracking-tight tabular-nums">
               {claimedDisplay}
               <span className="text-base text-muted-dim"> / {codeCount}</span>
             </div>
@@ -1179,7 +1179,7 @@ function StatCard({ label, value }: { label: string; value?: number }) {
       {value === undefined ? (
         <Skeleton className="h-9 w-14 rounded-md" />
       ) : (
-        <span className="font-heading text-3xl font-semibold tracking-tight tabular-nums">
+        <span className="font-heading text-3xl font-medium tracking-tight tabular-nums">
           {display}
         </span>
       )}

--- a/components/SiteHeader.tsx
+++ b/components/SiteHeader.tsx
@@ -14,7 +14,7 @@ export default function SiteHeader() {
           className="group flex min-w-0 items-center gap-2.5 rounded-sm focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ring"
         >
           <BrandMark className="size-5 shrink-0 transition-transform duration-300 group-hover:-rotate-6" />
-          <span className="max-w-36 truncate text-sm font-medium tracking-tight text-foreground transition-colors group-hover:text-muted-foreground sm:max-w-none">
+          <span className="max-w-36 truncate font-heading text-base font-medium tracking-tight text-foreground transition-colors group-hover:text-muted-foreground sm:max-w-none">
             {getAppName()}
           </span>
         </Link>

--- a/components/WalkUpClaim.tsx
+++ b/components/WalkUpClaim.tsx
@@ -115,7 +115,7 @@ export default function WalkUpClaim({ id }: { id: Id<"events"> }) {
           <ArrowLeft data-icon="inline-start" />
           Manage event
         </Button>
-        <h1 className="mt-3 font-heading text-3xl font-semibold tracking-[-0.02em]">
+        <h1 className="mt-3 font-heading text-3xl font-medium tracking-[-0.01em]">
           {event.name}
         </h1>
       </div>
@@ -135,7 +135,7 @@ export default function WalkUpClaim({ id }: { id: Id<"events"> }) {
               <span className="eyebrow text-muted-foreground">
                 Walk-up claim
               </span>
-              <CardTitle className="font-heading text-2xl font-semibold tracking-[-0.02em]">
+              <CardTitle className="font-heading text-2xl font-medium tracking-[-0.01em]">
                 Add an attendee
               </CardTitle>
               <CardDescription className="text-sm leading-relaxed">
@@ -186,7 +186,7 @@ export default function WalkUpClaim({ id }: { id: Id<"events"> }) {
               <span className="eyebrow text-muted-foreground">
                 Scan to claim
               </span>
-              <CardTitle className="font-heading text-2xl font-semibold tracking-[-0.02em] text-balance">
+              <CardTitle className="font-heading text-2xl font-medium tracking-[-0.01em] text-balance">
                 {event.name}
               </CardTitle>
               {lastAdded ? (


### PR DESCRIPTION
## Summary
Design-direction exploration: restyles the landing page, claim page, and admin UI in an "Editorial Luxe" aesthetic — magazine-inspired, with generous whitespace, a strong serif/sans typographic hierarchy, thin hairline rules, and a muted ivory/charcoal palette with a single restrained sienna accent.

- `globals.css`: palette moves from white/blue "Paper" to ivory (`#f9f7f1`) / charcoal (`#26241f`) with sienna accent (`--brand: #8a3b2e`, lifted to `#b0553f` in dark mode); dark mode becomes warm charcoal instead of cool near-black; `--radius` drops to `0.25rem`; `--font-heading` now maps to a new `--font-source-serif` (Source Serif 4, loaded in `layout.tsx` with italics); the `eyebrow` utility switches from mono to wide-tracked sans; new `rule-hairline` utility.
- Landing hero: replaces the Unicorn Studio WebGL scene with a pure typographic editorial masthead (hairline-ruled eyebrow row, oversized serif headline with an italic turn, serif standfirst). `UnicornSceneEmbed` component remains in the repo but is no longer used on the landing page.
- `HeaderBar` gains a hairline bottom rule; brand name in `SiteHeader` set in the serif.
- Headings across claim/admin/my-codes[REDACTED SECRET] shift from `font-semibold tracking-[-0.02em]` to `font-medium tracking-[-0.01em]` (serifs carry the weight); section labels ("Active events"/"Past events") become eyebrows.
- Clerk `colorPrimary` updated to match the accent.

All hierarchy tokens (`--font-heading`, `--font-serif`) are centralized so follow-up font-stack variants only need to swap the loaded fonts.

Sibling PRs explore different font stacks on top of this branch.

Link to Devin session: https://app.devin.ai/sessions/a778be3283054ea88826171af1f95849
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/80" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->