### PR TITLE
Design direction: Luxury Dark

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,39 +4,37 @@
 
 @custom-variant dark (&:is(.dark *));
 
-/* Light mode (default) — "Paper": a white page field with warm off-neutrals
-   in the tints and borders rather than the pure grey axis, and ink (#22211E)
-   instead of near-black so text stays short of a harsh 19:1. Surface is a
-   neutral grey one step off white — hovers and the receipt stub read as a
-   quiet press of the field rather than a cream block. The blue accent is
-   reserved for the claim flow only. */
+/* Light mode — "Ivory Salon": the luxury palette's daylight companion. A
+   warm ivory field with champagne-gold accents, hairline parchment borders,
+   and deep espresso ink. Gold is the single accent, reserved for the claim
+   flow and fine metallic details. */
 :root {
-  --surface: #f6f6f6;
-  --surface-hover: #f0f0f0;
-  --border: #eae7df;
-  --border-strong: #d5cfc2;
-  --muted: #f1efe8;
-  --muted-dim: #78716a;
-  --background: #ffffff;
-  --foreground: #22211e;
-  --card: #ffffff;
-  --card-foreground: #22211e;
-  --popover: #ffffff;
-  --popover-foreground: #22211e;
-  --primary: #22211e;
-  --primary-foreground: #faf9f5;
-  --secondary: #f1efe8;
-  --secondary-foreground: #22211e;
-  --muted-foreground: #57534a;
-  --accent: #f1efe8;
-  --accent-foreground: #22211e;
+  --surface: #f5f1e8;
+  --surface-hover: #efe9dc;
+  --border: #e7dfcd;
+  --border-strong: #d2c5a8;
+  --muted: #f1ebdd;
+  --muted-dim: #8a7f6a;
+  --background: #faf7f0;
+  --foreground: #1e1a12;
+  --card: #fdfbf6;
+  --card-foreground: #1e1a12;
+  --popover: #fdfbf6;
+  --popover-foreground: #1e1a12;
+  --primary: #1e1a12;
+  --primary-foreground: #f8f4ea;
+  --secondary: #f1ebdd;
+  --secondary-foreground: #1e1a12;
+  --muted-foreground: #5c5442;
+  --accent: #f1ebdd;
+  --accent-foreground: #1e1a12;
   --destructive: oklch(0.577 0.245 27.325);
   --input: oklch(0 0 0 / 8%);
-  --brand: #2200ff;
-  --brand-foreground: #ffffff;
-  --ring: #44403a;
-  --selection: #e6e1d5;
-  --selection-foreground: #22211e;
+  --brand: #9a7b2f;
+  --brand-foreground: #fdfbf6;
+  --ring: #9a7b2f;
+  --selection: #ecdfc0;
+  --selection-foreground: #1e1a12;
   /* Soft two-layer card shadow: invisible as "shadow", read as depth. Dark
      mode zeroes it out and relies on surface contrast instead. */
   --shadow-card:
@@ -47,14 +45,14 @@
   --chart-4: oklch(0.708 0 0);
   --chart-5: oklch(0.87 0 0);
   --radius: 0.625rem;
-  --sidebar: #ffffff;
-  --sidebar-foreground: #22211e;
-  --sidebar-primary: #22211e;
-  --sidebar-primary-foreground: #faf9f5;
-  --sidebar-accent: #f1efe8;
-  --sidebar-accent-foreground: #22211e;
-  --sidebar-border: #e7e3da;
-  --sidebar-ring: #78716a;
+  --sidebar: #fdfbf6;
+  --sidebar-foreground: #1e1a12;
+  --sidebar-primary: #1e1a12;
+  --sidebar-primary-foreground: #f8f4ea;
+  --sidebar-accent: #f1ebdd;
+  --sidebar-accent-foreground: #1e1a12;
+  --sidebar-border: #e7dfcd;
+  --sidebar-ring: #8a7f6a;
 }
 
 @theme inline {
@@ -68,9 +66,9 @@
   --color-muted-dim: var(--muted-dim);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
-  /* Headings share the body face — hierarchy comes from weight, size, and
-     tracking rather than a second display family. */
-  --font-heading: var(--font-geist-sans);
+  /* Headings switch to the luxury serif — the display face carries the
+     premium register while body copy stays on the grotesque. */
+  --font-heading: var(--font-luxury-serif);
   --color-brand: var(--brand);
   --color-brand-foreground: var(--brand-foreground);
   --color-sidebar-ring: var(--sidebar-ring);
@@ -114,7 +112,7 @@ body {
 }
 
 /* Neutral, not brand: selection is incidental, so it shouldn't compete with
-   the one blue thing on screen. */
+   the gold accents on screen. */
 ::selection {
   background: var(--selection);
   color: var(--selection-foreground);
@@ -184,50 +182,51 @@ input:-webkit-autofill:focus {
   }
 }
 
-/* Dark mode — "Paper" after dark: the near-black picks up a faint cool cast
-   while the text stays warm off-white, and contrast drops from 18:1 to ~16:1
-   to stop white type haloing on OLED. */
+/* Dark mode — "Luxury Dark": rich near-black surfaces with a warm cast,
+   champagne-gold as the single metallic accent, and fine gold-tinted
+   hairline borders. Text is warm parchment rather than white so nothing
+   glares against the black lacquer field. */
 .dark {
-  --surface: #141416;
-  --surface-hover: #1a1a1d;
-  --border: #26262a;
-  --border-strong: #3a3a40;
-  --muted: #212125;
-  --muted-dim: #7a7772;
-  --background: #0c0c0e;
-  --foreground: #e8e6e1;
-  --card: #141416;
-  --card-foreground: #e8e6e1;
-  --popover: #1a1a1d;
-  --popover-foreground: #e8e6e1;
-  --primary: #e8e6e1;
-  --primary-foreground: #0c0c0e;
-  --secondary: #2b2b30;
-  --secondary-foreground: #e8e6e1;
-  --muted-foreground: #a8a5a0;
-  --accent: #2b2b30;
-  --accent-foreground: #e8e6e1;
+  --surface: #131109;
+  --surface-hover: #191610;
+  --border: #29241a;
+  --border-strong: #453b28;
+  --muted: #1e1a12;
+  --muted-dim: #8a8172;
+  --background: #0b0a07;
+  --foreground: #ece6d8;
+  --card: #12100b;
+  --card-foreground: #ece6d8;
+  --popover: #17140e;
+  --popover-foreground: #ece6d8;
+  --primary: #e6ddc8;
+  --primary-foreground: #0b0a07;
+  --secondary: #241f15;
+  --secondary-foreground: #ece6d8;
+  --muted-foreground: #b0a793;
+  --accent: #241f15;
+  --accent-foreground: #ece6d8;
   --destructive: oklch(0.704 0.191 22.216);
   --input: oklch(1 0 0 / 15%);
-  --brand: #2200ff;
-  --brand-foreground: #ffffff;
-  --ring: #c4c1bb;
-  --selection: #33333a;
-  --selection-foreground: #e8e6e1;
+  --brand: #c3a35e;
+  --brand-foreground: #16120b;
+  --ring: #c3a35e;
+  --selection: #38301f;
+  --selection-foreground: #ece6d8;
   --shadow-card: 0 0 rgb(0 0 0 / 0);
   --chart-1: oklch(0.87 0 0);
   --chart-2: oklch(0.556 0 0);
   --chart-3: oklch(0.439 0 0);
   --chart-4: oklch(0.371 0 0);
   --chart-5: oklch(0.269 0 0);
-  --sidebar: #141416;
-  --sidebar-foreground: #e8e6e1;
-  --sidebar-primary: #e8e6e1;
-  --sidebar-primary-foreground: #0c0c0e;
-  --sidebar-accent: #2b2b30;
-  --sidebar-accent-foreground: #e8e6e1;
-  --sidebar-border: #26262a;
-  --sidebar-ring: #7a7772;
+  --sidebar: #12100b;
+  --sidebar-foreground: #ece6d8;
+  --sidebar-primary: #e6ddc8;
+  --sidebar-primary-foreground: #0b0a07;
+  --sidebar-accent: #241f15;
+  --sidebar-accent-foreground: #ece6d8;
+  --sidebar-border: #29241a;
+  --sidebar-ring: #8a8172;
 }
 
 @layer base {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Cormorant_Garamond, Geist, Geist_Mono } from "next/font/google";
 import { ClerkProvider } from "@clerk/nextjs";
 import ConvexClientProvider from "@/components/ConvexClientProvider";
 import { ThemeProvider } from "@/components/ThemeProvider";
@@ -17,6 +17,14 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
+// Luxury serif reserved for display headings — body copy stays on the
+// grotesque for legibility.
+const cormorant = Cormorant_Garamond({
+  variable: "--font-luxury-serif",
+  subsets: ["latin"],
+  weight: ["500", "600", "700"],
+});
+
 export const metadata: Metadata = {
   title: getAppName(),
   description: "Claim credits for hackathons, conferences, and meetups.",
@@ -26,8 +34,8 @@ export const metadata: Metadata = {
 // page background automatically.
 const clerkAppearance: React.ComponentProps<typeof ClerkProvider>["appearance"] = {
   variables: {
-    colorPrimary: "#2200ff",
-    colorPrimaryForeground: "#ffffff",
+    colorPrimary: "#c3a35e",
+    colorPrimaryForeground: "#16120b",
     borderRadius: "0.625rem",
     fontFamily: "var(--font-geist-sans), system-ui, sans-serif",
   },
@@ -49,7 +57,7 @@ export default function RootLayout({
     <ClerkProvider appearance={clerkAppearance}>
       <html
         lang="en"
-        className={`${geistSans.variable} ${geistMono.variable} h-full overscroll-none antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} ${cormorant.variable} h-full overscroll-none antialiased`}
         suppressHydrationWarning
       >
         <body className="flex min-h-full flex-col overscroll-none">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -77,7 +77,7 @@ function EventRow({
         )}
       >
         <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 font-heading text-xl font-medium tracking-tight sm:text-2xl">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 font-heading text-2xl font-medium tracking-tight sm:text-3xl">
             {event.name}
             {claimed ? (
               <Badge variant="secondary" className="gap-1">
@@ -150,11 +150,11 @@ export default function Home() {
   // copy centered in the visible area.
   const heroCopy = (
     <div className="relative mx-auto flex h-full w-full max-w-5xl flex-col justify-center px-4 pt-15.25 sm:px-6">
-      <p className="eyebrow animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 text-black/60 dark:text-white/60 motion-reduce:animate-none">
+      <p className="eyebrow animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 text-brand motion-reduce:animate-none">
         {process.env.NEXT_PUBLIC_IS_DEVIN ? "Devin " : ""}Event credit
         distribution
       </p>
-      <h1 className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-100 mt-6 max-w-2xl font-heading text-5xl leading-[0.95] font-semibold tracking-[-0.03em] text-balance text-black dark:text-white motion-reduce:animate-none sm:text-7xl">
+      <h1 className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-100 mt-6 max-w-2xl font-heading text-6xl leading-[0.98] font-medium tracking-[-0.01em] text-balance text-black dark:text-white motion-reduce:animate-none sm:text-8xl">
         Claim your credits.
       </h1>
       <p className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-200 mt-6 max-w-md text-sm leading-relaxed text-black/70 dark:text-white/70 motion-reduce:animate-none">
@@ -176,7 +176,7 @@ export default function Home() {
               by project swaps it cleanly on theme change while the copy stays
               mounted. The scene's mouse interactivity listens on window, so
               the copy sitting above it doesn't block it. */}
-          <div className="relative h-[520px] overflow-hidden bg-background dark:bg-[#131313] sm:h-[486px]">
+          <div className="relative h-[520px] overflow-hidden bg-background dark:bg-[#0b0a07] sm:h-[486px]">
             {heroProjectId ? (
               <div className="absolute inset-0" aria-hidden>
                 {/* Dev fetches fresh scene data on every load; deploys pin
@@ -203,9 +203,7 @@ export default function Home() {
         </section>
 
         <section className="mx-auto w-full max-w-5xl px-4 py-14 sm:px-6 sm:py-20">
-          <h2 className="text-sm font-medium text-muted-foreground">
-            Active events
-          </h2>
+          <h2 className="eyebrow text-brand">Active events</h2>
 
           {events === undefined ? (
             <div
@@ -258,9 +256,7 @@ export default function Home() {
               {past.length > 0 ? (
                 <>
                   <div className="mt-14 flex items-baseline justify-between">
-                    <h2 className="text-sm font-medium text-muted-foreground">
-                      Past events
-                    </h2>
+                    <h2 className="eyebrow text-muted-dim">Past events</h2>
                     <span className="font-mono text-xs text-muted-dim tabular-nums">
                       {String(past.length).padStart(2, "0")}
                     </span>

--- a/components/ClaimPage.tsx
+++ b/components/ClaimPage.tsx
@@ -249,11 +249,11 @@ export default function ClaimPage({
               >
             <Card
               inert={showQr || undefined}
-              className="gap-0 py-0 backface-hidden [grid-area:1/1] [--card-spacing:--spacing(6)] sm:[--card-spacing:--spacing(8)]"
+              className="gap-0 border-t-brand/50 py-0 backface-hidden [grid-area:1/1] [--card-spacing:--spacing(6)] sm:[--card-spacing:--spacing(8)]"
             >
               <CardHeader className="gap-4 pt-(--card-spacing)">
                 <div className="flex items-start justify-between gap-3">
-                  <CardTitle className="font-heading text-3xl font-semibold tracking-[-0.02em] text-balance">
+                  <CardTitle className="font-heading text-4xl font-semibold tracking-[-0.01em] text-balance">
                     {event.name}
                   </CardTitle>
                   <Button
@@ -585,7 +585,7 @@ function QrPanel({
         <div className="flex items-start justify-between gap-3">
           <div className="flex flex-col gap-2">
             <span className="eyebrow text-muted-foreground">Scan to claim</span>
-            <CardTitle className="font-heading text-2xl font-semibold tracking-[-0.02em] text-balance">
+            <CardTitle className="font-heading text-3xl font-semibold tracking-[-0.01em] text-balance">
               {eventName}
             </CardTitle>
           </div>
@@ -645,7 +645,7 @@ function Receipt({
 }) {
   return (
     <div
-      className="receipt-edge receipt-print rounded-t-xl border border-border bg-surface pb-10 motion-reduce:animate-none"
+      className="receipt-edge receipt-print rounded-t-xl border border-border border-t-brand/50 bg-surface pb-10 motion-reduce:animate-none"
       role="status"
     >
       <div className="flex flex-col gap-6 p-6 sm:p-8">
@@ -660,7 +660,7 @@ function Receipt({
         </div>
 
         <div>
-          <h1 className="font-heading text-2xl font-semibold tracking-tight text-balance">
+          <h1 className="font-heading text-3xl font-semibold tracking-tight text-balance">
             {eventName}
           </h1>
           {creditAmount ? (


### PR DESCRIPTION
## Summary
Explores a LUXURY DARK design direction across the user-facing pages (home + claim), keeping all functionality intact.

- `globals.css`: dark palette becomes rich near-black with a warm lacquer cast (`--background: #0b0a07`), champagne-gold as the single metallic accent (`--brand`/`--ring: #c3a35e`), gold-tinted hairline borders, and warm parchment text. Light mode becomes the "Ivory Salon" companion (warm ivory field, gold accent `#9a7b2f`).
- `--font-heading` now points to a new Cormorant Garamond serif (`--font-luxury-serif`, loaded in `layout.tsx`), so all `font-heading` display text (hero, event rows, claim card, receipt) renders in an elegant serif; body copy stays on Geist.
- Home: gold eyebrows for the hero and section labels, larger serif hero headline, hero dark fill matched to the new background.
- Claim page: fine gold top hairline on the claim card and receipt (`border-t-brand/50`), slightly larger serif titles to compensate for the serif's smaller optical size.
- Clerk `colorPrimary` updated to the gold accent.

No logic, data, or flow changes — styling only.

Link to Devin session: https://app.devin.ai/sessions/f52368f892444e8eb27dc21894ccd23c
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->