### PR TITLE
Design direction: Editorial Print

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -68,9 +68,10 @@
   --color-muted-dim: var(--muted-dim);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
-  /* Headings share the body face — hierarchy comes from weight, size, and
-     tracking rather than a second display family. */
-  --font-heading: var(--font-geist-sans);
+  /* Editorial print: headlines set in a serif display face, with a text
+     serif for decks and pull quotes. */
+  --font-heading: var(--font-playfair);
+  --font-serif: var(--font-source-serif);
   --color-brand: var(--brand);
   --color-brand-foreground: var(--brand-foreground);
   --color-sidebar-ring: var(--sidebar-ring);
@@ -139,6 +140,25 @@ input:-webkit-autofill:focus {
   font-weight: 500;
   letter-spacing: 0.18em;
   text-transform: uppercase;
+}
+
+/* Editorial double rule: the stacked hairline pair that opens a section,
+   as on a broadsheet front page. */
+@utility rule-double {
+  border-top: 3px double var(--foreground);
+}
+
+/* Heavy masthead rule paired with a hairline below. */
+@utility rule-masthead {
+  border-top: 2px solid var(--foreground);
+  box-shadow: 0 3px 0 -2px var(--foreground);
+}
+
+/* Pull quote: text serif italic with a stout left rule. */
+@utility pull-quote {
+  font-family: var(--font-serif), Georgia, serif;
+  font-style: italic;
+  border-left: 3px solid var(--foreground);
 }
 
 /* Faint dot grid backdrop for hero surfaces. */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Geist, Geist_Mono, Playfair_Display, Source_Serif_4 } from "next/font/google";
 import { ClerkProvider } from "@clerk/nextjs";
 import ConvexClientProvider from "@/components/ConvexClientProvider";
 import { ThemeProvider } from "@/components/ThemeProvider";
@@ -14,6 +14,18 @@ const geistSans = Geist({
 
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
+  subsets: ["latin"],
+});
+
+// Editorial display face for mastheads and headlines.
+const playfair = Playfair_Display({
+  variable: "--font-playfair",
+  subsets: ["latin"],
+});
+
+// Text serif for decks, pull quotes, and running copy.
+const sourceSerif = Source_Serif_4({
+  variable: "--font-source-serif",
   subsets: ["latin"],
 });
 
@@ -49,7 +61,7 @@ export default function RootLayout({
     <ClerkProvider appearance={clerkAppearance}>
       <html
         lang="en"
-        className={`${geistSans.variable} ${geistMono.variable} h-full overscroll-none antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} ${playfair.variable} ${sourceSerif.variable} h-full overscroll-none antialiased`}
         suppressHydrationWarning
       >
         <body className="flex min-h-full flex-col overscroll-none">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,13 +1,10 @@
 "use client";
 
-import { useSyncExternalStore } from "react";
 import Link from "next/link";
 import { BadgeCheck, Ticket } from "lucide-react";
-import { useTheme } from "next-themes";
 import { useConvexAuth, useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { daysUntilEvent, formatEventDate } from "@/lib/event-date";
-import UnicornSceneEmbed from "@/components/UnicornSceneEmbed";
 import SiteHeader from "@/components/SiteHeader";
 import SiteFooter from "@/components/SiteFooter";
 import { Badge } from "@/components/ui/badge";
@@ -20,30 +17,7 @@ import {
   EmptyDescription,
 } from "@/components/ui/empty";
 import { cn } from "@/lib/utils";
-
-// The hero background is a theme-paired Unicorn Studio WebGL scene
-// (experiment). A Unicorn project publishes exactly one authored design and
-// the SDK has no color-scheme awareness, so a light-authored project shows
-// its light design in dark mode too — each theme therefore needs its own
-// project ID here.
-const UNICORN_PROJECTS = {
-  light: "wEz2vCJgsynwCYSb3HgR",
-  dark: "aEdLurlqLEmU1DUjAaUz",
-} as const;
-
-// Bump this whenever a scene is republished in Unicorn Studio. Deployed
-// builds read scene data through Unicorn's CDN, which caches for months and
-// doesn't reliably purge on republish; the update param below is part of the
-// CDN cache key, so bumping the version makes deploys fetch the new design.
-// Dev skips the param (and the CDN): without it the SDK cache-busts every
-// load, so republishes show up on a plain refresh.
-const UNICORN_CACHE_VERSION = 2;
-
-const isProdBuild = process.env.NODE_ENV === "production";
-
-// Stable no-op subscription for the hydration gate below: the snapshot never
-// changes on the client, we only care that the server snapshot is false.
-const emptySubscribe = () => () => {};
+import { getAppName } from "@/lib/app-name";
 
 interface EventItem {
   _id: string;
@@ -72,33 +46,58 @@ function EventRow({
       <Link
         href={`/${event.slug}`}
         className={cn(
-          "group flex items-center gap-6 px-2 py-7 transition-colors hover:bg-surface focus-visible:bg-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/60 sm:gap-10 sm:px-4",
+          "group flex items-baseline gap-5 py-6 transition-colors hover:bg-surface focus-visible:bg-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/60 sm:gap-8",
           past && "opacity-60 transition-opacity hover:opacity-100",
         )}
       >
+        <span
+          className="hidden w-8 shrink-0 font-heading text-lg tabular-nums text-muted-dim sm:inline"
+          aria-hidden
+        >
+          {String(index + 1).padStart(2, "0")}
+        </span>
         <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 font-heading text-xl font-medium tracking-tight sm:text-2xl">
+          <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1 font-heading text-2xl font-medium tracking-tight text-balance sm:text-3xl">
             {event.name}
             {claimed ? (
-              <Badge variant="secondary" className="gap-1">
+              <Badge variant="secondary" className="gap-1 align-middle">
                 <BadgeCheck data-icon="inline-start" />
                 Claimed
               </Badge>
             ) : null}
           </div>
           {event.description ? (
-            <p className="mt-1.5 line-clamp-1 text-sm text-muted-foreground">
+            <p className="mt-1.5 line-clamp-1 font-serif text-sm leading-relaxed text-muted-foreground">
               {event.description}
             </p>
           ) : null}
         </div>
         {event.eventDate ? (
-          <span className="hidden shrink-0 text-xs text-muted-dim tabular-nums sm:inline">
+          <span className="eyebrow hidden shrink-0 text-muted-dim tabular-nums sm:inline">
             {formatEventDate(event.eventDate)}
           </span>
         ) : null}
       </Link>
     </li>
+  );
+}
+
+function SectionHeading({
+  label,
+  count,
+}: {
+  label: string;
+  count?: number;
+}) {
+  return (
+    <div className="rule-double flex items-baseline justify-between border-b border-border pt-2 pb-2">
+      <h2 className="eyebrow text-foreground">{label}</h2>
+      {count !== undefined ? (
+        <span className="font-mono text-xs text-muted-dim tabular-nums">
+          No. {String(count).padStart(2, "0")}
+        </span>
+      ) : null}
+    </div>
   );
 }
 
@@ -109,23 +108,6 @@ export default function Home() {
   const claimedEventIds = new Set(
     mine?.map((item) => item.event?._id).filter(Boolean) ?? [],
   );
-
-  // The scene choice needs JS (the server doesn't know the theme, while the
-  // hydration render already does), so gate it behind hydration to keep both
-  // trees identical; the copy and scrim flip with pure dark: variants and
-  // render correctly from the first paint. Until hydration the plain
-  // theme-tinted shell stands in for both themes.
-  const { resolvedTheme } = useTheme();
-  const hydrated = useSyncExternalStore(
-    emptySubscribe,
-    () => true,
-    () => false,
-  );
-  const heroProjectId = hydrated
-    ? resolvedTheme === "light"
-      ? UNICORN_PROJECTS.light
-      : UNICORN_PROJECTS.dark
-    : undefined;
 
   // Dated events that have passed sink into their own dimmed group; undated
   // events are treated as current. Active events order soonest-first, with
@@ -145,81 +127,46 @@ export default function Home() {
     events?.filter((e) => e.eventDate && daysUntilEvent(e.eventDate) < 0) ?? []
   ).sort((a, b) => (b.eventDate ?? "").localeCompare(a.eventDate ?? ""));
 
-  // Shared hero copy: crisp DOM stacked above the theme's scene. pt-15.25
-  // offsets the translucent header bar the hero slides under, keeping the
-  // copy centered in the visible area.
-  const heroCopy = (
-    <div className="relative mx-auto flex h-full w-full max-w-5xl flex-col justify-center px-4 pt-15.25 sm:px-6">
-      <p className="eyebrow animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 text-black/60 dark:text-white/60 motion-reduce:animate-none">
-        {process.env.NEXT_PUBLIC_IS_DEVIN ? "Devin " : ""}Event credit
-        distribution
-      </p>
-      <h1 className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-100 mt-6 max-w-2xl font-heading text-5xl leading-[0.95] font-semibold tracking-[-0.03em] text-balance text-black dark:text-white motion-reduce:animate-none sm:text-7xl">
-        Claim your credits.
-      </h1>
-      <p className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-200 mt-6 max-w-md text-sm leading-relaxed text-black/70 dark:text-white/70 motion-reduce:animate-none">
-        Sign in, then select your event to claim your credits.
-      </p>
-    </div>
-  );
-
   return (
     <div className="flex min-h-screen flex-col">
       <SiteHeader />
       <main id="main-content" className="flex-1">
-        <section className="-mt-15.25 border-b border-border/65">
-          {/* The section pulls up behind the translucent header bar
-              (-mt-15.25) so the background runs to the top of the page; the
-              hero is 61px taller to compensate and the scene shows through
-              the bar's frosted fill. The theme's Unicorn Studio scene renders
-              behind the copy and a soft theme-matched scrim; keying the scene
-              by project swaps it cleanly on theme change while the copy stays
-              mounted. The scene's mouse interactivity listens on window, so
-              the copy sitting above it doesn't block it. */}
-          <div className="relative h-[520px] overflow-hidden bg-background dark:bg-[#131313] sm:h-[486px]">
-            {heroProjectId ? (
-              <div className="absolute inset-0" aria-hidden>
-                {/* Dev fetches fresh scene data on every load; deploys pin
-                    the CDN to UNICORN_CACHE_VERSION — see the constant. */}
-                <UnicornSceneEmbed
-                  key={heroProjectId}
-                  projectId={
-                    isProdBuild
-                      ? `${heroProjectId}?update=${UNICORN_CACHE_VERSION}`
-                      : heroProjectId
-                  }
-                  production={isProdBuild}
-                />
-              </div>
-            ) : null}
-            {/* Soft scrim keeps the headline legible over the scenes; tune
-                or remove once the look settles. */}
-            <div
-              className="absolute inset-0 bg-white/20 dark:bg-black/20"
-              aria-hidden
-            />
-            {heroCopy}
+        {/* Masthead: a broadsheet front page — dateline row between rules,
+            display-serif headline, and an italic deck set as a pull quote. */}
+        <section className="border-b border-border">
+          <div className="mx-auto w-full max-w-4xl px-6 pt-12 sm:px-8 sm:pt-16">
+            <div className="rule-masthead flex flex-wrap items-baseline justify-between gap-x-6 gap-y-1 pt-3 pb-3">
+              <span className="eyebrow text-muted-foreground">
+                {process.env.NEXT_PUBLIC_IS_DEVIN ? "Devin " : ""}Event credit
+                distribution
+              </span>
+              <span className="eyebrow text-muted-dim">
+                {getAppName()} — Vol. I
+              </span>
+            </div>
+            <div className="border-t border-border pt-10 pb-12 sm:pt-14 sm:pb-16">
+              <h1 className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 max-w-3xl font-heading text-6xl leading-[1.02] font-semibold tracking-tight text-balance motion-reduce:animate-none sm:text-8xl">
+                Claim your credits.
+              </h1>
+              <p className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-150 pull-quote mt-10 max-w-md pl-5 text-lg leading-relaxed text-muted-foreground motion-reduce:animate-none sm:text-xl">
+                Sign in, then select your event to claim your credits.
+              </p>
+            </div>
           </div>
         </section>
 
-        <section className="mx-auto w-full max-w-5xl px-4 py-14 sm:px-6 sm:py-20">
-          <h2 className="text-sm font-medium text-muted-foreground">
-            Active events
-          </h2>
+        <section className="mx-auto w-full max-w-4xl px-6 py-14 sm:px-8 sm:py-20">
+          <SectionHeading label="Active events" count={current.length || undefined} />
 
           {events === undefined ? (
-            <div
-              className="mt-4 border-t border-border"
-              role="status"
-              aria-label="Loading active events"
-            >
+            <div role="status" aria-label="Loading active events">
               {[0, 1, 2].map((i) => (
                 <div
                   key={i}
-                  className="flex items-center gap-6 border-b border-border px-2 py-7 sm:gap-10 sm:px-4"
+                  className="flex items-center gap-6 border-b border-border py-6 sm:gap-10"
                 >
                   <div className="flex min-w-0 flex-1 flex-col gap-2">
-                    <Skeleton className="h-5 w-2/3 rounded-sm" />
+                    <Skeleton className="h-6 w-2/3 rounded-sm" />
                     <Skeleton className="h-3 w-1/2 rounded-sm" />
                   </div>
                 </div>
@@ -231,8 +178,10 @@ export default function Home() {
                 <EmptyMedia variant="icon">
                   <Ticket />
                 </EmptyMedia>
-                <EmptyTitle>Nothing to dispense yet</EmptyTitle>
-                <EmptyDescription>
+                <EmptyTitle className="font-heading tracking-tight">
+                  Nothing to dispense yet
+                </EmptyTitle>
+                <EmptyDescription className="font-serif">
                   Events will appear here as soon as they open.
                 </EmptyDescription>
               </EmptyHeader>
@@ -240,11 +189,11 @@ export default function Home() {
           ) : (
             <>
               {current.length === 0 ? (
-                <p className="mt-6 text-sm text-muted-foreground">
+                <p className="mt-6 font-serif text-sm italic text-muted-foreground">
                   No active events right now.
                 </p>
               ) : (
-                <ul className="mt-4 border-t border-border">
+                <ul>
                   {current.map((event, index) => (
                     <EventRow
                       key={event._id}
@@ -256,16 +205,9 @@ export default function Home() {
                 </ul>
               )}
               {past.length > 0 ? (
-                <>
-                  <div className="mt-14 flex items-baseline justify-between">
-                    <h2 className="text-sm font-medium text-muted-foreground">
-                      Past events
-                    </h2>
-                    <span className="font-mono text-xs text-muted-dim tabular-nums">
-                      {String(past.length).padStart(2, "0")}
-                    </span>
-                  </div>
-                  <ul className="mt-4 border-t border-border">
+                <div className="mt-16">
+                  <SectionHeading label="Past events" count={past.length} />
+                  <ul>
                     {past.map((event, index) => (
                       <EventRow
                         key={event._id}
@@ -276,7 +218,7 @@ export default function Home() {
                       />
                     ))}
                   </ul>
-                </>
+                </div>
               ) : null}
             </>
           )}

--- a/components/ClaimPage.tsx
+++ b/components/ClaimPage.tsx
@@ -252,8 +252,14 @@ export default function ClaimPage({
               className="gap-0 py-0 backface-hidden [grid-area:1/1] [--card-spacing:--spacing(6)] sm:[--card-spacing:--spacing(8)]"
             >
               <CardHeader className="gap-4 pt-(--card-spacing)">
+                <div className="rule-masthead flex items-baseline justify-between gap-3 pt-2.5 pb-1">
+                  <span className="eyebrow text-muted-foreground">
+                    The claim desk
+                  </span>
+                  <span className="eyebrow text-muted-dim">/{slug}</span>
+                </div>
                 <div className="flex items-start justify-between gap-3">
-                  <CardTitle className="font-heading text-3xl font-semibold tracking-[-0.02em] text-balance">
+                  <CardTitle className="font-heading text-4xl font-semibold tracking-tight text-balance">
                     {event.name}
                   </CardTitle>
                   <Button
@@ -268,7 +274,7 @@ export default function ClaimPage({
                   </Button>
                 </div>
                 {event.description ? (
-                  <CardDescription className="text-sm leading-relaxed">
+                  <CardDescription className="font-serif text-[15px] leading-relaxed">
                     {event.description}
                   </CardDescription>
                 ) : null}
@@ -393,7 +399,7 @@ export default function ClaimPage({
                             Redemption instructions for {event.name}
                           </DialogDescription>
                         </DialogHeader>
-                        <p className="text-sm leading-relaxed whitespace-pre-wrap">
+                        <p className="pull-quote pl-4 text-[15px] leading-relaxed whitespace-pre-wrap">
                           {event.claimInstructions}
                         </p>
                         <Button
@@ -557,7 +563,7 @@ function RedeemInstructionsDialog({
             Redemption instructions for {eventName}
           </DialogDescription>
         </DialogHeader>
-        <p className="text-sm leading-relaxed whitespace-pre-wrap">
+        <p className="pull-quote pl-4 text-[15px] leading-relaxed whitespace-pre-wrap">
           {instructions}
         </p>
       </DialogContent>
@@ -660,11 +666,11 @@ function Receipt({
         </div>
 
         <div>
-          <h1 className="font-heading text-2xl font-semibold tracking-tight text-balance">
+          <h1 className="font-heading text-3xl font-semibold tracking-tight text-balance">
             {eventName}
           </h1>
           {creditAmount ? (
-            <p className="mt-1 text-sm text-muted-foreground">
+            <p className="mt-1 font-serif text-sm italic text-muted-foreground">
               {formatValue(creditAmount)}
             </p>
           ) : null}


### PR DESCRIPTION
## Summary
Explores an editorial / print-magazine design direction on the user-facing pages (home + claim), all functionality intact.

- Fonts: adds `Playfair_Display` (display serif, now `--font-heading`) and `Source_Serif_4` (`--font-serif`) in `layout.tsx`; serif headlines propagate everywhere `font-heading` is used.
- `globals.css`: new print utilities — `rule-double` (double section rule), `rule-masthead` (heavy rule + hairline), `pull-quote` (italic serif with stout left rule).
- Home page: replaces the Unicorn WebGL hero with a broadsheet masthead — dateline row between rules ("Event credit distribution" / "{app name} — Vol. I"), oversized serif headline, italic pull-quote deck. Event lists become a front-page index: double-rule section headings with "No. NN" folio counts, numbered rows (01, 02…) with serif descriptions and small-caps dates.
- Claim page: card opens with a masthead rule + "The claim desk / /{slug}" dateline, larger serif title, serif descriptions, and pull-quote-styled redemption instructions; receipt gets a serif headline and italic credit line.

Base branch for the 5 colorway variant PRs.

Link to Devin session: https://app.devin.ai/sessions/1a48be4763ac47929801b9fb4fa9a601
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/113" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->