### PR TITLE
Allow deleting an entire code block while preserving claim status

### DIFF
--- a/components/ManageEvent.tsx
+++ b/components/ManageEvent.tsx
@@ -87,6 +87,7 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
   const allowReclaim = useMutation(api.claims.allowReclaim);
   const removeCode = useMutation(api.codes.remove);
   const renameCodeType = useMutation(api.codes.renameType);
+  const removeCodeType = useMutation(api.codes.removeType);
   const setTypeValue = useMutation(api.codes.setTypeValue);
 
   const [emailInput, setEmailInput] = useState("");
@@ -786,6 +787,14 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
                   prev === `existing:${from ?? ""}` ? `existing:${to}` : prev
                 );
               }}
+              canDelete={(event.codeTypes ?? []).length === 2}
+              onDelete={async (codeType) => {
+                const res = await removeCodeType({ eventId: id, codeType });
+                setBlockTarget((prev) =>
+                  prev === `existing:${codeType ?? ""}` ? null : prev
+                );
+                return res;
+              }}
             />
             <form onSubmit={handleAddCodes} className="flex flex-col gap-3">
               {hasBlocks ? (
@@ -929,6 +938,8 @@ function CodeBlocks({
   values,
   onRename,
   onSetValue,
+  canDelete,
+  onDelete,
 }: {
   codes: Doc<"codes">[] | undefined;
   values: Record<string, string> | undefined;
@@ -937,6 +948,10 @@ function CodeBlocks({
     codeType: string | undefined,
     value: string | undefined
   ) => Promise<unknown>;
+  canDelete: boolean;
+  onDelete: (
+    codeType: string | undefined
+  ) => Promise<{ removed: number; kept: number }>;
 }) {
   // Map insertion order follows creation time, so blocks list in the order
   // they were first created rather than alphabetically.
@@ -958,6 +973,8 @@ function CodeBlocks({
             value={values?.[type]}
             onRename={onRename}
             onSetValue={onSetValue}
+            canDelete={canDelete}
+            onDelete={onDelete}
           />
         ))}
     </div>
@@ -970,6 +987,8 @@ function CodeBlockRow({
   value,
   onRename,
   onSetValue,
+  canDelete,
+  onDelete,
 }: {
   type: string;
   count: number;
@@ -979,6 +998,10 @@ function CodeBlockRow({
     codeType: string | undefined,
     value: string | undefined
   ) => Promise<unknown>;
+  canDelete: boolean;
+  onDelete: (
+    codeType: string | undefined
+  ) => Promise<{ removed: number; kept: number }>;
 }) {
   const [editing, setEditing] = useState(false);
   const [name, setName] = useState(type);
@@ -1083,6 +1106,56 @@ function CodeBlockRow({
           >
             Edit
           </Button>
+          {canDelete ? (
+            <AlertDialog>
+              <AlertDialogTrigger
+                render={
+                  <Button
+                    size="icon-sm"
+                    variant="ghost"
+                    className="shrink-0 text-muted-foreground"
+                    aria-label={`Delete block ${type || "Unnamed"}`}
+                  />
+                }
+              >
+                <Trash2 />
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>
+                    Delete the &ldquo;{type || "Unnamed"}&rdquo; block?
+                  </AlertDialogTitle>
+                  <AlertDialogDescription>
+                    This removes the block and all of its unclaimed codes.
+                    Codes already dispensed are kept, so attendees keep their
+                    claim status and can still see their code.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction
+                    onClick={() => {
+                      onDelete(type || undefined)
+                        .then(({ removed, kept }) =>
+                          toast.success(
+                            `Deleted block${type ? ` “${type}”` : ""} — ${removed} unclaimed code${removed === 1 ? "" : "s"} removed${kept > 0 ? `, ${kept} claimed kept` : ""}`
+                          )
+                        )
+                        .catch((err) =>
+                          toast.error(
+                            err instanceof Error
+                              ? err.message
+                              : "Failed to delete code block"
+                          )
+                        );
+                    }}
+                  >
+                    Delete block
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          ) : null}
         </>
       )}
     </div>

--- a/convex/codes.ts
+++ b/convex/codes.ts
@@ -2,6 +2,7 @@ import { mutation, query, type MutationCtx } from "./_generated/server";
 import type { Id } from "./_generated/dataModel";
 import { v } from "convex/values";
 import { requireEventAdmin } from "./admins";
+import { logAudit } from "./auditLog";
 import { blockValue } from "./blockValues";
 
 // Drop the type from the event's denormalized list when its last code is
@@ -172,6 +173,59 @@ export const renameType = mutation({
     delete values[fromKey];
     await ctx.db.patch(args.eventId, { codeTypes, codeTypeValues: values });
     return { renamed: targets.length };
+  },
+});
+
+// Deletes an entire code block: its unclaimed codes plus the block's name
+// on the event. Claimed codes are kept so attendees keep their claim status
+// and receipts; the block's stored value also stays so those receipts keep
+// showing it. Only allowed while the event has two blocks, so the claim page
+// always has at least one block left.
+export const removeType = mutation({
+  args: { eventId: v.id("events"), codeType: v.optional(v.string()) },
+  handler: async (ctx, args) => {
+    const actorEmail = await requireEventAdmin(ctx, args.eventId);
+    const event = await ctx.db.get(args.eventId);
+    if (!event) throw new Error("Event not found");
+    if ((event.codeTypes ?? []).length !== 2) {
+      throw new Error(
+        "A code block can only be deleted while the event has two blocks."
+      );
+    }
+    const codeType = args.codeType?.trim() || undefined;
+    const typeKey = codeType ?? "";
+    if (!event.codeTypes?.includes(typeKey)) {
+      throw new Error("This event has no such code block.");
+    }
+    const codes = await ctx.db
+      .query("codes")
+      .withIndex("by_event_codeType_claimedBy", (q) =>
+        q.eq("eventId", args.eventId).eq("codeType", codeType)
+      )
+      .collect();
+    let removed = 0;
+    let kept = 0;
+    for (const code of codes) {
+      if (code.claimedBy) {
+        kept++;
+        continue;
+      }
+      await ctx.db.delete(code._id);
+      removed++;
+    }
+    const values = { ...(event.codeTypeValues ?? {}) };
+    if (kept === 0) delete values[typeKey];
+    await ctx.db.patch(args.eventId, {
+      codeTypes: event.codeTypes.filter((t) => t !== typeKey),
+      codeTypeValues: values,
+    });
+    await logAudit(ctx, {
+      eventId: args.eventId,
+      action: "code_block_deleted",
+      actorEmail: actorEmail ?? undefined,
+      details: `Deleted block "${typeKey}": ${removed} unclaimed code(s) removed, ${kept} claimed code(s) kept`,
+    });
+    return { removed, kept };
   },
 });
 

--- a/convex/events.ts
+++ b/convex/events.ts
@@ -115,6 +115,7 @@ export const get = query({
       slug: event.slug,
       description: event.description,
       creditAmount: event.creditAmount,
+      codeTypes: event.codeTypes,
       codeTypeValues: event.codeTypeValues,
       eventDate: event.eventDate,
       claimInstructions: event.claimInstructions,


### PR DESCRIPTION
## Summary
Adds an admin action to delete a whole code block (name + unclaimed codes) when an event has exactly two blocks, while keeping claimed codes so attendees' claim status and receipts survive.

- `codes.removeType({ eventId, codeType? })` (new mutation): requires event admin, only allowed when `event.codeTypes.length === 2`; deletes all unclaimed codes in the block, keeps claimed ones, removes the block from `event.codeTypes`, and drops its `codeTypeValues` entry only when no claimed codes remain (so retained receipts still resolve their value). Logs a `code_block_deleted` audit entry with removed/kept counts and returns `{ removed, kept }`.
- `events.get` now also returns `codeTypes` so the manage UI can gate the action.
- `ManageEvent`: each code block row shows a trash button (only when the event has two blocks) that opens an AlertDialog explaining that unclaimed codes are removed but dispensed codes are kept; confirming calls `removeType` and toasts the removed/kept counts. If the deleted block had claimed codes, its row remains listing just those kept claimed codes.


Link to Devin session: https://app.devin.ai/sessions/009417d7b0744ba6a4a2d182a619694d
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/91" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->