### PR TITLE
Design direction: Cyberpunk Neon

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,57 +4,60 @@
 
 @custom-variant dark (&:is(.dark *));
 
-/* Light mode (default) — "Paper": a white page field with warm off-neutrals
-   in the tints and borders rather than the pure grey axis, and ink (#22211E)
-   instead of near-black so text stays short of a harsh 19:1. Surface is a
-   neutral grey one step off white — hovers and the receipt stub read as a
-   quiet press of the field rather than a cream block. The blue accent is
-   reserved for the claim flow only. */
+/* Cyberpunk Neon — a dark HUD field with neon accents. The colorway is
+   defined by the three --neon-* hues below; everything else derives from
+   them. Default theme (no .dark class) is "night city": deep indigo-black
+   field, cool blue-tinted neutrals. */
 :root {
-  --surface: #f6f6f6;
-  --surface-hover: #f0f0f0;
-  --border: #eae7df;
-  --border-strong: #d5cfc2;
-  --muted: #f1efe8;
-  --muted-dim: #78716a;
-  --background: #ffffff;
-  --foreground: #22211e;
-  --card: #ffffff;
-  --card-foreground: #22211e;
-  --popover: #ffffff;
-  --popover-foreground: #22211e;
-  --primary: #22211e;
-  --primary-foreground: #faf9f5;
-  --secondary: #f1efe8;
-  --secondary-foreground: #22211e;
-  --muted-foreground: #57534a;
-  --accent: #f1efe8;
-  --accent-foreground: #22211e;
-  --destructive: oklch(0.577 0.245 27.325);
-  --input: oklch(0 0 0 / 8%);
-  --brand: #2200ff;
+  /* Colorway: magenta / cyan / ultraviolet. Swap these three to re-skin. */
+  --neon-primary: #ff2ecb;
+  --neon-secondary: #00e5ff;
+  --neon-tertiary: #9d4dff;
+
+  --surface: #10101c;
+  --surface-hover: #161628;
+  --border: #20203a;
+  --border-strong: #34345c;
+  --muted: #16162a;
+  --muted-dim: #6b7a99;
+  --background: #0a0a14;
+  --foreground: #e8f0ff;
+  --card: #10101c;
+  --card-foreground: #e8f0ff;
+  --popover: #141424;
+  --popover-foreground: #e8f0ff;
+  --primary: #e8f0ff;
+  --primary-foreground: #0a0a14;
+  --secondary: #1c1c34;
+  --secondary-foreground: #e8f0ff;
+  --muted-foreground: #9aa8c7;
+  --accent: #1c1c34;
+  --accent-foreground: #e8f0ff;
+  --destructive: oklch(0.704 0.191 22.216);
+  --input: oklch(1 0 0 / 12%);
+  --brand: var(--neon-primary);
   --brand-foreground: #ffffff;
-  --ring: #44403a;
-  --selection: #e6e1d5;
-  --selection-foreground: #22211e;
-  /* Soft two-layer card shadow: invisible as "shadow", read as depth. Dark
-     mode zeroes it out and relies on surface contrast instead. */
+  --ring: var(--neon-secondary);
+  --selection: #2a1a3e;
+  --selection-foreground: #e8f0ff;
+  /* Cards read as glowing panels rather than shadowed paper. */
   --shadow-card:
-    0 1px 2px rgb(34 33 30 / 0.04), 0 4px 12px -2px rgb(34 33 30 / 0.04);
-  --chart-1: oklch(0.269 0 0);
-  --chart-2: oklch(0.439 0 0);
-  --chart-3: oklch(0.556 0 0);
+    0 0 20px -8px color-mix(in srgb, var(--neon-primary) 35%, transparent),
+    0 0 40px -16px color-mix(in srgb, var(--neon-secondary) 25%, transparent);
+  --chart-1: var(--neon-primary);
+  --chart-2: var(--neon-secondary);
+  --chart-3: var(--neon-tertiary);
   --chart-4: oklch(0.708 0 0);
   --chart-5: oklch(0.87 0 0);
   --radius: 0.625rem;
-  --sidebar: #ffffff;
-  --sidebar-foreground: #22211e;
-  --sidebar-primary: #22211e;
-  --sidebar-primary-foreground: #faf9f5;
-  --sidebar-accent: #f1efe8;
-  --sidebar-accent-foreground: #22211e;
-  --sidebar-border: #e7e3da;
-  --sidebar-ring: #78716a;
+  --sidebar: #10101c;
+  --sidebar-foreground: #e8f0ff;
+  --sidebar-primary: #e8f0ff;
+  --sidebar-primary-foreground: #0a0a14;
+  --sidebar-accent: #1c1c34;
+  --sidebar-accent-foreground: #e8f0ff;
+  --sidebar-border: #20203a;
+  --sidebar-ring: #6b7a99;
 }
 
 @theme inline {
@@ -86,6 +89,9 @@
   --color-chart-3: var(--chart-3);
   --color-chart-2: var(--chart-2);
   --color-chart-1: var(--chart-1);
+  --color-neon-primary: var(--neon-primary);
+  --color-neon-secondary: var(--neon-secondary);
+  --color-neon-tertiary: var(--neon-tertiary);
   --color-ring: var(--ring);
   --color-input: var(--input);
   --color-destructive: var(--destructive);
@@ -111,6 +117,21 @@
 
 body {
   font-family: var(--font-sans), system-ui, sans-serif;
+}
+
+/* CRT scanline wash over the whole viewport — faint enough to read as
+   texture, not stripes. */
+body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  pointer-events: none;
+  background: repeating-linear-gradient(
+    0deg,
+    rgb(255 255 255 / 0.015) 0 1px,
+    transparent 1px 3px
+  );
 }
 
 /* Neutral, not brand: selection is incidental, so it shouldn't compete with
@@ -145,6 +166,87 @@ input:-webkit-autofill:focus {
 @utility bg-dotgrid {
   background-image: radial-gradient(var(--border) 1px, transparent 1px);
   background-size: 28px 28px;
+}
+
+/* Perspective-free cyber grid: faint neon graph lines for HUD surfaces. */
+@utility bg-cybergrid {
+  background-image:
+    linear-gradient(
+      color-mix(in srgb, var(--neon-secondary) 9%, transparent) 1px,
+      transparent 1px
+    ),
+    linear-gradient(
+      90deg,
+      color-mix(in srgb, var(--neon-secondary) 9%, transparent) 1px,
+      transparent 1px
+    );
+  background-size: 44px 44px;
+}
+
+/* Neon tube glow for text; inherits the element's color. */
+@utility neon-text {
+  text-shadow:
+    0 0 6px color-mix(in srgb, currentColor 70%, transparent),
+    0 0 22px color-mix(in srgb, currentColor 35%, transparent);
+}
+
+/* Glowing HUD panel: neon-tinted border plus an outer bloom in the
+   colorway's two hues. */
+@utility neon-panel {
+  border-color: color-mix(in srgb, var(--neon-primary) 35%, var(--border));
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--neon-primary) 15%, transparent),
+    0 0 32px -8px color-mix(in srgb, var(--neon-primary) 45%, transparent),
+    0 0 56px -16px color-mix(in srgb, var(--neon-secondary) 35%, transparent);
+}
+
+/* Gradient outline: 1px frame running primary → tertiary → secondary,
+   drawn in border-box behind a padding-box fill of the panel color. */
+@utility gradient-frame {
+  border: 1px solid transparent;
+  background:
+    linear-gradient(var(--card), var(--card)) padding-box,
+    linear-gradient(
+        135deg,
+        var(--neon-primary),
+        var(--neon-tertiary),
+        var(--neon-secondary)
+      )
+      border-box;
+}
+
+/* Glitch: occasional chromatic-aberration flicker on display text. */
+@utility animate-glitch {
+  animation: neon-glitch 4s steps(1, end) infinite;
+}
+
+@keyframes neon-glitch {
+  0%,
+  92%,
+  100% {
+    text-shadow:
+      0 0 6px color-mix(in srgb, currentColor 70%, transparent),
+      0 0 22px color-mix(in srgb, currentColor 35%, transparent);
+    transform: none;
+  }
+  93% {
+    text-shadow:
+      -2px 0 var(--neon-primary),
+      2px 0 var(--neon-secondary);
+    transform: translateX(1px);
+  }
+  95% {
+    text-shadow:
+      2px 0 var(--neon-primary),
+      -2px 0 var(--neon-secondary);
+    transform: translateX(-1px);
+  }
+  97% {
+    text-shadow:
+      -1px 0 var(--neon-tertiary),
+      1px 0 var(--neon-secondary);
+    transform: none;
+  }
 }
 
 /* Receipt edge: scalloped bottom, like a stub torn off a perforated roll. */
@@ -184,50 +286,52 @@ input:-webkit-autofill:focus {
   }
 }
 
-/* Dark mode — "Paper" after dark: the near-black picks up a faint cool cast
-   while the text stays warm off-white, and contrast drops from 18:1 to ~16:1
-   to stop white type haloing on OLED. */
+/* Dark mode — "blackout": the same neon language on a deeper, near-pure
+   black field for OLED. The neon hues stay identical; only the neutrals
+   sink. */
 .dark {
-  --surface: #141416;
-  --surface-hover: #1a1a1d;
-  --border: #26262a;
-  --border-strong: #3a3a40;
-  --muted: #212125;
-  --muted-dim: #7a7772;
-  --background: #0c0c0e;
-  --foreground: #e8e6e1;
-  --card: #141416;
-  --card-foreground: #e8e6e1;
-  --popover: #1a1a1d;
-  --popover-foreground: #e8e6e1;
-  --primary: #e8e6e1;
-  --primary-foreground: #0c0c0e;
-  --secondary: #2b2b30;
-  --secondary-foreground: #e8e6e1;
-  --muted-foreground: #a8a5a0;
-  --accent: #2b2b30;
-  --accent-foreground: #e8e6e1;
+  --surface: #0b0b15;
+  --surface-hover: #121220;
+  --border: #1a1a30;
+  --border-strong: #2c2c50;
+  --muted: #111120;
+  --muted-dim: #5e6c8c;
+  --background: #050509;
+  --foreground: #e8f0ff;
+  --card: #0b0b15;
+  --card-foreground: #e8f0ff;
+  --popover: #10101e;
+  --popover-foreground: #e8f0ff;
+  --primary: #e8f0ff;
+  --primary-foreground: #050509;
+  --secondary: #17172b;
+  --secondary-foreground: #e8f0ff;
+  --muted-foreground: #93a2c2;
+  --accent: #17172b;
+  --accent-foreground: #e8f0ff;
   --destructive: oklch(0.704 0.191 22.216);
   --input: oklch(1 0 0 / 15%);
-  --brand: #2200ff;
+  --brand: var(--neon-primary);
   --brand-foreground: #ffffff;
-  --ring: #c4c1bb;
-  --selection: #33333a;
-  --selection-foreground: #e8e6e1;
-  --shadow-card: 0 0 rgb(0 0 0 / 0);
-  --chart-1: oklch(0.87 0 0);
-  --chart-2: oklch(0.556 0 0);
-  --chart-3: oklch(0.439 0 0);
+  --ring: var(--neon-secondary);
+  --selection: #241536;
+  --selection-foreground: #e8f0ff;
+  --shadow-card:
+    0 0 24px -8px color-mix(in srgb, var(--neon-primary) 40%, transparent),
+    0 0 48px -16px color-mix(in srgb, var(--neon-secondary) 30%, transparent);
+  --chart-1: var(--neon-primary);
+  --chart-2: var(--neon-secondary);
+  --chart-3: var(--neon-tertiary);
   --chart-4: oklch(0.371 0 0);
   --chart-5: oklch(0.269 0 0);
-  --sidebar: #141416;
-  --sidebar-foreground: #e8e6e1;
-  --sidebar-primary: #e8e6e1;
-  --sidebar-primary-foreground: #0c0c0e;
-  --sidebar-accent: #2b2b30;
-  --sidebar-accent-foreground: #e8e6e1;
-  --sidebar-border: #26262a;
-  --sidebar-ring: #7a7772;
+  --sidebar: #0b0b15;
+  --sidebar-foreground: #e8f0ff;
+  --sidebar-primary: #e8f0ff;
+  --sidebar-primary-foreground: #050509;
+  --sidebar-accent: #17172b;
+  --sidebar-accent-foreground: #e8f0ff;
+  --sidebar-border: #1a1a30;
+  --sidebar-ring: #5e6c8c;
 }
 
 @layer base {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,13 +1,10 @@
 "use client";
 
-import { useSyncExternalStore } from "react";
 import Link from "next/link";
 import { BadgeCheck, Ticket } from "lucide-react";
-import { useTheme } from "next-themes";
 import { useConvexAuth, useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { daysUntilEvent, formatEventDate } from "@/lib/event-date";
-import UnicornSceneEmbed from "@/components/UnicornSceneEmbed";
 import SiteHeader from "@/components/SiteHeader";
 import SiteFooter from "@/components/SiteFooter";
 import { Badge } from "@/components/ui/badge";
@@ -20,30 +17,6 @@ import {
   EmptyDescription,
 } from "@/components/ui/empty";
 import { cn } from "@/lib/utils";
-
-// The hero background is a theme-paired Unicorn Studio WebGL scene
-// (experiment). A Unicorn project publishes exactly one authored design and
-// the SDK has no color-scheme awareness, so a light-authored project shows
-// its light design in dark mode too — each theme therefore needs its own
-// project ID here.
-const UNICORN_PROJECTS = {
-  light: "wEz2vCJgsynwCYSb3HgR",
-  dark: "aEdLurlqLEmU1DUjAaUz",
-} as const;
-
-// Bump this whenever a scene is republished in Unicorn Studio. Deployed
-// builds read scene data through Unicorn's CDN, which caches for months and
-// doesn't reliably purge on republish; the update param below is part of the
-// CDN cache key, so bumping the version makes deploys fetch the new design.
-// Dev skips the param (and the CDN): without it the SDK cache-busts every
-// load, so republishes show up on a plain refresh.
-const UNICORN_CACHE_VERSION = 2;
-
-const isProdBuild = process.env.NODE_ENV === "production";
-
-// Stable no-op subscription for the hydration gate below: the snapshot never
-// changes on the client, we only care that the server snapshot is false.
-const emptySubscribe = () => () => {};
 
 interface EventItem {
   _id: string;
@@ -77,7 +50,7 @@ function EventRow({
         )}
       >
         <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 font-heading text-xl font-medium tracking-tight sm:text-2xl">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 font-heading text-xl font-medium tracking-tight transition-colors group-hover:text-neon-secondary sm:text-2xl">
             {event.name}
             {claimed ? (
               <Badge variant="secondary" className="gap-1">
@@ -93,7 +66,7 @@ function EventRow({
           ) : null}
         </div>
         {event.eventDate ? (
-          <span className="hidden shrink-0 text-xs text-muted-dim tabular-nums sm:inline">
+          <span className="hidden shrink-0 font-mono text-xs text-muted-dim tabular-nums transition-colors group-hover:text-neon-secondary/80 sm:inline">
             {formatEventDate(event.eventDate)}
           </span>
         ) : null}
@@ -109,23 +82,6 @@ export default function Home() {
   const claimedEventIds = new Set(
     mine?.map((item) => item.event?._id).filter(Boolean) ?? [],
   );
-
-  // The scene choice needs JS (the server doesn't know the theme, while the
-  // hydration render already does), so gate it behind hydration to keep both
-  // trees identical; the copy and scrim flip with pure dark: variants and
-  // render correctly from the first paint. Until hydration the plain
-  // theme-tinted shell stands in for both themes.
-  const { resolvedTheme } = useTheme();
-  const hydrated = useSyncExternalStore(
-    emptySubscribe,
-    () => true,
-    () => false,
-  );
-  const heroProjectId = hydrated
-    ? resolvedTheme === "light"
-      ? UNICORN_PROJECTS.light
-      : UNICORN_PROJECTS.dark
-    : undefined;
 
   // Dated events that have passed sink into their own dimmed group; undated
   // events are treated as current. Active events order soonest-first, with
@@ -150,15 +106,21 @@ export default function Home() {
   // copy centered in the visible area.
   const heroCopy = (
     <div className="relative mx-auto flex h-full w-full max-w-5xl flex-col justify-center px-4 pt-15.25 sm:px-6">
-      <p className="eyebrow animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 text-black/60 dark:text-white/60 motion-reduce:animate-none">
+      <p className="eyebrow animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 text-neon-secondary neon-text motion-reduce:animate-none">
         {process.env.NEXT_PUBLIC_IS_DEVIN ? "Devin " : ""}Event credit
         distribution
       </p>
-      <h1 className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-100 mt-6 max-w-2xl font-heading text-5xl leading-[0.95] font-semibold tracking-[-0.03em] text-balance text-black dark:text-white motion-reduce:animate-none sm:text-7xl">
+      <h1 className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-100 mt-6 max-w-2xl font-heading text-5xl leading-[0.95] font-semibold tracking-[-0.03em] text-balance text-white neon-text animate-glitch motion-reduce:animate-none sm:text-7xl">
         Claim your credits.
       </h1>
-      <p className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-200 mt-6 max-w-md text-sm leading-relaxed text-black/70 dark:text-white/70 motion-reduce:animate-none">
+      <p className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-200 mt-6 max-w-md text-sm leading-relaxed text-foreground/70 motion-reduce:animate-none">
         Sign in, then select your event to claim your credits.
+      </p>
+      <p
+        className="eyebrow animate-in fade-in fill-mode-both duration-500 delay-300 mt-8 text-neon-primary/70 motion-reduce:animate-none"
+        aria-hidden
+      >
+        SYS//CREDIT.DISPENSER :: ONLINE
       </p>
     </div>
   );
@@ -170,32 +132,24 @@ export default function Home() {
         <section className="-mt-15.25 border-b border-border/65">
           {/* The section pulls up behind the translucent header bar
               (-mt-15.25) so the background runs to the top of the page; the
-              hero is 61px taller to compensate and the scene shows through
-              the bar's frosted fill. The theme's Unicorn Studio scene renders
-              behind the copy and a soft theme-matched scrim; keying the scene
-              by project swaps it cleanly on theme change while the copy stays
-              mounted. The scene's mouse interactivity listens on window, so
-              the copy sitting above it doesn't block it. */}
-          <div className="relative h-[520px] overflow-hidden bg-background dark:bg-[#131313] sm:h-[486px]">
-            {heroProjectId ? (
-              <div className="absolute inset-0" aria-hidden>
-                {/* Dev fetches fresh scene data on every load; deploys pin
-                    the CDN to UNICORN_CACHE_VERSION — see the constant. */}
-                <UnicornSceneEmbed
-                  key={heroProjectId}
-                  projectId={
-                    isProdBuild
-                      ? `${heroProjectId}?update=${UNICORN_CACHE_VERSION}`
-                      : heroProjectId
-                  }
-                  production={isProdBuild}
-                />
-              </div>
-            ) : null}
-            {/* Soft scrim keeps the headline legible over the scenes; tune
-                or remove once the look settles. */}
+              hero is 61px taller to compensate. The backdrop is a HUD scene:
+              a faint cyber grid fading toward the fold, with two neon blooms
+              in the colorway's hues drifting behind the copy. */}
+          <div className="relative h-[520px] overflow-hidden bg-background sm:h-[486px]">
             <div
-              className="absolute inset-0 bg-white/20 dark:bg-black/20"
+              className="absolute inset-0 bg-cybergrid [mask-image:linear-gradient(to_bottom,black,transparent_94%)]"
+              aria-hidden
+            />
+            <div
+              className="absolute -top-32 -left-24 size-96 rounded-full bg-neon-primary/25 blur-[120px]"
+              aria-hidden
+            />
+            <div
+              className="absolute right-[-10%] -bottom-40 size-[28rem] rounded-full bg-neon-secondary/20 blur-[140px]"
+              aria-hidden
+            />
+            <div
+              className="absolute inset-x-0 bottom-0 h-px bg-gradient-to-r from-transparent via-neon-primary/60 to-transparent"
               aria-hidden
             />
             {heroCopy}
@@ -203,9 +157,7 @@ export default function Home() {
         </section>
 
         <section className="mx-auto w-full max-w-5xl px-4 py-14 sm:px-6 sm:py-20">
-          <h2 className="text-sm font-medium text-muted-foreground">
-            Active events
-          </h2>
+          <h2 className="eyebrow text-neon-secondary/80">Active events</h2>
 
           {events === undefined ? (
             <div
@@ -258,7 +210,7 @@ export default function Home() {
               {past.length > 0 ? (
                 <>
                   <div className="mt-14 flex items-baseline justify-between">
-                    <h2 className="text-sm font-medium text-muted-foreground">
+                    <h2 className="eyebrow text-neon-secondary/80">
                       Past events
                     </h2>
                     <span className="font-mono text-xs text-muted-dim tabular-nums">

--- a/components/ClaimPage.tsx
+++ b/components/ClaimPage.tsx
@@ -191,7 +191,15 @@ export default function ClaimPage({
       >
         <div
           aria-hidden
-          className="pointer-events-none absolute inset-0 bg-dotgrid [mask-image:radial-gradient(ellipse_60%_60%_at_50%_45%,black,transparent)]"
+          className="pointer-events-none absolute inset-0 bg-cybergrid [mask-image:radial-gradient(ellipse_60%_60%_at_50%_45%,black,transparent)]"
+        />
+        <div
+          aria-hidden
+          className="pointer-events-none absolute top-1/4 left-1/2 size-80 -translate-x-[80%] rounded-full bg-neon-primary/15 blur-[110px]"
+        />
+        <div
+          aria-hidden
+          className="pointer-events-none absolute bottom-1/4 left-1/2 size-80 -translate-x-[20%] rounded-full bg-neon-secondary/15 blur-[110px]"
         />
         <div className="relative w-full max-w-md">
           {previewMode ? (
@@ -249,11 +257,11 @@ export default function ClaimPage({
               >
             <Card
               inert={showQr || undefined}
-              className="gap-0 py-0 backface-hidden [grid-area:1/1] [--card-spacing:--spacing(6)] sm:[--card-spacing:--spacing(8)]"
+              className="gradient-frame neon-panel gap-0 py-0 backface-hidden [grid-area:1/1] [--card-spacing:--spacing(6)] sm:[--card-spacing:--spacing(8)]"
             >
               <CardHeader className="gap-4 pt-(--card-spacing)">
                 <div className="flex items-start justify-between gap-3">
-                  <CardTitle className="font-heading text-3xl font-semibold tracking-[-0.02em] text-balance">
+                  <CardTitle className="font-heading text-3xl font-semibold tracking-[-0.02em] text-balance neon-text">
                     {event.name}
                   </CardTitle>
                   <Button
@@ -579,12 +587,12 @@ function QrPanel({
   return (
     <Card
       inert={hidden || undefined}
-      className="gap-0 rotate-y-180 py-0 backface-hidden [grid-area:1/1] [--card-spacing:--spacing(6)] sm:[--card-spacing:--spacing(8)]"
+      className="gradient-frame neon-panel gap-0 rotate-y-180 py-0 backface-hidden [grid-area:1/1] [--card-spacing:--spacing(6)] sm:[--card-spacing:--spacing(8)]"
     >
       <CardHeader className="gap-2 pt-(--card-spacing)">
         <div className="flex items-start justify-between gap-3">
           <div className="flex flex-col gap-2">
-            <span className="eyebrow text-muted-foreground">Scan to claim</span>
+            <span className="eyebrow text-neon-secondary">Scan to claim</span>
             <CardTitle className="font-heading text-2xl font-semibold tracking-[-0.02em] text-balance">
               {eventName}
             </CardTitle>
@@ -645,12 +653,12 @@ function Receipt({
 }) {
   return (
     <div
-      className="receipt-edge receipt-print rounded-t-xl border border-border bg-surface pb-10 motion-reduce:animate-none"
+      className="receipt-edge receipt-print neon-panel rounded-t-xl border border-border bg-surface pb-10 motion-reduce:animate-none"
       role="status"
     >
       <div className="flex flex-col gap-6 p-6 sm:p-8">
         <div className="flex items-center justify-between">
-          <span className="eyebrow text-muted-foreground">
+          <span className="eyebrow text-neon-secondary neon-text">
             Code dispensed
           </span>
           <span className="relative flex size-2">
@@ -683,7 +691,7 @@ function Receipt({
           <div className="text-xs text-muted-dim">
             {codeType ? `Your “${codeType}” code` : "Your credit code"}
           </div>
-          <div className="mt-2 font-mono text-3xl font-medium tracking-[0.06em] break-all select-all sm:text-4xl">
+          <div className="mt-2 font-mono text-3xl font-medium tracking-[0.06em] break-all text-neon-secondary neon-text select-all sm:text-4xl">
             {code}
           </div>
         </div>


### PR DESCRIPTION
## Summary
Design-direction exploration: reskins the user-facing pages (home, claim) as a dark HUD with neon glows, gradient outlines, and glitch accents. Functionality untouched.

- `globals.css`: both themes become dark neon palettes driven by three colorway vars at the top of `:root` (`--neon-primary` magenta, `--neon-secondary` cyan, `--neon-tertiary` ultraviolet) — swap those three to re-skin. `--brand`/`--ring` now derive from them; card shadows become neon blooms; a faint fixed CRT scanline wash overlays `body::after`. New utilities: `bg-cybergrid`, `neon-text`, `neon-panel`, `gradient-frame`, `animate-glitch`.
- Home hero: the theme-paired Unicorn Studio WebGL scene (and its hydration/theme gating) is replaced by a CSS HUD backdrop — cyber grid, two neon blooms, a neon baseline — with cyan neon eyebrow, glitching headline, and a `SYS//CREDIT.DISPENSER :: ONLINE` readout. Event rows glow cyan on hover; section headings use the mono eyebrow style.
- Claim page: claim/QR cards get `gradient-frame neon-panel` (gradient outline + bloom), the receipt panel glows, the dispensed code renders in cyan `neon-text`, and the backdrop swaps to the cyber grid with neon blooms.

Base for the 5 "Cyberpunk Neon colorway" PRs, each of which retargets the `--neon-*` triple.

Link to Devin session: https://app.devin.ai/sessions/3528ad044d7342c2bffda868d6001b00
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/115" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->