### PR TITLE
Nicer not-on-the-list message on the claim page

### DIFF
--- a/components/ClaimPage.tsx
+++ b/components/ClaimPage.tsx
@@ -28,7 +28,7 @@ import {
 import { copyText } from "@/lib/clipboard";
 import SiteHeader from "@/components/SiteHeader";
 import SiteFooter from "@/components/SiteFooter";
-import { Alert, AlertTitle } from "@/components/ui/alert";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -334,9 +334,22 @@ export default function ClaimPage({
                       <OctagonX />
                       <AlertTitle>
                         {eligibility.reason === "unverified"
-                          ? "Your account has no verified email address. Sign in with the email you registered with."
-                          : `${eligibility.email ?? "This email"} is not on the participant list for this event. Sign in with the email you registered with.`}
+                          ? "No verified email on your account"
+                          : "You're not on the list for this event"}
                       </AlertTitle>
+                      <AlertDescription>
+                        {eligibility.reason === "unverified" ? (
+                          "Sign in with the email you registered with."
+                        ) : (
+                          <>
+                            <span className="font-medium text-foreground">
+                              {eligibility.email ?? "This email"}
+                            </span>{" "}
+                            isn&apos;t on the participant list. Sign in with
+                            the email you registered with.
+                          </>
+                        )}
+                      </AlertDescription>
                     </Alert>
                     <div className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
                       <span className="min-w-0 truncate">


### PR DESCRIPTION
## Summary
The ineligible state on the claim page crammed one long sentence into `AlertTitle`. It now uses a short bold title plus an `AlertDescription`:

- Not on list: title "You're not on the list for this event", description shows the **email in foreground weight** followed by "isn't on the participant list. Sign in with the email you registered with."
- Unverified: title "No verified email on your account" + the same sign-in hint as description.

Same destructive `Alert` + `OctagonX` styling; the "Signed in as … / Switch" row below is unchanged.

Link to Devin session: https://app.devin.ai/sessions/009417d7b0744ba6a4a2d182a619694d
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/96" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->