### PR TITLE
Design direction: Retro Terminal

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,57 +4,55 @@
 
 @custom-variant dark (&:is(.dark *));
 
-/* Light mode (default) — "Paper": a white page field with warm off-neutrals
-   in the tints and borders rather than the pure grey axis, and ink (#22211E)
-   instead of near-black so text stays short of a harsh 19:1. Surface is a
-   neutral grey one step off white — hovers and the receipt stub read as a
-   quiet press of the field rather than a cream block. The blue accent is
-   reserved for the claim flow only. */
+/* Retro terminal / CRT — green phosphor on near-black glass. Light mode is
+   a "paper terminal": dark phosphor ink on a pale phosphor-tinted field, so
+   the theme toggle still means something. The phosphor hue drives every
+   accent; radius is zeroed so everything reads as character cells. */
 :root {
-  --surface: #f6f6f6;
-  --surface-hover: #f0f0f0;
-  --border: #eae7df;
-  --border-strong: #d5cfc2;
-  --muted: #f1efe8;
-  --muted-dim: #78716a;
-  --background: #ffffff;
-  --foreground: #22211e;
-  --card: #ffffff;
-  --card-foreground: #22211e;
-  --popover: #ffffff;
-  --popover-foreground: #22211e;
-  --primary: #22211e;
-  --primary-foreground: #faf9f5;
-  --secondary: #f1efe8;
-  --secondary-foreground: #22211e;
-  --muted-foreground: #57534a;
-  --accent: #f1efe8;
-  --accent-foreground: #22211e;
+  --phosphor: #1a7a3c;
+  --phosphor-dim: #4a8a60;
+  --phosphor-bright: #0c5c2a;
+  --surface: #e9f2e9;
+  --surface-hover: #dfecdf;
+  --border: #b9d4bd;
+  --border-strong: #8db898;
+  --muted: #dcebde;
+  --muted-dim: #5c7a64;
+  --background: #f2f7f2;
+  --foreground: #123d22;
+  --card: #eef5ee;
+  --card-foreground: #123d22;
+  --popover: #eef5ee;
+  --popover-foreground: #123d22;
+  --primary: #123d22;
+  --primary-foreground: #f2f7f2;
+  --secondary: #dcebde;
+  --secondary-foreground: #123d22;
+  --muted-foreground: #3c6349;
+  --accent: #dcebde;
+  --accent-foreground: #123d22;
   --destructive: oklch(0.577 0.245 27.325);
   --input: oklch(0 0 0 / 8%);
-  --brand: #2200ff;
-  --brand-foreground: #ffffff;
-  --ring: #44403a;
-  --selection: #e6e1d5;
-  --selection-foreground: #22211e;
-  /* Soft two-layer card shadow: invisible as "shadow", read as depth. Dark
-     mode zeroes it out and relies on surface contrast instead. */
-  --shadow-card:
-    0 1px 2px rgb(34 33 30 / 0.04), 0 4px 12px -2px rgb(34 33 30 / 0.04);
+  --brand: #1a7a3c;
+  --brand-foreground: #f2f7f2;
+  --ring: #2a6b42;
+  --selection: #123d22;
+  --selection-foreground: #d8f5d8;
+  --shadow-card: 0 0 rgb(0 0 0 / 0);
   --chart-1: oklch(0.269 0 0);
   --chart-2: oklch(0.439 0 0);
   --chart-3: oklch(0.556 0 0);
   --chart-4: oklch(0.708 0 0);
   --chart-5: oklch(0.87 0 0);
-  --radius: 0.625rem;
-  --sidebar: #ffffff;
-  --sidebar-foreground: #22211e;
-  --sidebar-primary: #22211e;
-  --sidebar-primary-foreground: #faf9f5;
-  --sidebar-accent: #f1efe8;
-  --sidebar-accent-foreground: #22211e;
-  --sidebar-border: #e7e3da;
-  --sidebar-ring: #78716a;
+  --radius: 0rem;
+  --sidebar: #eef5ee;
+  --sidebar-foreground: #123d22;
+  --sidebar-primary: #123d22;
+  --sidebar-primary-foreground: #f2f7f2;
+  --sidebar-accent: #dcebde;
+  --sidebar-accent-foreground: #123d22;
+  --sidebar-border: #b9d4bd;
+  --sidebar-ring: #5c7a64;
 }
 
 @theme inline {
@@ -66,11 +64,13 @@
   --color-foreground: var(--foreground);
   --color-muted: var(--muted);
   --color-muted-dim: var(--muted-dim);
-  --font-sans: var(--font-geist-sans);
+  /* Everything is monospace — the terminal has exactly one typeface. */
+  --font-sans: var(--font-geist-mono);
   --font-mono: var(--font-geist-mono);
-  /* Headings share the body face — hierarchy comes from weight, size, and
-     tracking rather than a second display family. */
-  --font-heading: var(--font-geist-sans);
+  --font-heading: var(--font-geist-mono);
+  --color-phosphor: var(--phosphor);
+  --color-phosphor-dim: var(--phosphor-dim);
+  --color-phosphor-bright: var(--phosphor-bright);
   --color-brand: var(--brand);
   --color-brand-foreground: var(--brand-foreground);
   --color-sidebar-ring: var(--sidebar-ring);
@@ -110,7 +110,38 @@
 }
 
 body {
-  font-family: var(--font-sans), system-ui, sans-serif;
+  font-family: var(--font-mono), monospace;
+}
+
+/* CRT scanlines: a fixed full-viewport overlay of faint horizontal lines,
+   plus a soft vignette that pools at the glass corners. Sits above content
+   but never intercepts input. */
+body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  pointer-events: none;
+  background-image: repeating-linear-gradient(
+    to bottom,
+    transparent 0px,
+    transparent 2px,
+    var(--scanline, rgb(0 0 0 / 0.06)) 2px,
+    var(--scanline, rgb(0 0 0 / 0.06)) 3px
+  );
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: 9998;
+  pointer-events: none;
+  background: radial-gradient(
+    ellipse 120% 120% at 50% 50%,
+    transparent 60%,
+    var(--vignette, rgb(0 0 0 / 0.12)) 100%
+  );
 }
 
 /* Neutral, not brand: selection is incidental, so it shouldn't compete with
@@ -145,6 +176,64 @@ input:-webkit-autofill:focus {
 @utility bg-dotgrid {
   background-image: radial-gradient(var(--border) 1px, transparent 1px);
   background-size: 28px 28px;
+}
+
+/* Phosphor glow: the soft halo a lit CRT pixel bleeds into the glass. */
+@utility phosphor-glow {
+  text-shadow:
+    0 0 6px color-mix(in srgb, var(--phosphor) 55%, transparent),
+    0 0 24px color-mix(in srgb, var(--phosphor) 25%, transparent);
+}
+
+@utility phosphor-glow-soft {
+  text-shadow: 0 0 8px color-mix(in srgb, var(--phosphor) 30%, transparent);
+}
+
+/* Blinking block cursor, as an ::after so it rides the end of a line. */
+@utility terminal-cursor {
+  &::after {
+    content: "█";
+    margin-left: 0.15em;
+    animation: cursor-blink 1.1s steps(1) infinite;
+  }
+}
+
+@keyframes cursor-blink {
+  0%,
+  49% {
+    opacity: 1;
+  }
+  50%,
+  100% {
+    opacity: 0;
+  }
+}
+
+/* CRT power-on flicker for hero copy. */
+@utility crt-flicker {
+  animation: crt-flicker 2.4s ease-in-out 1;
+}
+
+@keyframes crt-flicker {
+  0% {
+    opacity: 0;
+  }
+  4% {
+    opacity: 0.7;
+  }
+  8% {
+    opacity: 0.2;
+  }
+  12% {
+    opacity: 1;
+  }
+  16% {
+    opacity: 0.6;
+  }
+  20%,
+  100% {
+    opacity: 1;
+  }
 }
 
 /* Receipt edge: scalloped bottom, like a stub torn off a perforated roll. */
@@ -184,50 +273,53 @@ input:-webkit-autofill:focus {
   }
 }
 
-/* Dark mode — "Paper" after dark: the near-black picks up a faint cool cast
-   while the text stays warm off-white, and contrast drops from 18:1 to ~16:1
-   to stop white type haloing on OLED. */
+/* Dark mode — the real CRT: green phosphor burning on near-black glass. */
 .dark {
-  --surface: #141416;
-  --surface-hover: #1a1a1d;
-  --border: #26262a;
-  --border-strong: #3a3a40;
-  --muted: #212125;
-  --muted-dim: #7a7772;
-  --background: #0c0c0e;
-  --foreground: #e8e6e1;
-  --card: #141416;
-  --card-foreground: #e8e6e1;
-  --popover: #1a1a1d;
-  --popover-foreground: #e8e6e1;
-  --primary: #e8e6e1;
-  --primary-foreground: #0c0c0e;
-  --secondary: #2b2b30;
-  --secondary-foreground: #e8e6e1;
-  --muted-foreground: #a8a5a0;
-  --accent: #2b2b30;
-  --accent-foreground: #e8e6e1;
+  --phosphor: #33ff66;
+  --phosphor-dim: #1e9944;
+  --phosphor-bright: #7dffa3;
+  --scanline: rgb(0 0 0 / 0.22);
+  --vignette: rgb(0 0 0 / 0.45);
+  --surface: #0a140c;
+  --surface-hover: #0e1c10;
+  --border: #143d1f;
+  --border-strong: #1e5c2e;
+  --muted: #0e1c10;
+  --muted-dim: #2e7a44;
+  --background: #050a06;
+  --foreground: #33ff66;
+  --card: #081109;
+  --card-foreground: #33ff66;
+  --popover: #0a140c;
+  --popover-foreground: #33ff66;
+  --primary: #33ff66;
+  --primary-foreground: #050a06;
+  --secondary: #0e1c10;
+  --secondary-foreground: #7dffa3;
+  --muted-foreground: #2e9950;
+  --accent: #0e1c10;
+  --accent-foreground: #7dffa3;
   --destructive: oklch(0.704 0.191 22.216);
-  --input: oklch(1 0 0 / 15%);
-  --brand: #2200ff;
-  --brand-foreground: #ffffff;
-  --ring: #c4c1bb;
-  --selection: #33333a;
-  --selection-foreground: #e8e6e1;
+  --input: oklch(0.7 0.2 150 / 15%);
+  --brand: #33ff66;
+  --brand-foreground: #050a06;
+  --ring: #33ff66;
+  --selection: #33ff66;
+  --selection-foreground: #050a06;
   --shadow-card: 0 0 rgb(0 0 0 / 0);
   --chart-1: oklch(0.87 0 0);
   --chart-2: oklch(0.556 0 0);
   --chart-3: oklch(0.439 0 0);
   --chart-4: oklch(0.371 0 0);
   --chart-5: oklch(0.269 0 0);
-  --sidebar: #141416;
-  --sidebar-foreground: #e8e6e1;
-  --sidebar-primary: #e8e6e1;
-  --sidebar-primary-foreground: #0c0c0e;
-  --sidebar-accent: #2b2b30;
-  --sidebar-accent-foreground: #e8e6e1;
-  --sidebar-border: #26262a;
-  --sidebar-ring: #7a7772;
+  --sidebar: #081109;
+  --sidebar-foreground: #33ff66;
+  --sidebar-primary: #33ff66;
+  --sidebar-primary-foreground: #050a06;
+  --sidebar-accent: #0e1c10;
+  --sidebar-accent-foreground: #7dffa3;
+  --sidebar-border: #143d1f;
+  --sidebar-ring: #2e7a44;
 }
 
 @layer base {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,13 +1,10 @@
 "use client";
 
-import { useSyncExternalStore } from "react";
 import Link from "next/link";
 import { BadgeCheck, Ticket } from "lucide-react";
-import { useTheme } from "next-themes";
 import { useConvexAuth, useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { daysUntilEvent, formatEventDate } from "@/lib/event-date";
-import UnicornSceneEmbed from "@/components/UnicornSceneEmbed";
 import SiteHeader from "@/components/SiteHeader";
 import SiteFooter from "@/components/SiteFooter";
 import { Badge } from "@/components/ui/badge";
@@ -21,29 +18,12 @@ import {
 } from "@/components/ui/empty";
 import { cn } from "@/lib/utils";
 
-// The hero background is a theme-paired Unicorn Studio WebGL scene
-// (experiment). A Unicorn project publishes exactly one authored design and
-// the SDK has no color-scheme awareness, so a light-authored project shows
-// its light design in dark mode too — each theme therefore needs its own
-// project ID here.
-const UNICORN_PROJECTS = {
-  light: "wEz2vCJgsynwCYSb3HgR",
-  dark: "aEdLurlqLEmU1DUjAaUz",
-} as const;
-
-// Bump this whenever a scene is republished in Unicorn Studio. Deployed
-// builds read scene data through Unicorn's CDN, which caches for months and
-// doesn't reliably purge on republish; the update param below is part of the
-// CDN cache key, so bumping the version makes deploys fetch the new design.
-// Dev skips the param (and the CDN): without it the SDK cache-busts every
-// load, so republishes show up on a plain refresh.
-const UNICORN_CACHE_VERSION = 2;
-
-const isProdBuild = process.env.NODE_ENV === "production";
-
-// Stable no-op subscription for the hydration gate below: the snapshot never
-// changes on the client, we only care that the server snapshot is false.
-const emptySubscribe = () => () => {};
+// ASCII masthead for the hero — rendered in a <pre> so the terminal owns
+// the top of the page. Hidden from screen readers; the h1 carries meaning.
+const ASCII_MASTHEAD = String.raw`
+ █▀▀ █▀▀█ █▀▀ █▀▀█ █▀▀█ █▀▀█ ▀█▀ ▀█▀ █▀▀█
+ █   █▄▄▀ █▀▀ █  █ █  █ █▄▄█  █   █  █  █
+ ▀▀▀ ▀ ▀▀ ▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀  ▀  ▀  ▀▀▀ ▀▀▀▀`;
 
 interface EventItem {
   _id: string;
@@ -78,6 +58,12 @@ function EventRow({
       >
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-x-3 gap-y-1 font-heading text-xl font-medium tracking-tight sm:text-2xl">
+            <span
+              aria-hidden
+              className="text-phosphor-dim opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100"
+            >
+              &gt;
+            </span>
             {event.name}
             {claimed ? (
               <Badge variant="secondary" className="gap-1">
@@ -110,23 +96,6 @@ export default function Home() {
     mine?.map((item) => item.event?._id).filter(Boolean) ?? [],
   );
 
-  // The scene choice needs JS (the server doesn't know the theme, while the
-  // hydration render already does), so gate it behind hydration to keep both
-  // trees identical; the copy and scrim flip with pure dark: variants and
-  // render correctly from the first paint. Until hydration the plain
-  // theme-tinted shell stands in for both themes.
-  const { resolvedTheme } = useTheme();
-  const hydrated = useSyncExternalStore(
-    emptySubscribe,
-    () => true,
-    () => false,
-  );
-  const heroProjectId = hydrated
-    ? resolvedTheme === "light"
-      ? UNICORN_PROJECTS.light
-      : UNICORN_PROJECTS.dark
-    : undefined;
-
   // Dated events that have passed sink into their own dimmed group; undated
   // events are treated as current. Active events order soonest-first, with
   // undated ones following in their arrival (newest created) order; past
@@ -145,20 +114,31 @@ export default function Home() {
     events?.filter((e) => e.eventDate && daysUntilEvent(e.eventDate) < 0) ?? []
   ).sort((a, b) => (b.eventDate ?? "").localeCompare(a.eventDate ?? ""));
 
-  // Shared hero copy: crisp DOM stacked above the theme's scene. pt-15.25
-  // offsets the translucent header bar the hero slides under, keeping the
-  // copy centered in the visible area.
+  // Terminal boot-screen hero: ASCII masthead, a shell prompt line, and the
+  // headline typed out behind a blinking block cursor. pt-15.25 offsets the
+  // translucent header bar the hero slides under.
   const heroCopy = (
     <div className="relative mx-auto flex h-full w-full max-w-5xl flex-col justify-center px-4 pt-15.25 sm:px-6">
-      <p className="eyebrow animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 text-black/60 dark:text-white/60 motion-reduce:animate-none">
-        {process.env.NEXT_PUBLIC_IS_DEVIN ? "Devin " : ""}Event credit
-        distribution
+      <pre
+        aria-hidden
+        className="crt-flicker phosphor-glow-soft hidden select-none text-[9px] leading-[1.15] text-phosphor-dim motion-reduce:animate-none sm:block sm:text-[11px]"
+      >
+        {ASCII_MASTHEAD}
+      </pre>
+      <p className="eyebrow animate-in fade-in fill-mode-both duration-500 mt-6 text-muted-foreground motion-reduce:animate-none">
+        <span aria-hidden className="text-phosphor-dim">$ </span>
+        ./vend --{process.env.NEXT_PUBLIC_IS_DEVIN ? "devin " : ""}event-credit-distribution
       </p>
-      <h1 className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-100 mt-6 max-w-2xl font-heading text-5xl leading-[0.95] font-semibold tracking-[-0.03em] text-balance text-black dark:text-white motion-reduce:animate-none sm:text-7xl">
+      <h1 className="animate-in fade-in fill-mode-both duration-500 delay-100 terminal-cursor phosphor-glow mt-6 max-w-2xl font-heading text-4xl leading-[1.05] font-semibold tracking-tight text-balance text-foreground uppercase motion-reduce:animate-none sm:text-6xl">
         Claim your credits.
       </h1>
-      <p className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-200 mt-6 max-w-md text-sm leading-relaxed text-black/70 dark:text-white/70 motion-reduce:animate-none">
+      <p className="animate-in fade-in fill-mode-both duration-500 delay-200 mt-6 max-w-md text-sm leading-relaxed text-muted-foreground motion-reduce:animate-none">
+        <span aria-hidden className="text-phosphor-dim">&gt; </span>
         Sign in, then select your event to claim your credits.
+      </p>
+      <p className="animate-in fade-in fill-mode-both duration-500 delay-300 mt-2 text-xs text-muted-dim motion-reduce:animate-none">
+        <span aria-hidden className="text-phosphor-dim">&gt; </span>
+        READY.
       </p>
     </div>
   );
@@ -170,41 +150,21 @@ export default function Home() {
         <section className="-mt-15.25 border-b border-border/65">
           {/* The section pulls up behind the translucent header bar
               (-mt-15.25) so the background runs to the top of the page; the
-              hero is 61px taller to compensate and the scene shows through
-              the bar's frosted fill. The theme's Unicorn Studio scene renders
-              behind the copy and a soft theme-matched scrim; keying the scene
-              by project swaps it cleanly on theme change while the copy stays
-              mounted. The scene's mouse interactivity listens on window, so
-              the copy sitting above it doesn't block it. */}
-          <div className="relative h-[520px] overflow-hidden bg-background dark:bg-[#131313] sm:h-[486px]">
-            {heroProjectId ? (
-              <div className="absolute inset-0" aria-hidden>
-                {/* Dev fetches fresh scene data on every load; deploys pin
-                    the CDN to UNICORN_CACHE_VERSION — see the constant. */}
-                <UnicornSceneEmbed
-                  key={heroProjectId}
-                  projectId={
-                    isProdBuild
-                      ? `${heroProjectId}?update=${UNICORN_CACHE_VERSION}`
-                      : heroProjectId
-                  }
-                  production={isProdBuild}
-                />
-              </div>
-            ) : null}
-            {/* Soft scrim keeps the headline legible over the scenes; tune
-                or remove once the look settles. */}
+              hero is 61px taller to compensate. A faint dot grid stands in
+              for CRT phosphor texture behind the boot copy. */}
+          <div className="relative h-[520px] overflow-hidden bg-background sm:h-[486px]">
             <div
-              className="absolute inset-0 bg-white/20 dark:bg-black/20"
               aria-hidden
+              className="absolute inset-0 bg-dotgrid [mask-image:radial-gradient(ellipse_70%_70%_at_50%_50%,black,transparent)]"
             />
             {heroCopy}
           </div>
         </section>
 
         <section className="mx-auto w-full max-w-5xl px-4 py-14 sm:px-6 sm:py-20">
-          <h2 className="text-sm font-medium text-muted-foreground">
-            Active events
+          <h2 className="eyebrow text-muted-foreground">
+            <span aria-hidden className="text-phosphor-dim">$ </span>ls
+            ./active-events
           </h2>
 
           {events === undefined ? (
@@ -258,8 +218,9 @@ export default function Home() {
               {past.length > 0 ? (
                 <>
                   <div className="mt-14 flex items-baseline justify-between">
-                    <h2 className="text-sm font-medium text-muted-foreground">
-                      Past events
+                    <h2 className="eyebrow text-muted-foreground">
+                      <span aria-hidden className="text-phosphor-dim">$ </span>
+                      ls ./past-events
                     </h2>
                     <span className="font-mono text-xs text-muted-dim tabular-nums">
                       {String(past.length).padStart(2, "0")}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,9 +21,9 @@ import { cn } from "@/lib/utils";
 // ASCII masthead for the hero — rendered in a <pre> so the terminal owns
 // the top of the page. Hidden from screen readers; the h1 carries meaning.
 const ASCII_MASTHEAD = String.raw`
- █▀▀ █▀▀█ █▀▀ █▀▀█ █▀▀█ █▀▀█ ▀█▀ ▀█▀ █▀▀█
- █   █▄▄▀ █▀▀ █  █ █  █ █▄▄█  █   █  █  █
- ▀▀▀ ▀ ▀▀ ▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀  ▀  ▀  ▀▀▀ ▀▀▀▀`;
+ █   █ █▀▀▀ █▀▀▄ █▀▀▄
+ █   █ █▀▀  █  █ █  █
+  ▀▀▀  ▀▀▀▀ ▀  ▀ ▀▀▀ `;
 
 interface EventItem {
   _id: string;

--- a/components/ClaimPage.tsx
+++ b/components/ClaimPage.tsx
@@ -253,7 +253,7 @@ export default function ClaimPage({
             >
               <CardHeader className="gap-4 pt-(--card-spacing)">
                 <div className="flex items-start justify-between gap-3">
-                  <CardTitle className="font-heading text-3xl font-semibold tracking-[-0.02em] text-balance">
+                  <CardTitle className="phosphor-glow font-heading text-3xl font-semibold tracking-tight text-balance uppercase">
                     {event.name}
                   </CardTitle>
                   <Button
@@ -480,10 +480,10 @@ export default function ClaimPage({
                       {submitting ? (
                         <>
                           <Spinner data-icon="inline-start" />
-                          Checking the list...
+                          CHECKING THE LIST...
                         </>
                       ) : (
-                        "Dispense my code"
+                        "[ DISPENSE MY CODE ]"
                       )}
                     </Button>
                     {event.claimInstructions ? (
@@ -651,6 +651,7 @@ function Receipt({
       <div className="flex flex-col gap-6 p-6 sm:p-8">
         <div className="flex items-center justify-between">
           <span className="eyebrow text-muted-foreground">
+            <span aria-hidden className="text-phosphor-dim">&gt; </span>
             Code dispensed
           </span>
           <span className="relative flex size-2">
@@ -683,7 +684,7 @@ function Receipt({
           <div className="text-xs text-muted-dim">
             {codeType ? `Your “${codeType}” code` : "Your credit code"}
           </div>
-          <div className="mt-2 font-mono text-3xl font-medium tracking-[0.06em] break-all select-all sm:text-4xl">
+          <div className="phosphor-glow mt-2 font-mono text-3xl font-medium tracking-[0.06em] break-all select-all sm:text-4xl">
             {code}
           </div>
         </div>


### PR DESCRIPTION
## Summary
Explores a RETRO TERMINAL / CRT design direction across the user-facing pages (home + claim), all functionality intact.

- `globals.css`: repoints the whole palette to green phosphor — dark mode is bright phosphor (`#33ff66`) on near-black glass; light mode is a "paper terminal" (dark phosphor ink on a pale green-tinted field) so the theme toggle still means something. `--radius: 0` (blocky character-cell corners), all type set in Geist Mono (`--font-sans`/`--font-heading` → mono). Adds fixed `body::before/::after` CRT overlays (scanlines + vignette, pointer-events none) and utilities: `phosphor-glow`, `terminal-cursor` (blinking `█`), `crt-flicker`.
- Home (`app/page.tsx`): the Unicorn Studio WebGL hero is replaced by a terminal boot screen — ASCII masthead in a `<pre>`, `$ ./vend --event-credit-distribution` prompt eyebrow, glowing headline with blinking block cursor, `> READY.` line. Section headings become `$ ls ./active-events` / `$ ls ./past-events`; event rows gain a `>` prompt on hover.
- Claim page (`ClaimPage.tsx`): glowing uppercase event title, `[ DISPENSE MY CODE ]` button label, phosphor glow on the dispensed code, `> ` prompt on the receipt eyebrow.

Base colorway is green phosphor; alternate colorways will follow as PRs targeting this branch.

Link to Devin session: https://app.devin.ai/sessions/49723fb3c0c04e62b807b076aa51af28
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/116" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->