### PR TITLE
Update hero subtitle to reflect sign-in-first claim flow

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -164,8 +164,7 @@ export default function Home() {
         Claim your credits.
       </h1>
       <p className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-200 mt-6 max-w-md text-sm leading-relaxed text-black/70 dark:text-white/70 motion-reduce:animate-none">
-        Select your event, enter the email you registered with, and your credit
-        code is dispensed on the spot.
+        Sign in, then select your event to claim your credits.
       </p>
     </div>
   );


### PR DESCRIPTION
## Summary
Homepage hero subtitle now reads "Sign in, then select your event to claim your credits." instead of the outdated email-entry copy ("Select your event, enter the email you registered with, and your credit code is dispensed on the spot."), matching the current sign-in-gated claim flow.

Link to Devin session: https://app.devin.ai/sessions/009417d7b0744ba6a4a2d182a619694d
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/93" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->