### PR TITLE
Remove /slug from admin event list rows

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -73,9 +73,6 @@ function AdminEventRow({
             {event.name}
           </div>
         </div>
-        <span className="hidden font-mono text-xs text-muted-dim sm:inline">
-          /{event.slug}
-        </span>
         <span className="hidden text-xs text-muted-dim tabular-nums md:inline">
           {event.eventDate
             ? formatEventDate(event.eventDate)


### PR DESCRIPTION
## Summary
Drops the monospace `/{event.slug}` column from each row in the admin events list; the name, date, and status remain.

Link to Devin session: https://app.devin.ai/sessions/009417d7b0744ba6a4a2d182a619694d
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/98" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->