### PR TITLE
Remove "Control room" eyebrow from the admin events page

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -121,11 +121,7 @@ export default function AdminDashboard() {
     <div>
       <div className="mb-10 flex flex-col items-start gap-5 sm:flex-row sm:items-end sm:justify-between sm:gap-6">
         <div>
-          <p className="eyebrow flex items-center gap-2 text-muted-foreground">
-            <span className="inline-block size-1.5 rounded-full bg-border-strong" />
-            Control room
-          </p>
-          <h1 className="mt-3 font-heading text-3xl font-semibold tracking-[-0.02em]">
+          <h1 className="font-heading text-3xl font-semibold tracking-[-0.02em]">
             Events
           </h1>
           <p className="mt-2 text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary
Drops the "Control room" eyebrow label and its dot indicator above the "Events" heading on the admin dashboard (the heading loses its `mt-3` since nothing sits above it now). The small "Control room" footer text in the admin layout is untouched — say the word if that should go too.

Link to Devin session: https://app.devin.ai/sessions/009417d7b0744ba6a4a2d182a619694d
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/97" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->