### PR TITLE
Subtle text-color hover on header nav buttons instead of background highlight

### DIFF
--- a/components/HeaderAuth.tsx
+++ b/components/HeaderAuth.tsx
@@ -24,7 +24,11 @@ export default function HeaderAuth() {
   if (!isAuthenticated) {
     return (
       <SignInButton mode="modal">
-        <Button variant="ghost" size="sm" className="text-muted-foreground">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="text-muted-foreground hover:bg-transparent dark:hover:bg-transparent"
+        >
           Sign in
           <ArrowRight
             data-icon="inline-end"
@@ -41,7 +45,7 @@ export default function HeaderAuth() {
       <Button
         variant="ghost"
         size="sm"
-        className="text-muted-foreground"
+        className="text-muted-foreground hover:bg-transparent dark:hover:bg-transparent"
         render={<Link href="/my-codes" />}
         nativeButton={false}
       >
@@ -51,7 +55,7 @@ export default function HeaderAuth() {
         <Button
           variant="ghost"
           size="sm"
-          className="text-muted-foreground"
+          className="text-muted-foreground hover:bg-transparent dark:hover:bg-transparent"
           render={<Link href="/admin" />}
           nativeButton={false}
         >


### PR DESCRIPTION
## Summary
The "Sign in", "My codes", and "Admin" buttons in the site header used the ghost button's `hover:bg-muted` background highlight. This removes the background on hover (`hover:bg-transparent`) so the only effect is the existing smooth muted-gray → foreground text color shift — matching the pattern `AdminNav` links already use (`text-muted-foreground hover:text-foreground`, no background). The "Sign in" arrow's slide-right hover animation is unchanged.

Link to Devin session: https://app.devin.ai/sessions/009417d7b0744ba6a4a2d182a619694d
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/92" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->