### PR TITLE
Editorial Luxe — font stack: Newsreader + IBM Plex Sans

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -65,12 +65,12 @@
   --color-foreground: var(--foreground);
   --color-muted: var(--muted);
   --color-muted-dim: var(--muted-dim);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
-  --font-serif: var(--font-source-serif);
+  --font-sans: var(--font-plex-sans);
+  --font-mono: var(--font-plex-mono);
+  --font-serif: var(--font-newsreader);
   /* Headings set in the editorial serif; hierarchy comes from the contrast
      between the serif display face and the sans body. */
-  --font-heading: var(--font-source-serif);
+  --font-heading: var(--font-newsreader);
   --color-brand: var(--brand);
   --color-brand-foreground: var(--brand-foreground);
   --color-sidebar-ring: var(--sidebar-ring);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono, Source_Serif_4 } from "next/font/google";
+import { IBM_Plex_Sans, IBM_Plex_Mono, Newsreader } from "next/font/google";
 import { ClerkProvider } from "@clerk/nextjs";
 import ConvexClientProvider from "@/components/ConvexClientProvider";
 import { ThemeProvider } from "@/components/ThemeProvider";
@@ -7,20 +7,22 @@ import { Toaster } from "@/components/ui/sonner";
 import { getAppName } from "@/lib/app-name";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const plexSans = IBM_Plex_Sans({
+  variable: "--font-plex-sans",
   subsets: ["latin"],
+  weight: ["400", "500", "600"],
 });
 
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
+const plexMono = IBM_Plex_Mono({
+  variable: "--font-plex-mono",
   subsets: ["latin"],
+  weight: ["400", "500"],
 });
 
 // Editorial serif for headings and display type; the sans stays for body
 // and UI chrome.
-const sourceSerif = Source_Serif_4({
-  variable: "--font-source-serif",
+const newsreader = Newsreader({
+  variable: "--font-newsreader",
   subsets: ["latin"],
   style: ["normal", "italic"],
 });
@@ -37,7 +39,7 @@ const clerkAppearance: React.ComponentProps<typeof ClerkProvider>["appearance"] 
     colorPrimary: "#8a3b2e",
     colorPrimaryForeground: "#ffffff",
     borderRadius: "0.625rem",
-    fontFamily: "var(--font-geist-sans), system-ui, sans-serif",
+    fontFamily: "var(--font-plex-sans), system-ui, sans-serif",
   },
   options: {
     unsafe_disableDevelopmentModeWarnings: true,
@@ -57,7 +59,7 @@ export default function RootLayout({
     <ClerkProvider appearance={clerkAppearance}>
       <html
         lang="en"
-        className={`${geistSans.variable} ${geistMono.variable} ${sourceSerif.variable} h-full overscroll-none antialiased`}
+        className={`${plexSans.variable} ${plexMono.variable} ${newsreader.variable} h-full overscroll-none antialiased`}
         suppressHydrationWarning
       >
         <body className="flex min-h-full flex-col overscroll-none">


### PR DESCRIPTION
## Summary
Swaps the Editorial Luxe font stack: Newsreader (display serif, normal+italic) replaces Source Serif 4 for `--font-heading`/`--font-serif`, and IBM Plex Sans (400/500/600) replaces Geist for body/UI. Geist Mono → IBM Plex Mono (400/500) for family coherence.

- `app/layout.tsx`: next/font loaders now emit `--font-plex-sans`, `--font-plex-mono`, `--font-newsreader`; Clerk `fontFamily` updated to `var(--font-plex-sans)`.
- `app/globals.css` `@theme inline`: `--font-sans`/`--font-mono`/`--font-serif`/`--font-heading` remapped to the new variables.

No optical adjustments needed — headings already use `font-medium` (500), which reads well in Newsreader at display sizes.

Link to Devin session: https://app.devin.ai/sessions/7b4830fb312349ef9d28d7d71afffab9
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/88" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->