### PR TITLE
Soft Neo-Minimal — font stack: Sora + Inter + JetBrains Mono

### DIFF
--- a/app/admin/admins/page.tsx
+++ b/app/admin/admins/page.tsx
@@ -88,7 +88,7 @@ export default function AdminsPage() {
           <span className="inline-block size-1.5 rounded-full bg-border-strong" />
           Access control
         </p>
-        <h1 className="mt-3 font-heading text-3xl font-semibold tracking-[-0.02em]">
+        <h1 className="mt-3 font-heading text-3xl font-medium tracking-[-0.01em]">
           Admins
         </h1>
         <p className="mt-2 text-sm text-muted-foreground">

--- a/app/admin/blacklist/page.tsx
+++ b/app/admin/blacklist/page.tsx
@@ -86,7 +86,7 @@ export default function BlacklistPage() {
           <span className="inline-block size-1.5 rounded-full bg-border-strong" />
           Access control
         </p>
-        <h1 className="mt-3 font-heading text-3xl font-semibold tracking-[-0.02em]">
+        <h1 className="mt-3 font-heading text-3xl font-medium tracking-[-0.01em]">
           Blacklist
         </h1>
         <p className="mt-2 text-sm text-muted-foreground">

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -125,7 +125,7 @@ export default function AdminDashboard() {
             <span className="inline-block size-1.5 rounded-full bg-border-strong" />
             Control room
           </p>
-          <h1 className="mt-3 font-heading text-3xl font-semibold tracking-[-0.02em]">
+          <h1 className="mt-3 font-heading text-3xl font-medium tracking-[-0.01em]">
             Events
           </h1>
           <p className="mt-2 text-sm text-muted-foreground">

--- a/app/globals.css
+++ b/app/globals.css
@@ -70,11 +70,11 @@
   --color-foreground: var(--foreground);
   --color-muted: var(--muted);
   --color-muted-dim: var(--muted-dim);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
-  /* Headings share the body face — hierarchy comes from weight, size, and
-     tracking rather than a second display family. */
-  --font-heading: var(--font-geist-sans);
+  --font-sans: var(--font-inter);
+  --font-mono: var(--font-jetbrains-mono);
+  /* Headings use Sora — a rounded geometric face that stays calm at
+     lighter weights and gentle negative tracking. */
+  --font-heading: var(--font-sora);
   --color-brand: var(--brand);
   --color-brand-foreground: var(--brand-foreground);
   --color-sidebar-ring: var(--sidebar-ring);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Inter, JetBrains_Mono, Sora } from "next/font/google";
 import { ClerkProvider } from "@clerk/nextjs";
 import ConvexClientProvider from "@/components/ConvexClientProvider";
 import { ThemeProvider } from "@/components/ThemeProvider";
@@ -7,13 +7,18 @@ import { Toaster } from "@/components/ui/sonner";
 import { getAppName } from "@/lib/app-name";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const inter = Inter({
+  variable: "--font-inter",
   subsets: ["latin"],
 });
 
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
+const sora = Sora({
+  variable: "--font-sora",
+  subsets: ["latin"],
+});
+
+const jetbrainsMono = JetBrains_Mono({
+  variable: "--font-jetbrains-mono",
   subsets: ["latin"],
 });
 
@@ -29,7 +34,7 @@ const clerkAppearance: React.ComponentProps<typeof ClerkProvider>["appearance"] 
     colorPrimary: "#6d5ae8",
     colorPrimaryForeground: "#ffffff",
     borderRadius: "1rem",
-    fontFamily: "var(--font-geist-sans), system-ui, sans-serif",
+    fontFamily: "var(--font-inter), system-ui, sans-serif",
   },
   options: {
     unsafe_disableDevelopmentModeWarnings: true,
@@ -49,7 +54,7 @@ export default function RootLayout({
     <ClerkProvider appearance={clerkAppearance}>
       <html
         lang="en"
-        className={`${geistSans.variable} ${geistMono.variable} h-full overscroll-none antialiased`}
+        className={`${inter.variable} ${sora.variable} ${jetbrainsMono.variable} h-full overscroll-none antialiased`}
         suppressHydrationWarning
       >
         <body className="flex min-h-full flex-col overscroll-none">

--- a/app/my-codes/page.tsx
+++ b/app/my-codes/page.tsx
@@ -111,7 +111,7 @@ export default function MyCodesPage() {
       <main id="main-content" className="flex-1">
         <section className="mx-auto w-full max-w-5xl px-4 py-12 sm:px-6 sm:py-14">
           <div className="mb-10">
-            <h1 className="font-heading text-3xl font-semibold tracking-[-0.02em]">
+            <h1 className="font-heading text-3xl font-medium tracking-[-0.01em]">
               My codes
             </h1>
             <p className="mt-2 text-sm text-muted-foreground">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -160,7 +160,7 @@ export default function Home() {
       <p className="eyebrow animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 text-black/60 dark:text-white/60 motion-reduce:animate-none">
         Event credit distribution
       </p>
-      <h1 className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-100 mt-6 max-w-2xl font-heading text-5xl leading-[0.95] font-semibold tracking-[-0.03em] text-balance text-black dark:text-white motion-reduce:animate-none sm:text-7xl">
+      <h1 className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-100 mt-6 max-w-2xl font-heading text-5xl leading-[0.95] font-medium tracking-[-0.02em] text-balance text-black dark:text-white motion-reduce:animate-none sm:text-7xl">
         Claim your credits.
       </h1>
       <p className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-200 mt-6 max-w-md text-sm leading-relaxed text-black/70 dark:text-white/70 motion-reduce:animate-none">

--- a/app/sign-in/[[...sign-in]]/page.tsx
+++ b/app/sign-in/[[...sign-in]]/page.tsx
@@ -16,7 +16,7 @@ export default function SignInPage() {
         />
         <div className="relative flex flex-col items-center gap-3 text-center">
           <p className="eyebrow text-muted-foreground">Operator access</p>
-          <h1 className="font-heading text-3xl font-semibold tracking-[-0.02em]">
+          <h1 className="font-heading text-3xl font-medium tracking-[-0.01em]">
             Sign in to the control room
           </h1>
         </div>

--- a/components/ClaimPage.tsx
+++ b/components/ClaimPage.tsx
@@ -253,7 +253,7 @@ export default function ClaimPage({
             >
               <CardHeader className="gap-4 pt-(--card-spacing)">
                 <div className="flex items-start justify-between gap-3">
-                  <CardTitle className="font-heading text-3xl font-semibold tracking-[-0.02em] text-balance">
+                  <CardTitle className="font-heading text-3xl font-medium tracking-[-0.01em] text-balance">
                     {event.name}
                   </CardTitle>
                   <Button
@@ -572,7 +572,7 @@ function QrPanel({
         <div className="flex items-start justify-between gap-3">
           <div className="flex flex-col gap-2">
             <span className="eyebrow text-muted-foreground">Scan to claim</span>
-            <CardTitle className="font-heading text-2xl font-semibold tracking-[-0.02em] text-balance">
+            <CardTitle className="font-heading text-2xl font-medium tracking-[-0.01em] text-balance">
               {eventName}
             </CardTitle>
           </div>
@@ -647,7 +647,7 @@ function Receipt({
         </div>
 
         <div>
-          <h1 className="font-heading text-2xl font-semibold tracking-tight text-balance">
+          <h1 className="font-heading text-2xl font-medium tracking-[-0.01em] text-balance">
             {eventName}
           </h1>
           {creditAmount ? (

--- a/components/ManageEvent.tsx
+++ b/components/ManageEvent.tsx
@@ -447,7 +447,7 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
           All events
         </Button>
         <div className="mt-3 flex flex-wrap items-end justify-between gap-4">
-          <h1 className="font-heading text-3xl font-semibold tracking-[-0.02em]">
+          <h1 className="font-heading text-3xl font-medium tracking-[-0.01em]">
             {event.name}
           </h1>
           <div className="flex flex-wrap items-center gap-2">
@@ -507,7 +507,7 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
             ) : null}
           </div>
           {codes ? (
-            <div className="font-heading text-3xl font-semibold tracking-tight tabular-nums">
+            <div className="font-heading text-3xl font-medium tracking-[-0.01em] tabular-nums">
               {claimedDisplay}
               <span className="text-base text-muted-dim"> / {codeCount}</span>
             </div>
@@ -1179,7 +1179,7 @@ function StatCard({ label, value }: { label: string; value?: number }) {
       {value === undefined ? (
         <Skeleton className="h-9 w-14 rounded-md" />
       ) : (
-        <span className="font-heading text-3xl font-semibold tracking-tight tabular-nums">
+        <span className="font-heading text-3xl font-medium tracking-[-0.01em] tabular-nums">
           {display}
         </span>
       )}

--- a/components/WalkUpClaim.tsx
+++ b/components/WalkUpClaim.tsx
@@ -115,7 +115,7 @@ export default function WalkUpClaim({ id }: { id: Id<"events"> }) {
           <ArrowLeft data-icon="inline-start" />
           Manage event
         </Button>
-        <h1 className="mt-3 font-heading text-3xl font-semibold tracking-[-0.02em]">
+        <h1 className="mt-3 font-heading text-3xl font-medium tracking-[-0.01em]">
           {event.name}
         </h1>
       </div>
@@ -135,7 +135,7 @@ export default function WalkUpClaim({ id }: { id: Id<"events"> }) {
               <span className="eyebrow text-muted-foreground">
                 Walk-up claim
               </span>
-              <CardTitle className="font-heading text-2xl font-semibold tracking-[-0.02em]">
+              <CardTitle className="font-heading text-2xl font-medium tracking-[-0.01em]">
                 Add an attendee
               </CardTitle>
               <CardDescription className="text-sm leading-relaxed">
@@ -186,7 +186,7 @@ export default function WalkUpClaim({ id }: { id: Id<"events"> }) {
               <span className="eyebrow text-muted-foreground">
                 Scan to claim
               </span>
-              <CardTitle className="font-heading text-2xl font-semibold tracking-[-0.02em] text-balance">
+              <CardTitle className="font-heading text-2xl font-medium tracking-[-0.01em] text-balance">
                 {event.name}
               </CardTitle>
               {lastAdded ? (


### PR DESCRIPTION
## Summary
Swaps the font stack for the Soft Neo-Minimal direction — typography only, no color/radius/shadow/layout changes.

- `app/layout.tsx`: replace `Geist`/`Geist_Mono` with `Sora`, `Inter`, `JetBrains_Mono` via next/font/google (`--font-sora`, `--font-inter`, `--font-jetbrains-mono`); Clerk `appearance.variables.fontFamily` now uses Inter.
- `app/globals.css`: `--font-heading: var(--font-sora)`, `--font-sans: var(--font-inter)`, `--font-mono: var(--font-jetbrains-mono)`.
- Since Sora sits heavier/wider than Geist, large headings are softened to keep the calm airy feel: `font-semibold tracking-[-0.02em]` → `font-medium tracking-[-0.01em]` (and hero `-0.03em` → `-0.02em`) across page/component headings.

`npm run lint` and `npx tsc --noEmit` pass.

Link to Devin session: https://app.devin.ai/sessions/1cbf491483154f489a322b508f2eb1d9
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/83" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->