### PR TITLE
Remove event count next to "Active events" on the homepage

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -210,16 +210,9 @@ export default function Home() {
         </section>
 
         <section className="mx-auto w-full max-w-5xl px-4 py-14 sm:px-6 sm:py-20">
-          <div className="flex items-baseline justify-between">
-            <h2 className="text-sm font-medium text-muted-foreground">
-              Active events
-            </h2>
-            {events ? (
-              <span className="font-mono text-xs text-muted-dim tabular-nums">
-                {String(current.length).padStart(2, "0")}
-              </span>
-            ) : null}
-          </div>
+          <h2 className="text-sm font-medium text-muted-foreground">
+            Active events
+          </h2>
 
           {events === undefined ? (
             <div


### PR DESCRIPTION
## Summary
Drops the zero-padded event counter ("02") that sat to the right of the homepage "Active events" heading, leaving just the heading. The admin dashboard's matching counter is untouched.

Link to Devin session: https://app.devin.ai/sessions/009417d7b0744ba6a4a2d182a619694d
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/94" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->