### PR TITLE
Remove index numbers from homepage event lists

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -76,9 +76,6 @@ function EventRow({
           past && "opacity-60 transition-opacity hover:opacity-100",
         )}
       >
-        <span className="font-mono text-xs text-muted-dim tabular-nums transition-colors group-hover:text-foreground">
-          {String(index + 1).padStart(2, "0")}
-        </span>
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-x-3 gap-y-1 font-heading text-xl font-medium tracking-tight sm:text-2xl">
             {event.name}
@@ -224,7 +221,6 @@ export default function Home() {
                   key={i}
                   className="flex items-center gap-6 border-b border-border px-2 py-7 sm:gap-10 sm:px-4"
                 >
-                  <Skeleton className="h-3 w-5 rounded-sm" />
                   <div className="flex min-w-0 flex-1 flex-col gap-2">
                     <Skeleton className="h-5 w-2/3 rounded-sm" />
                     <Skeleton className="h-3 w-1/2 rounded-sm" />


### PR DESCRIPTION
## Summary
Drops the `01`, `02`, … index column from the homepage event rows (active and past lists) and the matching placeholder in the loading skeleton. The `index` prop stays on `EventRow` since it still drives the staggered entrance animation delay.

Link to Devin session: https://app.devin.ai/sessions/009417d7b0744ba6a4a2d182a619694d
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/99" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->