### PR TITLE
Design: Glassmorphism — Sunset Haze

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,57 +4,60 @@
 
 @custom-variant dark (&:is(.dark *));
 
-/* Light mode (default) — "Paper": a white page field with warm off-neutrals
-   in the tints and borders rather than the pure grey axis, and ink (#22211E)
-   instead of near-black so text stays short of a harsh 19:1. Surface is a
-   neutral grey one step off white — hovers and the receipt stub read as a
-   quiet press of the field rather than a cream block. The blue accent is
+/* Light mode (default) — "Sunset Haze" glassmorphism: a warm hazy page field
+   washed with soft peach-to-lavender gradients, frosted translucent cards
+   with backdrop blur, thin luminous borders, and large radii. Text is deep
+   plum ink so contrast stays high against the warm haze. The coral accent is
    reserved for the claim flow only. */
 :root {
-  --surface: #f6f6f6;
-  --surface-hover: #f0f0f0;
-  --border: #eae7df;
-  --border-strong: #d5cfc2;
-  --muted: #f1efe8;
-  --muted-dim: #78716a;
-  --background: #ffffff;
-  --foreground: #22211e;
-  --card: #ffffff;
-  --card-foreground: #22211e;
-  --popover: #ffffff;
-  --popover-foreground: #22211e;
-  --primary: #22211e;
-  --primary-foreground: #faf9f5;
-  --secondary: #f1efe8;
-  --secondary-foreground: #22211e;
-  --muted-foreground: #57534a;
-  --accent: #f1efe8;
-  --accent-foreground: #22211e;
+  --surface: rgb(255 255 255 / 0.4);
+  --surface-hover: rgb(255 255 255 / 0.62);
+  --border: rgb(173 96 88 / 0.22);
+  --border-strong: rgb(150 78 72 / 0.42);
+  --muted: rgb(255 234 222 / 0.65);
+  --muted-dim: #92616c;
+  --background: #fdf4ee;
+  --foreground: #3b2433;
+  --card: rgb(255 255 255 / 0.55);
+  --card-foreground: #3b2433;
+  --popover: rgb(255 251 248 / 0.92);
+  --popover-foreground: #3b2433;
+  --primary: #3b2433;
+  --primary-foreground: #fff6ef;
+  --secondary: rgb(250 226 212 / 0.8);
+  --secondary-foreground: #3b2433;
+  --muted-foreground: #6d4a55;
+  --accent: rgb(250 226 212 / 0.8);
+  --accent-foreground: #3b2433;
   --destructive: oklch(0.577 0.245 27.325);
-  --input: oklch(0 0 0 / 8%);
-  --brand: #2200ff;
+  --input: oklch(0.35 0.06 20 / 12%);
+  --brand: #c93d12;
   --brand-foreground: #ffffff;
-  --ring: #44403a;
-  --selection: #e6e1d5;
-  --selection-foreground: #22211e;
-  /* Soft two-layer card shadow: invisible as "shadow", read as depth. Dark
-     mode zeroes it out and relies on surface contrast instead. */
+  --ring: #a35a43;
+  --selection: #fbd8c3;
+  --selection-foreground: #3b2433;
+  /* Luminous hairline for glass edges — brighter than the border tokens so
+     frosted panels catch the light. */
+  --glass-border: rgb(255 255 255 / 0.65);
+  /* Airy glass shadow: a soft warm drop plus an inner top highlight that
+     reads as light hitting the frosted pane. */
   --shadow-card:
-    0 1px 2px rgb(34 33 30 / 0.04), 0 4px 12px -2px rgb(34 33 30 / 0.04);
-  --chart-1: oklch(0.269 0 0);
-  --chart-2: oklch(0.439 0 0);
-  --chart-3: oklch(0.556 0 0);
-  --chart-4: oklch(0.708 0 0);
-  --chart-5: oklch(0.87 0 0);
-  --radius: 0.625rem;
-  --sidebar: #ffffff;
-  --sidebar-foreground: #22211e;
-  --sidebar-primary: #22211e;
-  --sidebar-primary-foreground: #faf9f5;
-  --sidebar-accent: #f1efe8;
-  --sidebar-accent-foreground: #22211e;
-  --sidebar-border: #e7e3da;
-  --sidebar-ring: #78716a;
+    inset 0 1px 0 rgb(255 255 255 / 0.6),
+    0 8px 32px -8px rgb(130 62 84 / 0.18);
+  --chart-1: oklch(0.62 0.19 35);
+  --chart-2: oklch(0.66 0.16 15);
+  --chart-3: oklch(0.58 0.15 320);
+  --chart-4: oklch(0.52 0.13 290);
+  --chart-5: oklch(0.72 0.12 55);
+  --radius: 1rem;
+  --sidebar: rgb(255 255 255 / 0.55);
+  --sidebar-foreground: #3b2433;
+  --sidebar-primary: #3b2433;
+  --sidebar-primary-foreground: #fff6ef;
+  --sidebar-accent: rgb(250 226 212 / 0.8);
+  --sidebar-accent-foreground: #3b2433;
+  --sidebar-border: rgb(173 96 88 / 0.22);
+  --sidebar-ring: #92616c;
 }
 
 @theme inline {
@@ -73,6 +76,7 @@
   --font-heading: var(--font-geist-sans);
   --color-brand: var(--brand);
   --color-brand-foreground: var(--brand-foreground);
+  --color-glass-border: var(--glass-border);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -111,10 +115,34 @@
 
 body {
   font-family: var(--font-sans), system-ui, sans-serif;
+  /* Sunset haze wash: soft peach, rose, and lavender pools drifting over the
+     page field. Fixed so frosted panels scroll across a stable gradient. */
+  background-image:
+    radial-gradient(52rem 36rem at 12% -6%, rgb(255 176 122 / 0.32), transparent 65%),
+    radial-gradient(46rem 32rem at 88% 4%, rgb(255 138 158 / 0.24), transparent 65%),
+    radial-gradient(56rem 40rem at 50% 108%, rgb(178 142 255 / 0.22), transparent 68%);
+  background-attachment: fixed;
+}
+
+.dark body {
+  background-image:
+    radial-gradient(52rem 36rem at 12% -6%, rgb(255 122 74 / 0.13), transparent 65%),
+    radial-gradient(46rem 32rem at 88% 4%, rgb(226 88 128 / 0.11), transparent 65%),
+    radial-gradient(56rem 40rem at 50% 108%, rgb(140 100 255 / 0.13), transparent 68%);
+}
+
+/* Frosted panes: cards and floating panels blur whatever drifts behind them,
+   which is what sells the translucent fills above. */
+[data-slot="card"],
+[data-slot="dialog-content"],
+[data-slot="alert-dialog-content"],
+[data-slot="popover"] {
+  backdrop-filter: blur(16px) saturate(140%);
+  -webkit-backdrop-filter: blur(16px) saturate(140%);
 }
 
 /* Neutral, not brand: selection is incidental, so it shouldn't compete with
-   the one blue thing on screen. */
+   the one coral thing on screen. */
 ::selection {
   background: var(--selection);
   color: var(--selection-foreground);
@@ -184,50 +212,53 @@ input:-webkit-autofill:focus {
   }
 }
 
-/* Dark mode — "Paper" after dark: the near-black picks up a faint cool cast
-   while the text stays warm off-white, and contrast drops from 18:1 to ~16:1
-   to stop white type haloing on OLED. */
+/* Dark mode — "Sunset Haze" at dusk: a deep plum-indigo field with the same
+   sunset pools dimmed to embers, frosted panes as faint white veils, and
+   luminous hairline borders doing the separating work. */
 .dark {
-  --surface: #141416;
-  --surface-hover: #1a1a1d;
-  --border: #26262a;
-  --border-strong: #3a3a40;
-  --muted: #212125;
-  --muted-dim: #7a7772;
-  --background: #0c0c0e;
-  --foreground: #e8e6e1;
-  --card: #141416;
-  --card-foreground: #e8e6e1;
-  --popover: #1a1a1d;
-  --popover-foreground: #e8e6e1;
-  --primary: #e8e6e1;
-  --primary-foreground: #0c0c0e;
-  --secondary: #2b2b30;
-  --secondary-foreground: #e8e6e1;
-  --muted-foreground: #a8a5a0;
-  --accent: #2b2b30;
-  --accent-foreground: #e8e6e1;
+  --surface: rgb(255 255 255 / 0.05);
+  --surface-hover: rgb(255 255 255 / 0.09);
+  --border: rgb(255 224 214 / 0.13);
+  --border-strong: rgb(255 224 214 / 0.26);
+  --muted: rgb(255 255 255 / 0.07);
+  --muted-dim: #a3899a;
+  --background: #171020;
+  --foreground: #f3e9e6;
+  --card: rgb(255 255 255 / 0.06);
+  --card-foreground: #f3e9e6;
+  --popover: rgb(40 28 48 / 0.94);
+  --popover-foreground: #f3e9e6;
+  --primary: #f3e9e6;
+  --primary-foreground: #241627;
+  --secondary: rgb(255 255 255 / 0.11);
+  --secondary-foreground: #f3e9e6;
+  --muted-foreground: #cbb4b8;
+  --accent: rgb(255 255 255 / 0.11);
+  --accent-foreground: #f3e9e6;
   --destructive: oklch(0.704 0.191 22.216);
   --input: oklch(1 0 0 / 15%);
-  --brand: #2200ff;
-  --brand-foreground: #ffffff;
-  --ring: #c4c1bb;
-  --selection: #33333a;
-  --selection-foreground: #e8e6e1;
-  --shadow-card: 0 0 rgb(0 0 0 / 0);
-  --chart-1: oklch(0.87 0 0);
-  --chart-2: oklch(0.556 0 0);
-  --chart-3: oklch(0.439 0 0);
-  --chart-4: oklch(0.371 0 0);
-  --chart-5: oklch(0.269 0 0);
-  --sidebar: #141416;
-  --sidebar-foreground: #e8e6e1;
-  --sidebar-primary: #e8e6e1;
-  --sidebar-primary-foreground: #0c0c0e;
-  --sidebar-accent: #2b2b30;
-  --sidebar-accent-foreground: #e8e6e1;
-  --sidebar-border: #26262a;
-  --sidebar-ring: #7a7772;
+  --brand: #ff6a3c;
+  --brand-foreground: #2b1006;
+  --ring: #e39b76;
+  --selection: #4c2c3d;
+  --selection-foreground: #f3e9e6;
+  --glass-border: rgb(255 235 224 / 0.14);
+  --shadow-card:
+    inset 0 1px 0 rgb(255 255 255 / 0.07),
+    0 8px 32px -8px rgb(0 0 0 / 0.5);
+  --chart-1: oklch(0.78 0.15 45);
+  --chart-2: oklch(0.72 0.16 15);
+  --chart-3: oklch(0.68 0.14 320);
+  --chart-4: oklch(0.6 0.13 290);
+  --chart-5: oklch(0.84 0.1 60);
+  --sidebar: rgb(255 255 255 / 0.06);
+  --sidebar-foreground: #f3e9e6;
+  --sidebar-primary: #f3e9e6;
+  --sidebar-primary-foreground: #241627;
+  --sidebar-accent: rgb(255 255 255 / 0.11);
+  --sidebar-accent-foreground: #f3e9e6;
+  --sidebar-border: rgb(255 224 214 / 0.13);
+  --sidebar-ring: #a3899a;
 }
 
 @layer base {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -26,9 +26,9 @@ export const metadata: Metadata = {
 // page background automatically.
 const clerkAppearance: React.ComponentProps<typeof ClerkProvider>["appearance"] = {
   variables: {
-    colorPrimary: "#2200ff",
+    colorPrimary: "#c93d12",
     colorPrimaryForeground: "#ffffff",
-    borderRadius: "0.625rem",
+    borderRadius: "1rem",
     fontFamily: "var(--font-geist-sans), system-ui, sans-serif",
   },
   options: {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -176,7 +176,7 @@ export default function Home() {
               by project swaps it cleanly on theme change while the copy stays
               mounted. The scene's mouse interactivity listens on window, so
               the copy sitting above it doesn't block it. */}
-          <div className="relative h-[520px] overflow-hidden bg-background dark:bg-[#131313] sm:h-[486px]">
+          <div className="relative h-[520px] overflow-hidden bg-background dark:bg-[#171020] sm:h-[486px]">
             {heroProjectId ? (
               <div className="absolute inset-0" aria-hidden>
                 {/* Dev fetches fresh scene data on every load; deploys pin

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -12,7 +12,7 @@ function Card({
       data-slot="card"
       data-size={size}
       className={cn(
-        "group/card flex flex-col gap-(--card-spacing) overflow-hidden rounded-xl bg-card py-(--card-spacing) text-sm text-card-foreground shadow-(--shadow-card) ring-1 ring-foreground/10 [--card-spacing:--spacing(4)] has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:[--card-spacing:--spacing(3)] data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
+        "group/card flex flex-col gap-(--card-spacing) overflow-hidden rounded-xl bg-card py-(--card-spacing) text-sm text-card-foreground shadow-(--shadow-card) ring-1 ring-glass-border [--card-spacing:--spacing(4)] has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:[--card-spacing:--spacing(3)] data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
Visual-only retheme from "Paper" to a Glassmorphism direction in a Sunset Haze colorway, expressed almost entirely through the CSS variables in `app/globals.css` for both light and dark modes:

- Page field: warm haze (`#fdf4ee` light / dusk plum-indigo `#171020` dark) with a fixed `body` background of soft radial peach/rose/lavender gradient pools (dimmed to embers in dark mode).
- Frosted panes: `--card`, `--surface`, `--secondary`, etc. become translucent white fills; a global rule adds `backdrop-filter: blur(16px) saturate(140%)` to `[data-slot="card"|"dialog-content"|"alert-dialog-content"|"popover"]`.
- New `--glass-border` luminous hairline token; `Card`'s `ring-foreground/10` → `ring-glass-border` so glass edges catch the light.
- `--shadow-card` becomes an airy glass shadow: inset top highlight + soft warm drop.
- `--radius` 0.625rem → 1rem for larger radii.
- Accent moves from `#2200ff` blue to sunset coral (`#c93d12` light / `#ff6a3c` with dark ink foreground in dark mode), still reserved for the claim flow; Clerk `colorPrimary`/`borderRadius` updated to match.
- Text stays deep plum ink / warm off-white; muted foregrounds chosen to keep ≥4.5:1 contrast on the haze.

No functionality, routes, or Convex logic changed. `npm run lint` and `npx tsc --noEmit` pass. Skipped screenshots: no local Convex/Clerk env is configured, so the dev server can't render.

Link to Devin session: https://app.devin.ai/sessions/39c2db77d3c34e05a34f73bd74937683
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/109" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->