### PR TITLE
Gate "Devin" in hero eyebrow behind NEXT_PUBLIC_IS_DEVIN

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -155,7 +155,8 @@ export default function Home() {
   const heroCopy = (
     <div className="relative mx-auto flex h-full w-full max-w-5xl flex-col justify-center px-4 pt-15.25 sm:px-6">
       <p className="eyebrow animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 text-black/60 dark:text-white/60 motion-reduce:animate-none">
-        Devin Event credit distribution
+        {process.env.NEXT_PUBLIC_IS_DEVIN ? "Devin " : ""}Event credit
+        distribution
       </p>
       <h1 className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-100 mt-6 max-w-2xl font-heading text-5xl leading-[0.95] font-semibold tracking-[-0.03em] text-balance text-black dark:text-white motion-reduce:animate-none sm:text-7xl">
         Claim your credits.


### PR DESCRIPTION
## Summary
Hero eyebrow now reads "Devin Event credit distribution" only when `NEXT_PUBLIC_IS_DEVIN` is set (any non-empty value at build time); otherwise "Event credit distribution". The `NEXT_PUBLIC_` prefix is required because the homepage is a client component — plain `IS_DEVIN` would never reach the browser bundle.

Link to Devin session: https://app.devin.ai/sessions/009417d7b0744ba6a4a2d182a619694d
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/102" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->