### PR TITLE
Remove link arrows on home and admin pages, and admin row numbers

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { ArrowRight, CalendarPlus, OctagonX, Plus } from "lucide-react";
+import { CalendarPlus, OctagonX, Plus } from "lucide-react";
 import { toast } from "sonner";
 import { useMutation, useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
@@ -49,11 +49,9 @@ interface ManagedEventItem {
 
 function AdminEventRow({
   event,
-  index,
   past,
 }: {
   event: ManagedEventItem;
-  index: number;
   past?: boolean;
 }) {
   return (
@@ -65,9 +63,6 @@ function AdminEventRow({
           past && "opacity-60 transition-opacity hover:opacity-100",
         )}
       >
-        <span className="font-mono text-xs text-muted-dim tabular-nums">
-          {String(index + 1).padStart(2, "0")}
-        </span>
         <div className="min-w-0 flex-1">
           <div className="font-heading font-medium tracking-tight">
             {event.name}
@@ -82,10 +77,6 @@ function AdminEventRow({
                 year: "numeric",
               })}
         </span>
-        <ArrowRight
-          className="size-4 shrink-0 text-muted-dim transition-all group-hover:translate-x-0.5 group-hover:text-foreground"
-          aria-hidden
-        />
       </Link>
     </li>
   );
@@ -166,8 +157,8 @@ export default function AdminDashboard() {
             </p>
           ) : (
             <ul className="mt-4 border-t border-border">
-              {current.map((event, index) => (
-                <AdminEventRow key={event._id} event={event} index={index} />
+              {current.map((event) => (
+                <AdminEventRow key={event._id} event={event} />
               ))}
             </ul>
           )}
@@ -182,13 +173,8 @@ export default function AdminDashboard() {
                 </span>
               </div>
               <ul className="mt-4 border-t border-border">
-                {past.map((event, index) => (
-                  <AdminEventRow
-                    key={event._id}
-                    event={event}
-                    index={index}
-                    past
-                  />
+                {past.map((event) => (
+                  <AdminEventRow key={event._id} event={event} past />
                 ))}
               </ul>
             </>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,7 +2,7 @@
 
 import { useSyncExternalStore } from "react";
 import Link from "next/link";
-import { ArrowUpRight, BadgeCheck, Ticket } from "lucide-react";
+import { BadgeCheck, Ticket } from "lucide-react";
 import { useTheme } from "next-themes";
 import { useConvexAuth, useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
@@ -97,10 +97,6 @@ function EventRow({
             {formatEventDate(event.eventDate)}
           </span>
         ) : null}
-        <ArrowUpRight
-          className="size-4 shrink-0 text-muted-dim transition-all group-hover:translate-x-0.5 group-hover:-translate-y-0.5 group-hover:text-foreground"
-          aria-hidden
-        />
       </Link>
     </li>
   );
@@ -226,7 +222,6 @@ export default function Home() {
                     <Skeleton className="h-5 w-2/3 rounded-sm" />
                     <Skeleton className="h-3 w-1/2 rounded-sm" />
                   </div>
-                  <Skeleton className="size-4 rounded-sm" />
                 </div>
               ))}
             </div>


### PR DESCRIPTION
## Summary
- Homepage event rows: drop the trailing `ArrowUpRight` icon (and its skeleton placeholder).
- Admin event rows: drop the trailing `ArrowRight` icon and the leading `01`, `02`, … index numbers; the now-unused `index` prop is removed from `AdminEventRow`.

Link to Devin session: https://app.devin.ai/sessions/009417d7b0744ba6a4a2d182a619694d
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->