### PR TITLE
Add ability to hide an event from the main page

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -11,6 +11,7 @@ import { daysUntilEvent, formatEventDate } from "@/lib/event-date";
 import { slugify } from "@/lib/slug";
 import { cn } from "@/lib/utils";
 import { Alert, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -45,6 +46,7 @@ interface ManagedEventItem {
   name: string;
   slug: string;
   eventDate?: string;
+  hidden?: boolean;
 }
 
 function AdminEventRow({
@@ -64,8 +66,9 @@ function AdminEventRow({
         )}
       >
         <div className="min-w-0 flex-1">
-          <div className="font-heading font-medium tracking-tight">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 font-heading font-medium tracking-tight">
             {event.name}
+            {event.hidden ? <Badge variant="outline">Hidden</Badge> : null}
           </div>
         </div>
         <span className="hidden text-xs text-muted-dim tabular-nums md:inline">

--- a/components/ManageEvent.tsx
+++ b/components/ManageEvent.tsx
@@ -43,6 +43,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Card,
   CardAction,
@@ -1423,6 +1424,7 @@ function EventDetailsForm({
   const [claimInstructions, setClaimInstructions] = useState(
     event.claimInstructions ?? ""
   );
+  const [hidden, setHidden] = useState(event.hidden ?? false);
   const [saving, setSaving] = useState(false);
 
   async function handleSave(e: React.FormEvent) {
@@ -1436,6 +1438,7 @@ function EventDetailsForm({
         description: description || undefined,
         eventDate: eventDate || undefined,
         claimInstructions: claimInstructions || undefined,
+        hidden: hidden || undefined,
       });
       setSlug(savedSlug);
       toast.success("Event saved");
@@ -1519,6 +1522,16 @@ function EventDetailsForm({
                 Optional — when set, attendees see a &ldquo;How to
                 redeem&rdquo; button after claiming their code.
               </FieldDescription>
+            </Field>
+            <Field orientation="horizontal" className="sm:col-span-2">
+              <Checkbox
+                id="detail-hidden"
+                checked={hidden}
+                onCheckedChange={(checked) => setHidden(checked === true)}
+              />
+              <FieldLabel htmlFor="detail-hidden" className="font-normal">
+                Hide from home page
+              </FieldLabel>
             </Field>
           </FieldGroup>
           <div className="flex items-center justify-between gap-4">

--- a/convex/events.ts
+++ b/convex/events.ts
@@ -26,14 +26,16 @@ export const list = query({
   args: {},
   handler: async (ctx) => {
     const events = await ctx.db.query("events").order("desc").collect();
-    return events.map((event) => ({
-      _id: event._id,
-      _creationTime: event._creationTime,
-      name: event.name,
-      slug: event.slug,
-      description: event.description,
-      eventDate: event.eventDate,
-    }));
+    return events
+      .filter((event) => !event.hidden)
+      .map((event) => ({
+        _id: event._id,
+        _creationTime: event._creationTime,
+        name: event.name,
+        slug: event.slug,
+        description: event.description,
+        eventDate: event.eventDate,
+      }));
   },
 });
 
@@ -119,6 +121,7 @@ export const get = query({
       codeTypeValues: event.codeTypeValues,
       eventDate: event.eventDate,
       claimInstructions: event.claimInstructions,
+      hidden: event.hidden,
     };
   },
 });
@@ -151,6 +154,7 @@ export const listManaged = query({
       slug: event.slug,
       description: event.description,
       eventDate: event.eventDate,
+      hidden: event.hidden,
     }));
   },
 });
@@ -195,6 +199,7 @@ export const update = mutation({
     description: v.optional(v.string()),
     eventDate: v.optional(v.string()),
     claimInstructions: v.optional(v.string()),
+    hidden: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     await requireEventAdmin(ctx, args.id);
@@ -213,6 +218,7 @@ export const update = mutation({
       description: args.description?.trim() || undefined,
       eventDate: normalizeEventDate(args.eventDate),
       claimInstructions: args.claimInstructions?.trim() || undefined,
+      hidden: args.hidden || undefined,
     });
     return { slug };
   },

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -23,6 +23,9 @@ export default defineSchema({
     eventDate: v.optional(v.string()),
     // Optional post-claim redemption instructions shown to attendees.
     claimInstructions: v.optional(v.string()),
+    // Hidden events are excluded from the public home page listing but
+    // remain reachable via their claim URL.
+    hidden: v.optional(v.boolean()),
     // Distinct code types in this event's pool ("" = unnamed), maintained by
     // codes.add/remove so availability checks don't scan the pool.
     codeTypes: v.optional(v.array(v.string())),


### PR DESCRIPTION
## Summary
Adds an optional `hidden` flag to events so admins can exclude an event from the public home page listing while keeping its claim URL (`/[slug]`) reachable.

- `convex/schema.ts`: `events.hidden: v.optional(v.boolean())` (stored as `undefined` when off, so existing docs are untouched)
- `events.list` filters `!event.hidden`; `events.get`/`listManaged` now return `hidden`; `events.update` accepts `hidden`
- Event details form (`ManageEvent`) gains a "Hide from home page" checkbox
- Admin dashboard rows show a "Hidden" badge so hidden events remain discoverable to admins

Link to Devin session: https://app.devin.ai/sessions/35524e6607e544329c06534f87171fc5
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/104" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->