### PR TITLE
Design direction: Glassmorphism

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -19,7 +19,7 @@
   --muted-dim: #78716a;
   --background: #ffffff;
   --foreground: #22211e;
-  --card: #ffffff;
+  --card: rgb(255 255 255 / 0.55);
   --card-foreground: #22211e;
   --popover: #ffffff;
   --popover-foreground: #22211e;
@@ -55,6 +55,15 @@
   --sidebar-accent-foreground: #22211e;
   --sidebar-border: #e7e3da;
   --sidebar-ring: #78716a;
+  /* Glass layer: frosted panels float over a soft ambient aurora field.
+     Colorways retint the app by swapping only the aurora + glass variables. */
+  --glass-border: rgb(255 255 255 / 0.65);
+  --glass-glow:
+    0 8px 32px rgb(31 38 68 / 0.12),
+    inset 0 1px 0 rgb(255 255 255 / 0.85);
+  --aurora-1: #c7d2fe;
+  --aurora-2: #fbcfe8;
+  --aurora-3: #bae6fd;
 }
 
 @theme inline {
@@ -100,6 +109,7 @@
   --color-popover: var(--popover);
   --color-card-foreground: var(--card-foreground);
   --color-card: var(--card);
+  --color-glass: var(--glass-border);
   --radius-sm: calc(var(--radius) * 0.6);
   --radius-md: calc(var(--radius) * 0.8);
   --radius-lg: var(--radius);
@@ -139,6 +149,24 @@ input:-webkit-autofill:focus {
   font-weight: 500;
   letter-spacing: 0.18em;
   text-transform: uppercase;
+}
+
+/* Frosted glass panel: translucent fill (via bg-card), heavy blur, a hairline
+   highlight border, and a soft ambient glow. */
+@utility glass-panel {
+  backdrop-filter: blur(24px) saturate(1.4);
+  -webkit-backdrop-filter: blur(24px) saturate(1.4);
+  border-color: var(--glass-border);
+  box-shadow: var(--glass-glow);
+}
+
+/* Ambient aurora field: three soft radial gradients layered behind the glass
+   panels to give the blur something to refract. */
+@utility bg-aurora {
+  background-image:
+    radial-gradient(40rem 28rem at 12% 8%, var(--aurora-1), transparent 62%),
+    radial-gradient(36rem 26rem at 88% 18%, var(--aurora-2), transparent 60%),
+    radial-gradient(48rem 34rem at 50% 95%, var(--aurora-3), transparent 65%);
 }
 
 /* Faint dot grid backdrop for hero surfaces. */
@@ -196,7 +224,7 @@ input:-webkit-autofill:focus {
   --muted-dim: #7a7772;
   --background: #0c0c0e;
   --foreground: #e8e6e1;
-  --card: #141416;
+  --card: rgb(30 30 36 / 0.5);
   --card-foreground: #e8e6e1;
   --popover: #1a1a1d;
   --popover-foreground: #e8e6e1;
@@ -228,6 +256,13 @@ input:-webkit-autofill:focus {
   --sidebar-accent-foreground: #e8e6e1;
   --sidebar-border: #26262a;
   --sidebar-ring: #7a7772;
+  --glass-border: rgb(255 255 255 / 0.12);
+  --glass-glow:
+    0 8px 32px rgb(0 0 0 / 0.45),
+    inset 0 1px 0 rgb(255 255 255 / 0.08);
+  --aurora-1: #2b2e5e;
+  --aurora-2: #4a2350;
+  --aurora-3: #123a4a;
 }
 
 @layer base {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -66,7 +66,7 @@ function EventRow({
 }) {
   return (
     <li
-      className="animate-in fade-in slide-in-from-bottom-1 fill-mode-both duration-300 border-b border-border motion-reduce:animate-none"
+      className="animate-in fade-in slide-in-from-bottom-1 fill-mode-both duration-300 border-b border-glass last:border-b-0 motion-reduce:animate-none"
       style={{ animationDelay: `${Math.min(index, 10) * 40}ms` }}
     >
       <Link
@@ -165,6 +165,10 @@ export default function Home() {
 
   return (
     <div className="flex min-h-screen flex-col">
+      <div
+        aria-hidden
+        className="pointer-events-none fixed inset-0 -z-10 bg-aurora"
+      />
       <SiteHeader />
       <main id="main-content" className="flex-1">
         <section className="-mt-15.25 border-b border-border/65">
@@ -209,14 +213,14 @@ export default function Home() {
 
           {events === undefined ? (
             <div
-              className="mt-4 border-t border-border"
+              className="glass-panel mt-4 overflow-hidden rounded-2xl border bg-card"
               role="status"
               aria-label="Loading active events"
             >
               {[0, 1, 2].map((i) => (
                 <div
                   key={i}
-                  className="flex items-center gap-6 border-b border-border px-2 py-7 sm:gap-10 sm:px-4"
+                  className="flex items-center gap-6 border-b border-glass px-2 py-7 last:border-b-0 sm:gap-10 sm:px-4"
                 >
                   <div className="flex min-w-0 flex-1 flex-col gap-2">
                     <Skeleton className="h-5 w-2/3 rounded-sm" />
@@ -226,7 +230,7 @@ export default function Home() {
               ))}
             </div>
           ) : events.length === 0 ? (
-            <Empty className="mt-6 border border-dashed border-border-strong py-16">
+            <Empty className="glass-panel mt-6 rounded-2xl border bg-card py-16">
               <EmptyHeader>
                 <EmptyMedia variant="icon">
                   <Ticket />
@@ -244,7 +248,7 @@ export default function Home() {
                   No active events right now.
                 </p>
               ) : (
-                <ul className="mt-4 border-t border-border">
+                <ul className="glass-panel mt-4 overflow-hidden rounded-2xl border bg-card">
                   {current.map((event, index) => (
                     <EventRow
                       key={event._id}
@@ -265,7 +269,7 @@ export default function Home() {
                       {String(past.length).padStart(2, "0")}
                     </span>
                   </div>
-                  <ul className="mt-4 border-t border-border">
+                  <ul className="glass-panel mt-4 overflow-hidden rounded-2xl border bg-card">
                     {past.map((event, index) => (
                       <EventRow
                         key={event._id}

--- a/components/ClaimPage.tsx
+++ b/components/ClaimPage.tsx
@@ -189,6 +189,7 @@ export default function ClaimPage({
         id="main-content"
         className="relative flex flex-1 items-center justify-center px-4 py-10 sm:px-6 sm:py-16"
       >
+        <div aria-hidden className="pointer-events-none absolute inset-0 bg-aurora" />
         <div
           aria-hidden
           className="pointer-events-none absolute inset-0 bg-dotgrid [mask-image:radial-gradient(ellipse_60%_60%_at_50%_45%,black,transparent)]"
@@ -249,7 +250,7 @@ export default function ClaimPage({
               >
             <Card
               inert={showQr || undefined}
-              className="gap-0 py-0 backface-hidden [grid-area:1/1] [--card-spacing:--spacing(6)] sm:[--card-spacing:--spacing(8)]"
+              className="glass-panel gap-0 rounded-2xl py-0 backface-hidden [grid-area:1/1] [--card-spacing:--spacing(6)] sm:[--card-spacing:--spacing(8)]"
             >
               <CardHeader className="gap-4 pt-(--card-spacing)">
                 <div className="flex items-start justify-between gap-3">
@@ -579,7 +580,7 @@ function QrPanel({
   return (
     <Card
       inert={hidden || undefined}
-      className="gap-0 rotate-y-180 py-0 backface-hidden [grid-area:1/1] [--card-spacing:--spacing(6)] sm:[--card-spacing:--spacing(8)]"
+      className="glass-panel gap-0 rounded-2xl rotate-y-180 py-0 backface-hidden [grid-area:1/1] [--card-spacing:--spacing(6)] sm:[--card-spacing:--spacing(8)]"
     >
       <CardHeader className="gap-2 pt-(--card-spacing)">
         <div className="flex items-start justify-between gap-3">
@@ -645,7 +646,7 @@ function Receipt({
 }) {
   return (
     <div
-      className="receipt-edge receipt-print rounded-t-xl border border-border bg-surface pb-10 motion-reduce:animate-none"
+      className="receipt-edge receipt-print glass-panel rounded-t-xl border bg-card pb-10 motion-reduce:animate-none"
       role="status"
     >
       <div className="flex flex-col gap-6 p-6 sm:p-8">


### PR DESCRIPTION
## Summary
Exploratory design direction: glassmorphism across the main user-facing pages (home + claim), functionality untouched.

- `globals.css`: new `glass-panel` utility (24px backdrop blur + saturate, hairline `--glass-border` highlight, `--glass-glow` inset-highlight/ambient shadow) and `bg-aurora` utility (three soft radial gradients from `--aurora-1..3`) that gives the blur something to refract. `--card` becomes translucent (`rgb(255 255 255 / 0.55)` light, `rgb(30 30 36 / 0.5)` dark) so shadcn Cards read as frosted glass wherever they sit over the aurora field.
- Home: fixed full-page `bg-aurora` backdrop; event lists, loading skeletons, and the empty state become rounded frosted panels (`glass-panel rounded-2xl bg-card`) instead of flat bordered lists.
- Claim page: aurora layer behind the existing dot grid; the claim card, QR flip panel, and receipt all get `glass-panel` treatment.

Colorways can be produced by swapping only the `--glass-*` and `--aurora-*` variables in `:root` / `.dark`.

Link to Devin session: https://app.devin.ai/sessions/09aba51f7b2048d5a87c2f367beaa800
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->