### PR TITLE
Design: Swiss / International Typographic — Charcoal Mono

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,57 +4,56 @@
 
 @custom-variant dark (&:is(.dark *));
 
-/* Light mode (default) — "Paper": a white page field with warm off-neutrals
-   in the tints and borders rather than the pure grey axis, and ink (#22211E)
-   instead of near-black so text stays short of a harsh 19:1. Surface is a
-   neutral grey one step off white — hovers and the receipt stub read as a
-   quiet press of the field rather than a cream block. The blue accent is
-   reserved for the claim flow only. */
+/* Light mode (default) — Swiss / International Typographic, "Charcoal Mono":
+   a strict achromatic axis from white paper to charcoal ink. No warm casts,
+   no tinted neutrals — every grey sits on the pure axis so the page reads as
+   print. Rules are hairline (#e4e4e4), corners are square, shadows are gone;
+   structure comes from the grid and the rules, not from depth. One accent —
+   Swiss red — is reserved for the claim action alone. */
 :root {
-  --surface: #f6f6f6;
-  --surface-hover: #f0f0f0;
-  --border: #eae7df;
-  --border-strong: #d5cfc2;
-  --muted: #f1efe8;
-  --muted-dim: #78716a;
+  --surface: #f5f5f5;
+  --surface-hover: #efefef;
+  --border: #e4e4e4;
+  --border-strong: #c6c6c6;
+  --muted: #f0f0f0;
+  --muted-dim: #757575;
   --background: #ffffff;
-  --foreground: #22211e;
+  --foreground: #1c1c1c;
   --card: #ffffff;
-  --card-foreground: #22211e;
+  --card-foreground: #1c1c1c;
   --popover: #ffffff;
-  --popover-foreground: #22211e;
-  --primary: #22211e;
-  --primary-foreground: #faf9f5;
-  --secondary: #f1efe8;
-  --secondary-foreground: #22211e;
-  --muted-foreground: #57534a;
-  --accent: #f1efe8;
-  --accent-foreground: #22211e;
+  --popover-foreground: #1c1c1c;
+  --primary: #1c1c1c;
+  --primary-foreground: #ffffff;
+  --secondary: #f0f0f0;
+  --secondary-foreground: #1c1c1c;
+  --muted-foreground: #525252;
+  --accent: #f0f0f0;
+  --accent-foreground: #1c1c1c;
   --destructive: oklch(0.577 0.245 27.325);
-  --input: oklch(0 0 0 / 8%);
-  --brand: #2200ff;
+  --input: oklch(0 0 0 / 10%);
+  --brand: #c8102e;
   --brand-foreground: #ffffff;
-  --ring: #44403a;
-  --selection: #e6e1d5;
-  --selection-foreground: #22211e;
-  /* Soft two-layer card shadow: invisible as "shadow", read as depth. Dark
-     mode zeroes it out and relies on surface contrast instead. */
-  --shadow-card:
-    0 1px 2px rgb(34 33 30 / 0.04), 0 4px 12px -2px rgb(34 33 30 / 0.04);
+  --ring: #1c1c1c;
+  --selection: #1c1c1c;
+  --selection-foreground: #ffffff;
+  /* Swiss surfaces are flat: hairline rules carry the structure, so the
+     card shadow is zeroed in both modes. */
+  --shadow-card: 0 0 rgb(0 0 0 / 0);
   --chart-1: oklch(0.269 0 0);
   --chart-2: oklch(0.439 0 0);
   --chart-3: oklch(0.556 0 0);
   --chart-4: oklch(0.708 0 0);
   --chart-5: oklch(0.87 0 0);
-  --radius: 0.625rem;
+  --radius: 0rem;
   --sidebar: #ffffff;
-  --sidebar-foreground: #22211e;
-  --sidebar-primary: #22211e;
-  --sidebar-primary-foreground: #faf9f5;
-  --sidebar-accent: #f1efe8;
-  --sidebar-accent-foreground: #22211e;
-  --sidebar-border: #e7e3da;
-  --sidebar-ring: #78716a;
+  --sidebar-foreground: #1c1c1c;
+  --sidebar-primary: #1c1c1c;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: #f0f0f0;
+  --sidebar-accent-foreground: #1c1c1c;
+  --sidebar-border: #e4e4e4;
+  --sidebar-ring: #757575;
 }
 
 @theme inline {
@@ -113,14 +112,14 @@ body {
   font-family: var(--font-sans), system-ui, sans-serif;
 }
 
-/* Neutral, not brand: selection is incidental, so it shouldn't compete with
-   the one blue thing on screen. */
+/* Selection inverts to charcoal-on-white / white-on-charcoal — the classic
+   print negative — rather than a tint. */
 ::selection {
   background: var(--selection);
   color: var(--selection-foreground);
 }
 
-/* Chrome paints autofilled fields yellow, which clashes with the paper
+/* Chrome paints autofilled fields yellow, which clashes with the achromatic
    palette. The background is set via an internal style that can't be
    overridden directly, but it *can* be transitioned — delaying it
    indefinitely keeps the field transparent while the ink stays themed. */
@@ -137,7 +136,7 @@ input:-webkit-autofill:focus {
   font-family: var(--font-mono), monospace;
   font-size: 10px;
   font-weight: 500;
-  letter-spacing: 0.18em;
+  letter-spacing: 0.22em;
   text-transform: uppercase;
 }
 
@@ -184,50 +183,50 @@ input:-webkit-autofill:focus {
   }
 }
 
-/* Dark mode — "Paper" after dark: the near-black picks up a faint cool cast
-   while the text stays warm off-white, and contrast drops from 18:1 to ~16:1
-   to stop white type haloing on OLED. */
+/* Dark mode — "Charcoal Mono" inverted: the page becomes the charcoal plate
+   and the type becomes the paper. Greys stay strictly achromatic; the red
+   accent lifts slightly so it holds its weight against the dark field. */
 .dark {
-  --surface: #141416;
-  --surface-hover: #1a1a1d;
-  --border: #26262a;
-  --border-strong: #3a3a40;
-  --muted: #212125;
-  --muted-dim: #7a7772;
-  --background: #0c0c0e;
-  --foreground: #e8e6e1;
-  --card: #141416;
-  --card-foreground: #e8e6e1;
-  --popover: #1a1a1d;
-  --popover-foreground: #e8e6e1;
-  --primary: #e8e6e1;
-  --primary-foreground: #0c0c0e;
-  --secondary: #2b2b30;
-  --secondary-foreground: #e8e6e1;
-  --muted-foreground: #a8a5a0;
-  --accent: #2b2b30;
-  --accent-foreground: #e8e6e1;
+  --surface: #1c1c1c;
+  --surface-hover: #232323;
+  --border: #2a2a2a;
+  --border-strong: #3f3f3f;
+  --muted: #242424;
+  --muted-dim: #8a8a8a;
+  --background: #121212;
+  --foreground: #ededed;
+  --card: #1c1c1c;
+  --card-foreground: #ededed;
+  --popover: #1c1c1c;
+  --popover-foreground: #ededed;
+  --primary: #ededed;
+  --primary-foreground: #121212;
+  --secondary: #2a2a2a;
+  --secondary-foreground: #ededed;
+  --muted-foreground: #a8a8a8;
+  --accent: #2a2a2a;
+  --accent-foreground: #ededed;
   --destructive: oklch(0.704 0.191 22.216);
   --input: oklch(1 0 0 / 15%);
-  --brand: #2200ff;
+  --brand: #d41436;
   --brand-foreground: #ffffff;
-  --ring: #c4c1bb;
-  --selection: #33333a;
-  --selection-foreground: #e8e6e1;
+  --ring: #ededed;
+  --selection: #ededed;
+  --selection-foreground: #121212;
   --shadow-card: 0 0 rgb(0 0 0 / 0);
   --chart-1: oklch(0.87 0 0);
   --chart-2: oklch(0.556 0 0);
   --chart-3: oklch(0.439 0 0);
   --chart-4: oklch(0.371 0 0);
   --chart-5: oklch(0.269 0 0);
-  --sidebar: #141416;
-  --sidebar-foreground: #e8e6e1;
-  --sidebar-primary: #e8e6e1;
-  --sidebar-primary-foreground: #0c0c0e;
-  --sidebar-accent: #2b2b30;
-  --sidebar-accent-foreground: #e8e6e1;
-  --sidebar-border: #26262a;
-  --sidebar-ring: #7a7772;
+  --sidebar: #1c1c1c;
+  --sidebar-foreground: #ededed;
+  --sidebar-primary: #ededed;
+  --sidebar-primary-foreground: #121212;
+  --sidebar-accent: #2a2a2a;
+  --sidebar-accent-foreground: #ededed;
+  --sidebar-border: #2a2a2a;
+  --sidebar-ring: #8a8a8a;
 }
 
 @layer base {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -26,9 +26,9 @@ export const metadata: Metadata = {
 // page background automatically.
 const clerkAppearance: React.ComponentProps<typeof ClerkProvider>["appearance"] = {
   variables: {
-    colorPrimary: "#2200ff",
+    colorPrimary: "#1c1c1c",
     colorPrimaryForeground: "#ffffff",
-    borderRadius: "0.625rem",
+    borderRadius: "0rem",
     fontFamily: "var(--font-geist-sans), system-ui, sans-serif",
   },
   options: {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -154,7 +154,7 @@ export default function Home() {
         {process.env.NEXT_PUBLIC_IS_DEVIN ? "Devin " : ""}Event credit
         distribution
       </p>
-      <h1 className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-100 mt-6 max-w-2xl font-heading text-5xl leading-[0.95] font-semibold tracking-[-0.03em] text-balance text-black dark:text-white motion-reduce:animate-none sm:text-7xl">
+      <h1 className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-100 mt-6 max-w-2xl font-heading text-5xl leading-[0.95] font-bold tracking-[-0.04em] text-balance text-black dark:text-white motion-reduce:animate-none sm:text-7xl">
         Claim your credits.
       </h1>
       <p className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-200 mt-6 max-w-md text-sm leading-relaxed text-black/70 dark:text-white/70 motion-reduce:animate-none">
@@ -176,7 +176,7 @@ export default function Home() {
               by project swaps it cleanly on theme change while the copy stays
               mounted. The scene's mouse interactivity listens on window, so
               the copy sitting above it doesn't block it. */}
-          <div className="relative h-[520px] overflow-hidden bg-background dark:bg-[#131313] sm:h-[486px]">
+          <div className="relative h-[520px] overflow-hidden bg-background dark:bg-[#121212] sm:h-[486px]">
             {heroProjectId ? (
               <div className="absolute inset-0" aria-hidden>
                 {/* Dev fetches fresh scene data on every load; deploys pin
@@ -203,9 +203,7 @@ export default function Home() {
         </section>
 
         <section className="mx-auto w-full max-w-5xl px-4 py-14 sm:px-6 sm:py-20">
-          <h2 className="text-sm font-medium text-muted-foreground">
-            Active events
-          </h2>
+          <h2 className="eyebrow text-muted-foreground">Active events</h2>
 
           {events === undefined ? (
             <div
@@ -258,7 +256,7 @@ export default function Home() {
               {past.length > 0 ? (
                 <>
                   <div className="mt-14 flex items-baseline justify-between">
-                    <h2 className="text-sm font-medium text-muted-foreground">
+                    <h2 className="eyebrow text-muted-foreground">
                       Past events
                     </h2>
                     <span className="font-mono text-xs text-muted-dim tabular-nums">

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -10,7 +10,7 @@ const buttonVariants = cva(
       variant: {
         default: "bg-primary text-primary-foreground hover:bg-primary/80",
         brand:
-          "bg-brand text-brand-foreground hover:bg-brand/85 hover:shadow-[0_2px_16px_-4px_var(--brand)]",
+          "bg-brand text-brand-foreground hover:bg-brand/85",
         outline:
           "border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
         secondary:


### PR DESCRIPTION
## Summary
Visual-only retheme in the Swiss / International Typographic direction, "Charcoal Mono" colorway. No functionality, route, or Convex changes.

`app/globals.css` (both modes):
- Palette moves from the warm "Paper" neutrals to a strictly achromatic charcoal axis: light = `#ffffff` field / `#1c1c1c` ink with hairline `#e4e4e4` rules; dark = inverted `#121212` / `#ededed`.
- `--radius: 0rem` — all derived shadcn radii collapse to square corners.
- `--shadow-card` zeroed in both modes; hairline rules carry structure instead of depth.
- The single accent `--brand` changes from blue `#2200ff` to Swiss red (`#c8102e` light / `#d41436` dark, both ≥5:1 on white text), still reserved for the claim flow.
- Selection becomes the print negative (charcoal↔white); `eyebrow` tracking widened to `0.22em`.

Targeted component tweaks to sell the direction:
- `button.tsx`: drop the brand glow `hover:shadow-[0_2px_16px_-4px_var(--brand)]` (no decoration).
- `app/page.tsx`: hero headline `font-semibold tracking-[-0.03em]` → `font-bold tracking-[-0.04em]`; "Active/Past events" headings become uppercase mono `eyebrow` labels; hero dark fill aligned to `#121212`.
- `app/layout.tsx`: Clerk appearance follows (`colorPrimary: #1c1c1c`, `borderRadius: 0rem`).

`npm run lint` and `npx tsc --noEmit` pass. No screenshots: the app can't render locally (no `.env.local` / Convex deployment configured in this environment).

Link to Devin session: https://app.devin.ai/sessions/a634d2512d8140ea8e86267f2f0afb31
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->