### PR TITLE
Fix Convex deploy typecheck: add node types to convex/tsconfig.json

### DIFF
--- a/convex/tsconfig.json
+++ b/convex/tsconfig.json
@@ -11,6 +11,7 @@
     "jsx": "react-jsx",
     "skipLibCheck": true,
     "allowSyntheticDefaultImports": true,
+    "types": ["node"],
 
     /* These compiler options are required by Convex */
     "target": "ESNext",


### PR DESCRIPTION
## Summary
`npx convex deploy` started failing with `TS2591: Cannot find name 'process'` in `convex/auth.config.ts` and `convex/notifications.ts` after the TypeScript 5→6 upgrade (PR #95): TS 6 no longer auto-includes `@types/node` globals under this config, and `convex/tsconfig.json` had no `types` field.

Fix: add `"types": ["node"]` to `convex/tsconfig.json` so `process` is typed again. Verified locally: `npx tsc -p convex`, `npx convex dev --once`, root `tsc --noEmit`, and lint all pass.

Link to Devin session: https://app.devin.ai/sessions/009417d7b0744ba6a4a2d182a619694d
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/101" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->