### PR TITLE
Design direction: Swiss Minimal

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,57 +4,53 @@
 
 @custom-variant dark (&:is(.dark *));
 
-/* Light mode (default) — "Paper": a white page field with warm off-neutrals
-   in the tints and borders rather than the pure grey axis, and ink (#22211E)
-   instead of near-black so text stays short of a harsh 19:1. Surface is a
-   neutral grey one step off white — hovers and the receipt stub read as a
-   quiet press of the field rather than a cream block. The blue accent is
-   reserved for the claim flow only. */
+/* Light mode (default) — Swiss / International Minimal: a pure white field
+   on the neutral grey axis, near-black ink, hairline rules, and a single
+   restrained Swiss-red accent reserved for the claim flow. No warm cast,
+   no soft tints — structure comes from the grid, not from color. */
 :root {
-  --surface: #f6f6f6;
-  --surface-hover: #f0f0f0;
-  --border: #eae7df;
-  --border-strong: #d5cfc2;
-  --muted: #f1efe8;
-  --muted-dim: #78716a;
+  --surface: #f5f5f5;
+  --surface-hover: #ededed;
+  --border: #e4e4e4;
+  --border-strong: #c8c8c8;
+  --muted: #f0f0f0;
+  --muted-dim: #767676;
   --background: #ffffff;
-  --foreground: #22211e;
+  --foreground: #111111;
   --card: #ffffff;
-  --card-foreground: #22211e;
+  --card-foreground: #111111;
   --popover: #ffffff;
-  --popover-foreground: #22211e;
-  --primary: #22211e;
-  --primary-foreground: #faf9f5;
-  --secondary: #f1efe8;
-  --secondary-foreground: #22211e;
-  --muted-foreground: #57534a;
-  --accent: #f1efe8;
-  --accent-foreground: #22211e;
+  --popover-foreground: #111111;
+  --primary: #111111;
+  --primary-foreground: #ffffff;
+  --secondary: #f0f0f0;
+  --secondary-foreground: #111111;
+  --muted-foreground: #555555;
+  --accent: #f0f0f0;
+  --accent-foreground: #111111;
   --destructive: oklch(0.577 0.245 27.325);
   --input: oklch(0 0 0 / 8%);
-  --brand: #2200ff;
+  --brand: #e30613;
   --brand-foreground: #ffffff;
-  --ring: #44403a;
-  --selection: #e6e1d5;
-  --selection-foreground: #22211e;
-  /* Soft two-layer card shadow: invisible as "shadow", read as depth. Dark
-     mode zeroes it out and relies on surface contrast instead. */
-  --shadow-card:
-    0 1px 2px rgb(34 33 30 / 0.04), 0 4px 12px -2px rgb(34 33 30 / 0.04);
+  --ring: #111111;
+  --selection: #e4e4e4;
+  --selection-foreground: #111111;
+  /* No shadows — the flat page and hairline rules carry all the depth. */
+  --shadow-card: 0 0 rgb(0 0 0 / 0);
   --chart-1: oklch(0.269 0 0);
   --chart-2: oklch(0.439 0 0);
   --chart-3: oklch(0.556 0 0);
   --chart-4: oklch(0.708 0 0);
   --chart-5: oklch(0.87 0 0);
-  --radius: 0.625rem;
+  --radius: 0rem;
   --sidebar: #ffffff;
-  --sidebar-foreground: #22211e;
-  --sidebar-primary: #22211e;
-  --sidebar-primary-foreground: #faf9f5;
-  --sidebar-accent: #f1efe8;
-  --sidebar-accent-foreground: #22211e;
-  --sidebar-border: #e7e3da;
-  --sidebar-ring: #78716a;
+  --sidebar-foreground: #111111;
+  --sidebar-primary: #111111;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: #f0f0f0;
+  --sidebar-accent-foreground: #111111;
+  --sidebar-border: #e4e4e4;
+  --sidebar-ring: #767676;
 }
 
 @theme inline {
@@ -66,11 +62,15 @@
   --color-foreground: var(--foreground);
   --color-muted: var(--muted);
   --color-muted-dim: var(--muted-dim);
-  --font-sans: var(--font-geist-sans);
+  /* Helvetica-first stack: the grotesque IS the identity. Geist stands in
+     where Helvetica isn't installed — it stays on the same neutral axis. */
+  --font-sans:
+    "Helvetica Neue", Helvetica, Arial, var(--font-geist-sans), sans-serif;
   --font-mono: var(--font-geist-mono);
   /* Headings share the body face — hierarchy comes from weight, size, and
      tracking rather than a second display family. */
-  --font-heading: var(--font-geist-sans);
+  --font-heading:
+    "Helvetica Neue", Helvetica, Arial, var(--font-geist-sans), sans-serif;
   --color-brand: var(--brand);
   --color-brand-foreground: var(--brand-foreground);
   --color-sidebar-ring: var(--sidebar-ring);
@@ -114,13 +114,13 @@ body {
 }
 
 /* Neutral, not brand: selection is incidental, so it shouldn't compete with
-   the one blue thing on screen. */
+   the one red accent on screen. */
 ::selection {
   background: var(--selection);
   color: var(--selection-foreground);
 }
 
-/* Chrome paints autofilled fields yellow, which clashes with the paper
+/* Chrome paints autofilled fields yellow, which clashes with the neutral
    palette. The background is set via an internal style that can't be
    overridden directly, but it *can* be transitioned — delaying it
    indefinitely keeps the field transparent while the ink stays themed. */
@@ -184,50 +184,49 @@ input:-webkit-autofill:focus {
   }
 }
 
-/* Dark mode — "Paper" after dark: the near-black picks up a faint cool cast
-   while the text stays warm off-white, and contrast drops from 18:1 to ~16:1
-   to stop white type haloing on OLED. */
+/* Dark mode — the same neutral axis inverted: near-black field, off-white
+   ink, hairline greys, and the identical Swiss-red accent. */
 .dark {
-  --surface: #141416;
-  --surface-hover: #1a1a1d;
-  --border: #26262a;
-  --border-strong: #3a3a40;
-  --muted: #212125;
-  --muted-dim: #7a7772;
-  --background: #0c0c0e;
-  --foreground: #e8e6e1;
-  --card: #141416;
-  --card-foreground: #e8e6e1;
-  --popover: #1a1a1d;
-  --popover-foreground: #e8e6e1;
-  --primary: #e8e6e1;
-  --primary-foreground: #0c0c0e;
-  --secondary: #2b2b30;
-  --secondary-foreground: #e8e6e1;
-  --muted-foreground: #a8a5a0;
-  --accent: #2b2b30;
-  --accent-foreground: #e8e6e1;
+  --surface: #161616;
+  --surface-hover: #1d1d1d;
+  --border: #2a2a2a;
+  --border-strong: #404040;
+  --muted: #222222;
+  --muted-dim: #7c7c7c;
+  --background: #0e0e0e;
+  --foreground: #f2f2f2;
+  --card: #161616;
+  --card-foreground: #f2f2f2;
+  --popover: #1d1d1d;
+  --popover-foreground: #f2f2f2;
+  --primary: #f2f2f2;
+  --primary-foreground: #0e0e0e;
+  --secondary: #2a2a2a;
+  --secondary-foreground: #f2f2f2;
+  --muted-foreground: #a6a6a6;
+  --accent: #2a2a2a;
+  --accent-foreground: #f2f2f2;
   --destructive: oklch(0.704 0.191 22.216);
   --input: oklch(1 0 0 / 15%);
-  --brand: #2200ff;
+  --brand: #e30613;
   --brand-foreground: #ffffff;
-  --ring: #c4c1bb;
-  --selection: #33333a;
-  --selection-foreground: #e8e6e1;
+  --ring: #c8c8c8;
+  --selection: #333333;
+  --selection-foreground: #f2f2f2;
   --shadow-card: 0 0 rgb(0 0 0 / 0);
   --chart-1: oklch(0.87 0 0);
   --chart-2: oklch(0.556 0 0);
   --chart-3: oklch(0.439 0 0);
   --chart-4: oklch(0.371 0 0);
   --chart-5: oklch(0.269 0 0);
-  --sidebar: #141416;
-  --sidebar-foreground: #e8e6e1;
-  --sidebar-primary: #e8e6e1;
-  --sidebar-primary-foreground: #0c0c0e;
-  --sidebar-accent: #2b2b30;
-  --sidebar-accent-foreground: #e8e6e1;
-  --sidebar-border: #26262a;
-  --sidebar-ring: #7a7772;
+  --sidebar: #161616;
+  --sidebar-foreground: #f2f2f2;
+  --sidebar-primary: #f2f2f2;
+  --sidebar-primary-foreground: #0e0e0e;
+  --sidebar-accent: #2a2a2a;
+  --sidebar-accent-foreground: #f2f2f2;
+  --sidebar-border: #2a2a2a;
+  --sidebar-ring: #7c7c7c;
 }
 
 @layer base {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,13 +1,10 @@
 "use client";
 
-import { useSyncExternalStore } from "react";
 import Link from "next/link";
 import { BadgeCheck, Ticket } from "lucide-react";
-import { useTheme } from "next-themes";
 import { useConvexAuth, useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { daysUntilEvent, formatEventDate } from "@/lib/event-date";
-import UnicornSceneEmbed from "@/components/UnicornSceneEmbed";
 import SiteHeader from "@/components/SiteHeader";
 import SiteFooter from "@/components/SiteFooter";
 import { Badge } from "@/components/ui/badge";
@@ -20,30 +17,6 @@ import {
   EmptyDescription,
 } from "@/components/ui/empty";
 import { cn } from "@/lib/utils";
-
-// The hero background is a theme-paired Unicorn Studio WebGL scene
-// (experiment). A Unicorn project publishes exactly one authored design and
-// the SDK has no color-scheme awareness, so a light-authored project shows
-// its light design in dark mode too — each theme therefore needs its own
-// project ID here.
-const UNICORN_PROJECTS = {
-  light: "wEz2vCJgsynwCYSb3HgR",
-  dark: "aEdLurlqLEmU1DUjAaUz",
-} as const;
-
-// Bump this whenever a scene is republished in Unicorn Studio. Deployed
-// builds read scene data through Unicorn's CDN, which caches for months and
-// doesn't reliably purge on republish; the update param below is part of the
-// CDN cache key, so bumping the version makes deploys fetch the new design.
-// Dev skips the param (and the CDN): without it the SDK cache-busts every
-// load, so republishes show up on a plain refresh.
-const UNICORN_CACHE_VERSION = 2;
-
-const isProdBuild = process.env.NODE_ENV === "production";
-
-// Stable no-op subscription for the hydration gate below: the snapshot never
-// changes on the client, we only care that the server snapshot is false.
-const emptySubscribe = () => () => {};
 
 interface EventItem {
   _id: string;
@@ -110,23 +83,6 @@ export default function Home() {
     mine?.map((item) => item.event?._id).filter(Boolean) ?? [],
   );
 
-  // The scene choice needs JS (the server doesn't know the theme, while the
-  // hydration render already does), so gate it behind hydration to keep both
-  // trees identical; the copy and scrim flip with pure dark: variants and
-  // render correctly from the first paint. Until hydration the plain
-  // theme-tinted shell stands in for both themes.
-  const { resolvedTheme } = useTheme();
-  const hydrated = useSyncExternalStore(
-    emptySubscribe,
-    () => true,
-    () => false,
-  );
-  const heroProjectId = hydrated
-    ? resolvedTheme === "light"
-      ? UNICORN_PROJECTS.light
-      : UNICORN_PROJECTS.dark
-    : undefined;
-
   // Dated events that have passed sink into their own dimmed group; undated
   // events are treated as current. Active events order soonest-first, with
   // undated ones following in their arrival (newest created) order; past
@@ -145,60 +101,33 @@ export default function Home() {
     events?.filter((e) => e.eventDate && daysUntilEvent(e.eventDate) < 0) ?? []
   ).sort((a, b) => (b.eventDate ?? "").localeCompare(a.eventDate ?? ""));
 
-  // Shared hero copy: crisp DOM stacked above the theme's scene. pt-15.25
-  // offsets the translucent header bar the hero slides under, keeping the
-  // copy centered in the visible area.
-  const heroCopy = (
-    <div className="relative mx-auto flex h-full w-full max-w-5xl flex-col justify-center px-4 pt-15.25 sm:px-6">
-      <p className="eyebrow animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 text-black/60 dark:text-white/60 motion-reduce:animate-none">
-        {process.env.NEXT_PUBLIC_IS_DEVIN ? "Devin " : ""}Event credit
-        distribution
-      </p>
-      <h1 className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-100 mt-6 max-w-2xl font-heading text-5xl leading-[0.95] font-semibold tracking-[-0.03em] text-balance text-black dark:text-white motion-reduce:animate-none sm:text-7xl">
-        Claim your credits.
-      </h1>
-      <p className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-200 mt-6 max-w-md text-sm leading-relaxed text-black/70 dark:text-white/70 motion-reduce:animate-none">
-        Sign in, then select your event to claim your credits.
-      </p>
-    </div>
-  );
-
   return (
     <div className="flex min-h-screen flex-col">
       <SiteHeader />
       <main id="main-content" className="flex-1">
-        <section className="-mt-15.25 border-b border-border/65">
-          {/* The section pulls up behind the translucent header bar
-              (-mt-15.25) so the background runs to the top of the page; the
-              hero is 61px taller to compensate and the scene shows through
-              the bar's frosted fill. The theme's Unicorn Studio scene renders
-              behind the copy and a soft theme-matched scrim; keying the scene
-              by project swaps it cleanly on theme change while the copy stays
-              mounted. The scene's mouse interactivity listens on window, so
-              the copy sitting above it doesn't block it. */}
-          <div className="relative h-[520px] overflow-hidden bg-background dark:bg-[#131313] sm:h-[486px]">
-            {heroProjectId ? (
-              <div className="absolute inset-0" aria-hidden>
-                {/* Dev fetches fresh scene data on every load; deploys pin
-                    the CDN to UNICORN_CACHE_VERSION — see the constant. */}
-                <UnicornSceneEmbed
-                  key={heroProjectId}
-                  projectId={
-                    isProdBuild
-                      ? `${heroProjectId}?update=${UNICORN_CACHE_VERSION}`
-                      : heroProjectId
-                  }
-                  production={isProdBuild}
-                />
-              </div>
-            ) : null}
-            {/* Soft scrim keeps the headline legible over the scenes; tune
-                or remove once the look settles. */}
-            <div
-              className="absolute inset-0 bg-white/20 dark:bg-black/20"
-              aria-hidden
-            />
-            {heroCopy}
+        {/* Typographic hero on a strict two-column grid: a red index mark and
+            eyebrow on the rule line, an oversized flush-left grotesque
+            headline, and the supporting line seated in the right column. */}
+        <section className="border-b border-border">
+          <div className="mx-auto w-full max-w-5xl px-4 sm:px-6">
+            <div className="flex items-baseline justify-between border-b border-border pt-14 pb-4 sm:pt-20">
+              <p className="eyebrow text-muted-foreground">
+                {process.env.NEXT_PUBLIC_IS_DEVIN ? "Devin " : ""}Event credit
+                distribution
+              </p>
+              <span
+                className="size-2 shrink-0 bg-brand"
+                aria-hidden
+              />
+            </div>
+            <div className="grid gap-10 py-14 sm:grid-cols-12 sm:py-20">
+              <h1 className="font-heading text-5xl leading-[0.95] font-bold tracking-[-0.04em] text-balance sm:col-span-8 sm:text-7xl">
+                Claim your credits.
+              </h1>
+              <p className="self-end text-sm leading-relaxed text-muted-foreground sm:col-span-4">
+                Sign in, then select your event to claim your credits.
+              </p>
+            </div>
           </div>
         </section>
 

--- a/components/ClaimPage.tsx
+++ b/components/ClaimPage.tsx
@@ -189,10 +189,6 @@ export default function ClaimPage({
         id="main-content"
         className="relative flex flex-1 items-center justify-center px-4 py-10 sm:px-6 sm:py-16"
       >
-        <div
-          aria-hidden
-          className="pointer-events-none absolute inset-0 bg-dotgrid [mask-image:radial-gradient(ellipse_60%_60%_at_50%_45%,black,transparent)]"
-        />
         <div className="relative w-full max-w-md">
           {previewMode ? (
             <Alert className="mb-4">


### PR DESCRIPTION
## Summary
Explores a Swiss / International Minimal design direction across the user-facing pages (home + claim), keeping all functionality intact.

- `globals.css`: retokened both themes to the pure neutral axis (white field / `#111` ink, hairline greys) with a single Swiss-red accent (`--brand: #e30613`), `--radius: 0` (sharp corners everywhere), zeroed card shadows, and a Helvetica-first font stack (`"Helvetica Neue", Helvetica, Arial, Geist fallback`) for both body and headings.
- Home hero: replaced the Unicorn Studio WebGL scene (and its theme/hydration gating) with a static typographic hero on a strict 12-column grid — eyebrow + red index square on a rule line, oversized flush-left bold headline, supporting copy seated in the right column.
- Claim page: removed the dot-grid backdrop in favor of plain whitespace; everything else restyles via the shared tokens.

This is the base branch for 5 colorway variant PRs (`Swiss Minimal colorway: <name>`) targeting it.

Link to Devin session: https://app.devin.ai/sessions/8eb9321e438b47b6a14597bce649cf33
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/114" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->