### PR TITLE
Precision Mono-Tech design direction

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -122,7 +122,7 @@ export default function AdminDashboard() {
       <div className="mb-10 flex flex-col items-start gap-5 sm:flex-row sm:items-end sm:justify-between sm:gap-6">
         <div>
           <p className="eyebrow flex items-center gap-2 text-muted-foreground">
-            <span className="inline-block size-1.5 rounded-full bg-border-strong" />
+            <span className="animate-brand-pulse inline-block size-1.5 rounded-full bg-brand motion-reduce:animate-none" />
             Control room
           </p>
           <h1 className="mt-3 font-heading text-3xl font-semibold tracking-[-0.02em]">
@@ -160,7 +160,7 @@ export default function AdminDashboard() {
       ) : (
         <>
           <div className="flex items-baseline justify-between">
-            <h2 className="text-sm font-medium text-muted-foreground">
+            <h2 className="eyebrow text-muted-foreground">
               Active events
             </h2>
             <span className="font-mono text-xs text-muted-dim tabular-nums">
@@ -181,7 +181,7 @@ export default function AdminDashboard() {
           {past.length > 0 ? (
             <>
               <div className="mt-12 flex items-baseline justify-between">
-                <h2 className="text-sm font-medium text-muted-foreground">
+                <h2 className="eyebrow text-muted-foreground">
                   Past events
                 </h2>
                 <span className="font-mono text-xs text-muted-dim tabular-nums">

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,57 +4,54 @@
 
 @custom-variant dark (&:is(.dark *));
 
-/* Light mode (default) — "Paper": a white page field with warm off-neutrals
-   in the tints and borders rather than the pure grey axis, and ink (#22211E)
-   instead of near-black so text stays short of a harsh 19:1. Surface is a
-   neutral grey one step off white — hovers and the receipt stub read as a
-   quiet press of the field rather than a cream block. The blue accent is
-   reserved for the claim flow only. */
+/* Light mode — "Instrument, daylight": a cool paper-white field with a pure
+   grey axis (no warm cast), precise hairline borders, and ink text. The one
+   luminous thing on screen is the phosphor-green accent, held darker here so
+   it reads as printed signal ink rather than glow. */
 :root {
-  --surface: #f6f6f6;
-  --surface-hover: #f0f0f0;
-  --border: #eae7df;
-  --border-strong: #d5cfc2;
-  --muted: #f1efe8;
-  --muted-dim: #78716a;
-  --background: #ffffff;
-  --foreground: #22211e;
-  --card: #ffffff;
-  --card-foreground: #22211e;
+  --surface: #f5f6f5;
+  --surface-hover: #eff1ef;
+  --border: #e4e6e4;
+  --border-strong: #c9cdc9;
+  --muted: #eef0ee;
+  --muted-dim: #737a75;
+  --background: #fbfcfb;
+  --foreground: #171a18;
+  --card: #fbfcfb;
+  --card-foreground: #171a18;
   --popover: #ffffff;
-  --popover-foreground: #22211e;
-  --primary: #22211e;
-  --primary-foreground: #faf9f5;
-  --secondary: #f1efe8;
-  --secondary-foreground: #22211e;
-  --muted-foreground: #57534a;
-  --accent: #f1efe8;
-  --accent-foreground: #22211e;
+  --popover-foreground: #171a18;
+  --primary: #171a18;
+  --primary-foreground: #f7f8f7;
+  --secondary: #eef0ee;
+  --secondary-foreground: #171a18;
+  --muted-foreground: #4d534f;
+  --accent: #eef0ee;
+  --accent-foreground: #171a18;
   --destructive: oklch(0.577 0.245 27.325);
   --input: oklch(0 0 0 / 8%);
-  --brand: #2200ff;
+  --brand: #0c7a3e;
   --brand-foreground: #ffffff;
-  --ring: #44403a;
-  --selection: #e6e1d5;
-  --selection-foreground: #22211e;
-  /* Soft two-layer card shadow: invisible as "shadow", read as depth. Dark
-     mode zeroes it out and relies on surface contrast instead. */
-  --shadow-card:
-    0 1px 2px rgb(34 33 30 / 0.04), 0 4px 12px -2px rgb(34 33 30 / 0.04);
+  --ring: #3c423e;
+  --selection: #d4efdd;
+  --selection-foreground: #10251a;
+  /* Instrument panels are flat: depth comes from hairline borders and
+     surface steps, never shadow. */
+  --shadow-card: 0 0 rgb(0 0 0 / 0);
   --chart-1: oklch(0.269 0 0);
   --chart-2: oklch(0.439 0 0);
   --chart-3: oklch(0.556 0 0);
   --chart-4: oklch(0.708 0 0);
   --chart-5: oklch(0.87 0 0);
-  --radius: 0.625rem;
-  --sidebar: #ffffff;
-  --sidebar-foreground: #22211e;
-  --sidebar-primary: #22211e;
-  --sidebar-primary-foreground: #faf9f5;
-  --sidebar-accent: #f1efe8;
-  --sidebar-accent-foreground: #22211e;
-  --sidebar-border: #e7e3da;
-  --sidebar-ring: #78716a;
+  --radius: 0.25rem;
+  --sidebar: #fbfcfb;
+  --sidebar-foreground: #171a18;
+  --sidebar-primary: #171a18;
+  --sidebar-primary-foreground: #f7f8f7;
+  --sidebar-accent: #eef0ee;
+  --sidebar-accent-foreground: #171a18;
+  --sidebar-border: #e4e6e4;
+  --sidebar-ring: #737a75;
 }
 
 @theme inline {
@@ -111,10 +108,12 @@
 
 body {
   font-family: var(--font-sans), system-ui, sans-serif;
+  /* Instrument numerals: every digit sits on the same grid, everywhere. */
+  font-variant-numeric: tabular-nums;
 }
 
-/* Neutral, not brand: selection is incidental, so it shouldn't compete with
-   the one blue thing on screen. */
+/* Selection carries a faint phosphor tint — the accent's only ambient
+   appearance outside the claim flow. */
 ::selection {
   background: var(--selection);
   color: var(--selection-foreground);
@@ -147,6 +146,15 @@ input:-webkit-autofill:focus {
   background-size: 28px 28px;
 }
 
+/* Restrained 1px grid lines — the instrument-panel backdrop. Hairlines only:
+   the color already sits at border strength, so the mask does the fading. */
+@utility bg-gridlines {
+  background-image:
+    linear-gradient(to right, var(--border) 1px, transparent 1px),
+    linear-gradient(to bottom, var(--border) 1px, transparent 1px);
+  background-size: 56px 56px;
+}
+
 /* Receipt edge: scalloped bottom, like a stub torn off a perforated roll. */
 @utility receipt-edge {
   mask-image: radial-gradient(circle at 8px 100%, transparent 5px, black 5.5px);
@@ -169,7 +177,7 @@ input:-webkit-autofill:focus {
   }
 }
 
-/* Brand pulse: a slow breath reserved for the one brand-blue element in view. */
+/* Brand pulse: a slow breath reserved for the one luminous element in view. */
 @utility animate-brand-pulse {
   animation: brand-pulse 3.2s ease-in-out infinite;
 }
@@ -184,50 +192,51 @@ input:-webkit-autofill:focus {
   }
 }
 
-/* Dark mode — "Paper" after dark: the near-black picks up a faint cool cast
-   while the text stays warm off-white, and contrast drops from 18:1 to ~16:1
-   to stop white type haloing on OLED. */
+/* Dark mode — "Instrument, night": deep-ink near-black with a barely-cool
+   cast, hairline borders one step above the field, and a single luminous
+   phosphor-green accent. Text is a cool off-white held to ~15:1 so it reads
+   as etched lettering, not glare. */
 .dark {
-  --surface: #141416;
-  --surface-hover: #1a1a1d;
-  --border: #26262a;
-  --border-strong: #3a3a40;
-  --muted: #212125;
-  --muted-dim: #7a7772;
-  --background: #0c0c0e;
-  --foreground: #e8e6e1;
-  --card: #141416;
-  --card-foreground: #e8e6e1;
-  --popover: #1a1a1d;
-  --popover-foreground: #e8e6e1;
-  --primary: #e8e6e1;
-  --primary-foreground: #0c0c0e;
-  --secondary: #2b2b30;
-  --secondary-foreground: #e8e6e1;
-  --muted-foreground: #a8a5a0;
-  --accent: #2b2b30;
-  --accent-foreground: #e8e6e1;
+  --surface: #0d1110;
+  --surface-hover: #121716;
+  --border: #1d2321;
+  --border-strong: #2e3634;
+  --muted: #161c1a;
+  --muted-dim: #6f7a75;
+  --background: #070909;
+  --foreground: #dfe4e1;
+  --card: #0d1110;
+  --card-foreground: #dfe4e1;
+  --popover: #121716;
+  --popover-foreground: #dfe4e1;
+  --primary: #dfe4e1;
+  --primary-foreground: #070909;
+  --secondary: #1b2220;
+  --secondary-foreground: #dfe4e1;
+  --muted-foreground: #9ba59f;
+  --accent: #1b2220;
+  --accent-foreground: #dfe4e1;
   --destructive: oklch(0.704 0.191 22.216);
   --input: oklch(1 0 0 / 15%);
-  --brand: #2200ff;
-  --brand-foreground: #ffffff;
-  --ring: #c4c1bb;
-  --selection: #33333a;
-  --selection-foreground: #e8e6e1;
+  --brand: #3dffa0;
+  --brand-foreground: #04160c;
+  --ring: #57cf8f;
+  --selection: #12351f;
+  --selection-foreground: #c8ffe0;
   --shadow-card: 0 0 rgb(0 0 0 / 0);
   --chart-1: oklch(0.87 0 0);
   --chart-2: oklch(0.556 0 0);
   --chart-3: oklch(0.439 0 0);
   --chart-4: oklch(0.371 0 0);
   --chart-5: oklch(0.269 0 0);
-  --sidebar: #141416;
-  --sidebar-foreground: #e8e6e1;
-  --sidebar-primary: #e8e6e1;
-  --sidebar-primary-foreground: #0c0c0e;
-  --sidebar-accent: #2b2b30;
-  --sidebar-accent-foreground: #e8e6e1;
-  --sidebar-border: #26262a;
-  --sidebar-ring: #7a7772;
+  --sidebar: #0d1110;
+  --sidebar-foreground: #dfe4e1;
+  --sidebar-primary: #dfe4e1;
+  --sidebar-primary-foreground: #070909;
+  --sidebar-accent: #1b2220;
+  --sidebar-accent-foreground: #dfe4e1;
+  --sidebar-border: #1d2321;
+  --sidebar-ring: #6f7a75;
 }
 
 @layer base {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -26,9 +26,9 @@ export const metadata: Metadata = {
 // page background automatically.
 const clerkAppearance: React.ComponentProps<typeof ClerkProvider>["appearance"] = {
   variables: {
-    colorPrimary: "#2200ff",
+    colorPrimary: "#0c7a3e",
     colorPrimaryForeground: "#ffffff",
-    borderRadius: "0.625rem",
+    borderRadius: "0.25rem",
     fontFamily: "var(--font-geist-sans), system-ui, sans-serif",
   },
   options: {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,13 +1,10 @@
 "use client";
 
-import { useSyncExternalStore } from "react";
 import Link from "next/link";
 import { ArrowUpRight, BadgeCheck, Ticket } from "lucide-react";
-import { useTheme } from "next-themes";
 import { useConvexAuth, useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { daysUntilEvent, formatEventDate } from "@/lib/event-date";
-import UnicornSceneEmbed from "@/components/UnicornSceneEmbed";
 import SiteHeader from "@/components/SiteHeader";
 import SiteFooter from "@/components/SiteFooter";
 import { Badge } from "@/components/ui/badge";
@@ -20,30 +17,6 @@ import {
   EmptyDescription,
 } from "@/components/ui/empty";
 import { cn } from "@/lib/utils";
-
-// The hero background is a theme-paired Unicorn Studio WebGL scene
-// (experiment). A Unicorn project publishes exactly one authored design and
-// the SDK has no color-scheme awareness, so a light-authored project shows
-// its light design in dark mode too — each theme therefore needs its own
-// project ID here.
-const UNICORN_PROJECTS = {
-  light: "wEz2vCJgsynwCYSb3HgR",
-  dark: "aEdLurlqLEmU1DUjAaUz",
-} as const;
-
-// Bump this whenever a scene is republished in Unicorn Studio. Deployed
-// builds read scene data through Unicorn's CDN, which caches for months and
-// doesn't reliably purge on republish; the update param below is part of the
-// CDN cache key, so bumping the version makes deploys fetch the new design.
-// Dev skips the param (and the CDN): without it the SDK cache-busts every
-// load, so republishes show up on a plain refresh.
-const UNICORN_CACHE_VERSION = 2;
-
-const isProdBuild = process.env.NODE_ENV === "production";
-
-// Stable no-op subscription for the hydration gate below: the snapshot never
-// changes on the client, we only care that the server snapshot is false.
-const emptySubscribe = () => () => {};
 
 interface EventItem {
   _id: string;
@@ -117,23 +90,6 @@ export default function Home() {
     mine?.map((item) => item.event?._id).filter(Boolean) ?? [],
   );
 
-  // The scene choice needs JS (the server doesn't know the theme, while the
-  // hydration render already does), so gate it behind hydration to keep both
-  // trees identical; the copy and scrim flip with pure dark: variants and
-  // render correctly from the first paint. Until hydration the plain
-  // theme-tinted shell stands in for both themes.
-  const { resolvedTheme } = useTheme();
-  const hydrated = useSyncExternalStore(
-    emptySubscribe,
-    () => true,
-    () => false,
-  );
-  const heroProjectId = hydrated
-    ? resolvedTheme === "light"
-      ? UNICORN_PROJECTS.light
-      : UNICORN_PROJECTS.dark
-    : undefined;
-
   // Dated events that have passed sink into their own dimmed group; undated
   // events are treated as current. Active events order soonest-first, with
   // undated ones following in their arrival (newest created) order; past
@@ -152,18 +108,21 @@ export default function Home() {
     events?.filter((e) => e.eventDate && daysUntilEvent(e.eventDate) < 0) ?? []
   ).sort((a, b) => (b.eventDate ?? "").localeCompare(a.eventDate ?? ""));
 
-  // Shared hero copy: crisp DOM stacked above the theme's scene. pt-15.25
-  // offsets the translucent header bar the hero slides under, keeping the
-  // copy centered in the visible area.
+  // Hero copy over the panel grid. pt-15.25 offsets the translucent header
+  // bar the hero slides under, keeping the copy centered in the visible area.
   const heroCopy = (
     <div className="relative mx-auto flex h-full w-full max-w-5xl flex-col justify-center px-4 pt-15.25 sm:px-6">
-      <p className="eyebrow animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 text-black/60 dark:text-white/60 motion-reduce:animate-none">
+      <p className="eyebrow animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 flex items-center gap-2.5 text-muted-foreground motion-reduce:animate-none">
+        <span
+          className="animate-brand-pulse inline-block size-1.5 rounded-full bg-brand motion-reduce:animate-none"
+          aria-hidden
+        />
         Event credit distribution
       </p>
-      <h1 className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-100 mt-6 max-w-2xl font-heading text-5xl leading-[0.95] font-semibold tracking-[-0.03em] text-balance text-black dark:text-white motion-reduce:animate-none sm:text-7xl">
+      <h1 className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-100 mt-6 max-w-2xl font-heading text-5xl leading-[0.95] font-semibold tracking-[-0.03em] text-balance motion-reduce:animate-none sm:text-7xl">
         Claim your credits.
       </h1>
-      <p className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-200 mt-6 max-w-md text-sm leading-relaxed text-black/70 dark:text-white/70 motion-reduce:animate-none">
+      <p className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-200 mt-6 max-w-md text-sm leading-relaxed text-muted-foreground motion-reduce:animate-none">
         Select your event, enter the email you registered with, and your credit
         code is dispensed on the spot.
       </p>
@@ -177,33 +136,13 @@ export default function Home() {
         <section className="-mt-15.25 border-b border-border/65">
           {/* The section pulls up behind the translucent header bar
               (-mt-15.25) so the background runs to the top of the page; the
-              hero is 61px taller to compensate and the scene shows through
-              the bar's frosted fill. The theme's Unicorn Studio scene renders
-              behind the copy and a soft theme-matched scrim; keying the scene
-              by project swaps it cleanly on theme change while the copy stays
-              mounted. The scene's mouse interactivity listens on window, so
-              the copy sitting above it doesn't block it. */}
-          <div className="relative h-[520px] overflow-hidden bg-background dark:bg-[#131313] sm:h-[486px]">
-            {heroProjectId ? (
-              <div className="absolute inset-0" aria-hidden>
-                {/* Dev fetches fresh scene data on every load; deploys pin
-                    the CDN to UNICORN_CACHE_VERSION — see the constant. */}
-                <UnicornSceneEmbed
-                  key={heroProjectId}
-                  projectId={
-                    isProdBuild
-                      ? `${heroProjectId}?update=${UNICORN_CACHE_VERSION}`
-                      : heroProjectId
-                  }
-                  production={isProdBuild}
-                />
-              </div>
-            ) : null}
-            {/* Soft scrim keeps the headline legible over the scenes; tune
-                or remove once the look settles. */}
+              hero is 61px taller to compensate. The backdrop is a restrained
+              1px panel grid fading out toward the edges — no scene, no
+              scrim: the instrument face is the hero. */}
+          <div className="relative h-[520px] overflow-hidden bg-background sm:h-[486px]">
             <div
-              className="absolute inset-0 bg-white/20 dark:bg-black/20"
               aria-hidden
+              className="pointer-events-none absolute inset-0 bg-gridlines [mask-image:radial-gradient(ellipse_75%_80%_at_50%_45%,black,transparent)]"
             />
             {heroCopy}
           </div>
@@ -211,7 +150,7 @@ export default function Home() {
 
         <section className="mx-auto w-full max-w-5xl px-4 py-14 sm:px-6 sm:py-20">
           <div className="flex items-baseline justify-between">
-            <h2 className="text-sm font-medium text-muted-foreground">
+            <h2 className="eyebrow text-muted-foreground">
               Active events
             </h2>
             {events ? (
@@ -274,7 +213,7 @@ export default function Home() {
               {past.length > 0 ? (
                 <>
                   <div className="mt-14 flex items-baseline justify-between">
-                    <h2 className="text-sm font-medium text-muted-foreground">
+                    <h2 className="eyebrow text-muted-foreground">
                       Past events
                     </h2>
                     <span className="font-mono text-xs text-muted-dim tabular-nums">

--- a/components/ClaimPage.tsx
+++ b/components/ClaimPage.tsx
@@ -191,7 +191,7 @@ export default function ClaimPage({
       >
         <div
           aria-hidden
-          className="pointer-events-none absolute inset-0 bg-dotgrid [mask-image:radial-gradient(ellipse_60%_60%_at_50%_45%,black,transparent)]"
+          className="pointer-events-none absolute inset-0 bg-gridlines [mask-image:radial-gradient(ellipse_60%_60%_at_50%_45%,black,transparent)]"
         />
         <div className="relative w-full max-w-md">
           {previewMode ? (

--- a/components/HeaderBar.tsx
+++ b/components/HeaderBar.tsx
@@ -8,7 +8,7 @@ export default function HeaderBar({
   children: React.ReactNode;
 }) {
   return (
-    <header className="sticky top-0 z-40 bg-background/30 backdrop-blur-md">
+    <header className="sticky top-0 z-40 border-b border-border/60 bg-background/30 backdrop-blur-md">
       {children}
     </header>
   );

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/20 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 items-center justify-center rounded-md border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/20 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {


### PR DESCRIPTION
## Summary
Explores a "Precision Mono-Tech" instrument-panel aesthetic across the landing page, claim page, and admin UI. Almost everything flows from the design tokens in `globals.css`:

- **Palette**: dark mode becomes deep-ink near-black (`#070909`) with a barely-cool cast; light mode drops the warm "paper" tints for a cool grey axis. The single luminous accent is phosphor green — `--brand: #3dffa0` (dark) / `#0c7a3e` (light) — replacing the blue `#2200ff` everywhere (including selection tint, ring, and Clerk `colorPrimary`).
- **Precision geometry**: `--radius` drops 0.625rem → 0.25rem, card shadows are zeroed in both modes (depth via hairline borders and surface steps), buttons go `rounded-lg` → `rounded-md`, and `HeaderBar` gains a 1px bottom hairline.
- **Instrument numerals**: `body { font-variant-numeric: tabular-nums }` so all digits align app-wide.
- **Grid lines**: new `bg-gridlines` utility (1px 56px hairline grid). The landing hero swaps the Unicorn Studio WebGL scene (and its theme/hydration gating) for a radially-masked gridline panel with a brand-pulse status dot; the claim page backdrop moves from dot grid to gridlines.
- **Micro-typography**: "Active/Past events" section headings adopt the mono uppercase `eyebrow` style; the admin "Control room" dot becomes a pulsing brand-green indicator.

Base branch for three follow-up font-stack variant PRs.

Link to Devin session: https://app.devin.ai/sessions/820c59002e61436cba1b789365013e03
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/81" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->