### PR TITLE
Editorial Luxe — font stack: Libre Caslon + Manrope

### DIFF
--- a/app/admin/admins/page.tsx
+++ b/app/admin/admins/page.tsx
@@ -88,7 +88,7 @@ export default function AdminsPage() {
           <span className="inline-block size-1.5 rounded-full bg-border-strong" />
           Access control
         </p>
-        <h1 className="mt-3 font-heading text-4xl font-medium tracking-[-0.01em]">
+        <h1 className="mt-3 font-heading text-4xl font-normal tracking-[-0.01em]">
           Admins
         </h1>
         <p className="mt-2 text-sm text-muted-foreground">

--- a/app/admin/blacklist/page.tsx
+++ b/app/admin/blacklist/page.tsx
@@ -86,7 +86,7 @@ export default function BlacklistPage() {
           <span className="inline-block size-1.5 rounded-full bg-border-strong" />
           Access control
         </p>
-        <h1 className="mt-3 font-heading text-4xl font-medium tracking-[-0.01em]">
+        <h1 className="mt-3 font-heading text-4xl font-normal tracking-[-0.01em]">
           Blacklist
         </h1>
         <p className="mt-2 text-sm text-muted-foreground">

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -69,7 +69,7 @@ function AdminEventRow({
           {String(index + 1).padStart(2, "0")}
         </span>
         <div className="min-w-0 flex-1">
-          <div className="font-heading font-medium tracking-tight">
+          <div className="font-heading font-normal tracking-tight">
             {event.name}
           </div>
         </div>
@@ -125,7 +125,7 @@ export default function AdminDashboard() {
             <span className="inline-block size-1.5 rounded-full bg-border-strong" />
             Control room
           </p>
-          <h1 className="mt-3 font-heading text-4xl font-medium tracking-[-0.01em]">
+          <h1 className="mt-3 font-heading text-4xl font-normal tracking-[-0.01em]">
             Events
           </h1>
           <p className="mt-2 text-sm text-muted-foreground">

--- a/app/globals.css
+++ b/app/globals.css
@@ -65,12 +65,12 @@
   --color-foreground: var(--foreground);
   --color-muted: var(--muted);
   --color-muted-dim: var(--muted-dim);
-  --font-sans: var(--font-geist-sans);
+  --font-sans: var(--font-manrope);
   --font-mono: var(--font-geist-mono);
-  --font-serif: var(--font-source-serif);
+  --font-serif: var(--font-libre-caslon);
   /* Headings set in the editorial serif; hierarchy comes from the contrast
      between the serif display face and the sans body. */
-  --font-heading: var(--font-source-serif);
+  --font-heading: var(--font-libre-caslon);
   --color-brand: var(--brand);
   --color-brand-foreground: var(--brand-foreground);
   --color-sidebar-ring: var(--sidebar-ring);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono, Source_Serif_4 } from "next/font/google";
+import { Manrope, Geist_Mono, Libre_Caslon_Text } from "next/font/google";
 import { ClerkProvider } from "@clerk/nextjs";
 import ConvexClientProvider from "@/components/ConvexClientProvider";
 import { ThemeProvider } from "@/components/ThemeProvider";
@@ -7,8 +7,8 @@ import { Toaster } from "@/components/ui/sonner";
 import { getAppName } from "@/lib/app-name";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const manrope = Manrope({
+  variable: "--font-manrope",
   subsets: ["latin"],
 });
 
@@ -19,9 +19,10 @@ const geistMono = Geist_Mono({
 
 // Editorial serif for headings and display type; the sans stays for body
 // and UI chrome.
-const sourceSerif = Source_Serif_4({
-  variable: "--font-source-serif",
+const libreCaslon = Libre_Caslon_Text({
+  variable: "--font-libre-caslon",
   subsets: ["latin"],
+  weight: ["400", "700"],
   style: ["normal", "italic"],
 });
 
@@ -37,7 +38,7 @@ const clerkAppearance: React.ComponentProps<typeof ClerkProvider>["appearance"] 
     colorPrimary: "#8a3b2e",
     colorPrimaryForeground: "#ffffff",
     borderRadius: "0.625rem",
-    fontFamily: "var(--font-geist-sans), system-ui, sans-serif",
+    fontFamily: "var(--font-manrope), system-ui, sans-serif",
   },
   options: {
     unsafe_disableDevelopmentModeWarnings: true,
@@ -57,7 +58,7 @@ export default function RootLayout({
     <ClerkProvider appearance={clerkAppearance}>
       <html
         lang="en"
-        className={`${geistSans.variable} ${geistMono.variable} ${sourceSerif.variable} h-full overscroll-none antialiased`}
+        className={`${manrope.variable} ${geistMono.variable} ${libreCaslon.variable} h-full overscroll-none antialiased`}
         suppressHydrationWarning
       >
         <body className="flex min-h-full flex-col overscroll-none">

--- a/app/my-codes/page.tsx
+++ b/app/my-codes/page.tsx
@@ -111,7 +111,7 @@ export default function MyCodesPage() {
       <main id="main-content" className="flex-1">
         <section className="mx-auto w-full max-w-5xl px-4 py-12 sm:px-6 sm:py-14">
           <div className="mb-10">
-            <h1 className="font-heading text-3xl font-medium tracking-[-0.01em]">
+            <h1 className="font-heading text-3xl font-normal tracking-[-0.01em]">
               My codes
             </h1>
             <p className="mt-2 text-sm text-muted-foreground">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -53,7 +53,7 @@ function EventRow({
           {String(index + 1).padStart(2, "0")}
         </span>
         <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 font-heading text-xl font-medium tracking-tight sm:text-2xl">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 font-heading text-xl font-normal tracking-tight sm:text-2xl">
             {event.name}
             {claimed ? (
               <Badge variant="secondary" className="gap-1">
@@ -126,7 +126,7 @@ export default function Home() {
                 No. 01
               </span>
             </div>
-            <h1 className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-100 mt-10 max-w-3xl font-heading text-6xl leading-[1.02] font-medium tracking-[-0.015em] text-balance motion-reduce:animate-none sm:text-8xl">
+            <h1 className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-100 mt-10 max-w-3xl font-heading text-6xl leading-[1.02] font-normal tracking-[-0.015em] text-balance motion-reduce:animate-none sm:text-8xl">
               Claim your <em className="italic">credits</em>.
             </h1>
             <p className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-200 mt-8 max-w-md font-heading text-lg leading-relaxed text-muted-foreground motion-reduce:animate-none">

--- a/app/sign-in/[[...sign-in]]/page.tsx
+++ b/app/sign-in/[[...sign-in]]/page.tsx
@@ -16,7 +16,7 @@ export default function SignInPage() {
         />
         <div className="relative flex flex-col items-center gap-3 text-center">
           <p className="eyebrow text-muted-foreground">Operator access</p>
-          <h1 className="font-heading text-3xl font-medium tracking-[-0.01em]">
+          <h1 className="font-heading text-3xl font-normal tracking-[-0.01em]">
             Sign in to the control room
           </h1>
         </div>

--- a/components/ClaimPage.tsx
+++ b/components/ClaimPage.tsx
@@ -253,7 +253,7 @@ export default function ClaimPage({
             >
               <CardHeader className="gap-4 pt-(--card-spacing)">
                 <div className="flex items-start justify-between gap-3">
-                  <CardTitle className="font-heading text-3xl font-medium tracking-[-0.01em] text-balance">
+                  <CardTitle className="font-heading text-3xl font-normal tracking-[-0.01em] text-balance">
                     {event.name}
                   </CardTitle>
                   <Button
@@ -572,7 +572,7 @@ function QrPanel({
         <div className="flex items-start justify-between gap-3">
           <div className="flex flex-col gap-2">
             <span className="eyebrow text-muted-foreground">Scan to claim</span>
-            <CardTitle className="font-heading text-2xl font-medium tracking-[-0.01em] text-balance">
+            <CardTitle className="font-heading text-2xl font-normal tracking-[-0.01em] text-balance">
               {eventName}
             </CardTitle>
           </div>
@@ -647,7 +647,7 @@ function Receipt({
         </div>
 
         <div>
-          <h1 className="font-heading text-2xl font-semibold tracking-tight text-balance">
+          <h1 className="font-heading text-2xl font-normal tracking-tight text-balance">
             {eventName}
           </h1>
           {creditAmount ? (

--- a/components/ManageEvent.tsx
+++ b/components/ManageEvent.tsx
@@ -447,7 +447,7 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
           All events
         </Button>
         <div className="mt-3 flex flex-wrap items-end justify-between gap-4">
-          <h1 className="font-heading text-3xl font-medium tracking-[-0.01em]">
+          <h1 className="font-heading text-3xl font-normal tracking-[-0.01em]">
             {event.name}
           </h1>
           <div className="flex flex-wrap items-center gap-2">
@@ -507,7 +507,7 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
             ) : null}
           </div>
           {codes ? (
-            <div className="font-heading text-3xl font-medium tracking-tight tabular-nums">
+            <div className="font-heading text-3xl font-normal tracking-tight tabular-nums">
               {claimedDisplay}
               <span className="text-base text-muted-dim"> / {codeCount}</span>
             </div>
@@ -1179,7 +1179,7 @@ function StatCard({ label, value }: { label: string; value?: number }) {
       {value === undefined ? (
         <Skeleton className="h-9 w-14 rounded-md" />
       ) : (
-        <span className="font-heading text-3xl font-medium tracking-tight tabular-nums">
+        <span className="font-heading text-3xl font-normal tracking-tight tabular-nums">
           {display}
         </span>
       )}

--- a/components/SiteHeader.tsx
+++ b/components/SiteHeader.tsx
@@ -14,7 +14,7 @@ export default function SiteHeader() {
           className="group flex min-w-0 items-center gap-2.5 rounded-sm focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ring"
         >
           <BrandMark className="size-5 shrink-0 transition-transform duration-300 group-hover:-rotate-6" />
-          <span className="max-w-36 truncate font-heading text-base font-medium tracking-tight text-foreground transition-colors group-hover:text-muted-foreground sm:max-w-none">
+          <span className="max-w-36 truncate font-heading text-base font-normal tracking-tight text-foreground transition-colors group-hover:text-muted-foreground sm:max-w-none">
             {getAppName()}
           </span>
         </Link>

--- a/components/WalkUpClaim.tsx
+++ b/components/WalkUpClaim.tsx
@@ -115,7 +115,7 @@ export default function WalkUpClaim({ id }: { id: Id<"events"> }) {
           <ArrowLeft data-icon="inline-start" />
           Manage event
         </Button>
-        <h1 className="mt-3 font-heading text-3xl font-medium tracking-[-0.01em]">
+        <h1 className="mt-3 font-heading text-3xl font-normal tracking-[-0.01em]">
           {event.name}
         </h1>
       </div>
@@ -135,7 +135,7 @@ export default function WalkUpClaim({ id }: { id: Id<"events"> }) {
               <span className="eyebrow text-muted-foreground">
                 Walk-up claim
               </span>
-              <CardTitle className="font-heading text-2xl font-medium tracking-[-0.01em]">
+              <CardTitle className="font-heading text-2xl font-normal tracking-[-0.01em]">
                 Add an attendee
               </CardTitle>
               <CardDescription className="text-sm leading-relaxed">
@@ -186,7 +186,7 @@ export default function WalkUpClaim({ id }: { id: Id<"events"> }) {
               <span className="eyebrow text-muted-foreground">
                 Scan to claim
               </span>
-              <CardTitle className="font-heading text-2xl font-medium tracking-[-0.01em] text-balance">
+              <CardTitle className="font-heading text-2xl font-normal tracking-[-0.01em] text-balance">
                 {event.name}
               </CardTitle>
               {lastAdded ? (

--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -117,7 +117,7 @@ function AlertDialogTitle({
     <AlertDialogPrimitive.Title
       data-slot="alert-dialog-title"
       className={cn(
-        "font-heading text-base font-medium sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2",
+        "font-heading text-base font-normal sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2",
         className
       )}
       {...props}

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -38,7 +38,7 @@ function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card-title"
       className={cn(
-        "font-heading text-base leading-snug font-medium group-data-[size=sm]/card:text-sm",
+        "font-heading text-base leading-snug font-normal group-data-[size=sm]/card:text-sm",
         className
       )}
       {...props}

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -121,7 +121,7 @@ function DialogTitle({ className, ...props }: DialogPrimitive.Title.Props) {
     <DialogPrimitive.Title
       data-slot="dialog-title"
       className={cn(
-        "font-heading text-base leading-none font-medium",
+        "font-heading text-base leading-none font-normal",
         className
       )}
       {...props}

--- a/components/ui/empty.tsx
+++ b/components/ui/empty.tsx
@@ -60,7 +60,7 @@ function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="empty-title"
       className={cn(
-        "font-heading text-sm font-medium tracking-tight",
+        "font-heading text-sm font-normal tracking-tight",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
Swaps the Editorial Luxe font stack to **Libre Caslon Text** (headings/display serif) + **Manrope** (body/UI sans); Geist Mono stays.

- `app/layout.tsx`: `Geist` → `Manrope` (`--font-manrope`), `Source_Serif_4` → `Libre_Caslon_Text` (`--font-libre-caslon`, weights 400/700, normal+italic — the only weights it ships). Clerk `fontFamily` updated to the Manrope variable.
- `app/globals.css` `@theme inline`: `--font-sans` → `var(--font-manrope)`, `--font-serif`/`--font-heading` → `var(--font-libre-caslon)`.
- Since Libre Caslon has no 500/600 weights, all `font-heading` usages with `font-medium`/`font-semibold` were changed to `font-normal` so headings render at true 400 instead of a synthetic fallback.

Lint (`npm run lint`) and typecheck (`npx tsc --noEmit`) pass.

Link to Devin session: https://app.devin.ai/sessions/29ad88b944df46278899bd0254baa534
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/90" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->