### PR TITLE
Soft Neo-Minimal — font stack: Geist Sans + Geist Mono

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -70,11 +70,17 @@
   --color-foreground: var(--foreground);
   --color-muted: var(--muted);
   --color-muted-dim: var(--muted-dim);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: var(--font-geist-sans), ui-sans-serif, system-ui, sans-serif;
+  --font-mono: var(--font-geist-mono), ui-monospace, "SF Mono", monospace;
   /* Headings share the body face — hierarchy comes from weight, size, and
      tracking rather than a second display family. */
-  --font-heading: var(--font-geist-sans);
+  --font-heading: var(--font-geist-sans), ui-sans-serif, system-ui, sans-serif;
+  /* Soft Neo-Minimal type tuning: semibold headings sit a step lighter than
+     Geist's default 600 so large sizes read airy rather than inky, and tight
+     tracking is slightly relaxed to match the direction's soft, open feel. */
+  --font-weight-semibold: 560;
+  --tracking-tight: -0.015em;
+  --tracking-tighter: -0.03em;
   --color-brand: var(--brand);
   --color-brand-foreground: var(--brand-foreground);
   --color-sidebar-ring: var(--sidebar-ring);
@@ -114,7 +120,9 @@
 }
 
 body {
-  font-family: var(--font-sans), system-ui, sans-serif;
+  font-family: var(--font-sans);
+  /* A touch more air in running text than the browser default. */
+  line-height: 1.6;
 }
 
 /* Neutral, not brand: selection is incidental, so it shouldn't compete with


### PR DESCRIPTION
## Summary
Typography-only polish for the Soft Neo-Minimal direction, keeping the existing Geist Sans / Geist Mono stack loaded via next/font. All tuning is centralized in `app/globals.css` theme tokens so every existing `font-semibold` / `tracking-tight(er)` / `font-heading` usage picks it up without touching components:

```diff
@theme inline {
- --font-sans: var(--font-geist-sans);
- --font-mono: var(--font-geist-mono);
- --font-heading: var(--font-geist-sans);
+ --font-sans: var(--font-geist-sans), ui-sans-serif, system-ui, sans-serif;
+ --font-mono: var(--font-geist-mono), ui-monospace, "SF Mono", monospace;
+ --font-heading: var(--font-geist-sans), ui-sans-serif, system-ui, sans-serif;
+ --font-weight-semibold: 560;   /* lighter, airier semibold headings (Geist variable axis) */
+ --tracking-tight: -0.015em;    /* slightly relaxed from Tailwind's -0.025em */
+ --tracking-tighter: -0.03em;
}

body {
- font-family: var(--font-sans), system-ui, sans-serif;
+ font-family: var(--font-sans);   /* fallbacks now live in the token */
+ line-height: 1.6;                /* more air in running text */
}
```

No changes to colors, radii, shadows, or layout. `npm run lint` and `npx tsc --noEmit` pass.

Link to Devin session: https://app.devin.ai/sessions/ab7f745dca45417f95f8e9fdfa8677c9
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/84" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->