### PR TITLE
Design direction: Soft Neumorphism

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,57 +4,66 @@
 
 @custom-variant dark (&:is(.dark *));
 
-/* Light mode (default) — "Paper": a white page field with warm off-neutrals
-   in the tints and borders rather than the pure grey axis, and ink (#22211E)
-   instead of near-black so text stays short of a harsh 19:1. Surface is a
-   neutral grey one step off white — hovers and the receipt stub read as a
-   quiet press of the field rather than a cream block. The blue accent is
-   reserved for the claim flow only. */
+/* Light mode (default) — "Soft Neumorphism": one low-contrast tonal field
+   (a cool porcelain grey) where every surface is the same material as the
+   page. Depth comes from paired shadows — a light source at the top-left
+   casts a dark shadow below-right and a highlight above-left — so elements
+   read as extruded from or pressed into the field rather than layered on
+   top of it. */
 :root {
-  --surface: #f6f6f6;
-  --surface-hover: #f0f0f0;
-  --border: #eae7df;
-  --border-strong: #d5cfc2;
-  --muted: #f1efe8;
-  --muted-dim: #78716a;
-  --background: #ffffff;
-  --foreground: #22211e;
-  --card: #ffffff;
-  --card-foreground: #22211e;
-  --popover: #ffffff;
-  --popover-foreground: #22211e;
-  --primary: #22211e;
-  --primary-foreground: #faf9f5;
-  --secondary: #f1efe8;
-  --secondary-foreground: #22211e;
-  --muted-foreground: #57534a;
-  --accent: #f1efe8;
-  --accent-foreground: #22211e;
+  --surface: #e0e5ec;
+  --surface-hover: #d8dee7;
+  --border: #cfd6e0;
+  --border-strong: #b7c0cd;
+  --muted: #d4dae3;
+  --muted-dim: #7d8694;
+  --background: #e0e5ec;
+  --foreground: #33383f;
+  --card: #e0e5ec;
+  --card-foreground: #33383f;
+  --popover: #e4e9f0;
+  --popover-foreground: #33383f;
+  --primary: #3c424b;
+  --primary-foreground: #eef1f6;
+  --secondary: #d4dae3;
+  --secondary-foreground: #33383f;
+  --muted-foreground: #5b626d;
+  --accent: #d4dae3;
+  --accent-foreground: #33383f;
   --destructive: oklch(0.577 0.245 27.325);
   --input: oklch(0 0 0 / 8%);
   --brand: #2200ff;
   --brand-foreground: #ffffff;
-  --ring: #44403a;
-  --selection: #e6e1d5;
-  --selection-foreground: #22211e;
-  /* Soft two-layer card shadow: invisible as "shadow", read as depth. Dark
-     mode zeroes it out and relies on surface contrast instead. */
-  --shadow-card:
-    0 1px 2px rgb(34 33 30 / 0.04), 0 4px 12px -2px rgb(34 33 30 / 0.04);
+  --ring: #4d5560;
+  --selection: #c8d0dc;
+  --selection-foreground: #33383f;
+  /* Neumorphic shadow pairs: a dark drop below-right + a light highlight
+     above-left reads as extrusion; the inset pair reads as a press. */
+  --neu-light: rgb(255 255 255 / 0.85);
+  --neu-dark: rgb(163 177 198 / 0.65);
+  --shadow-neu:
+    8px 8px 18px var(--neu-dark), -8px -8px 18px var(--neu-light);
+  --shadow-neu-sm:
+    4px 4px 9px var(--neu-dark), -4px -4px 9px var(--neu-light);
+  --shadow-neu-inset:
+    inset 4px 4px 8px var(--neu-dark), inset -4px -4px 8px var(--neu-light);
+  --shadow-neu-inset-sm:
+    inset 2px 2px 5px var(--neu-dark), inset -2px -2px 5px var(--neu-light);
+  --shadow-card: var(--shadow-neu);
   --chart-1: oklch(0.269 0 0);
   --chart-2: oklch(0.439 0 0);
   --chart-3: oklch(0.556 0 0);
   --chart-4: oklch(0.708 0 0);
   --chart-5: oklch(0.87 0 0);
-  --radius: 0.625rem;
-  --sidebar: #ffffff;
-  --sidebar-foreground: #22211e;
-  --sidebar-primary: #22211e;
-  --sidebar-primary-foreground: #faf9f5;
-  --sidebar-accent: #f1efe8;
-  --sidebar-accent-foreground: #22211e;
-  --sidebar-border: #e7e3da;
-  --sidebar-ring: #78716a;
+  --radius: 1rem;
+  --sidebar: #e0e5ec;
+  --sidebar-foreground: #33383f;
+  --sidebar-primary: #3c424b;
+  --sidebar-primary-foreground: #eef1f6;
+  --sidebar-accent: #d4dae3;
+  --sidebar-accent-foreground: #33383f;
+  --sidebar-border: #cfd6e0;
+  --sidebar-ring: #7d8694;
 }
 
 @theme inline {
@@ -141,6 +150,24 @@ input:-webkit-autofill:focus {
   text-transform: uppercase;
 }
 
+/* Neumorphic depth utilities: raised surfaces extrude out of the field,
+   inset surfaces press into it. */
+@utility neu-raised {
+  box-shadow: var(--shadow-neu);
+}
+
+@utility neu-raised-sm {
+  box-shadow: var(--shadow-neu-sm);
+}
+
+@utility neu-inset {
+  box-shadow: var(--shadow-neu-inset);
+}
+
+@utility neu-inset-sm {
+  box-shadow: var(--shadow-neu-inset-sm);
+}
+
 /* Faint dot grid backdrop for hero surfaces. */
 @utility bg-dotgrid {
   background-image: radial-gradient(var(--border) 1px, transparent 1px);
@@ -184,50 +211,52 @@ input:-webkit-autofill:focus {
   }
 }
 
-/* Dark mode — "Paper" after dark: the near-black picks up a faint cool cast
-   while the text stays warm off-white, and contrast drops from 18:1 to ~16:1
-   to stop white type haloing on OLED. */
+/* Dark mode — the same tonal field lowered to a soft charcoal-slate. The
+   highlight half of each shadow pair dims to a faint sheen so extrusion
+   still reads without haloing. */
 .dark {
-  --surface: #141416;
-  --surface-hover: #1a1a1d;
-  --border: #26262a;
-  --border-strong: #3a3a40;
-  --muted: #212125;
-  --muted-dim: #7a7772;
-  --background: #0c0c0e;
-  --foreground: #e8e6e1;
-  --card: #141416;
-  --card-foreground: #e8e6e1;
-  --popover: #1a1a1d;
-  --popover-foreground: #e8e6e1;
-  --primary: #e8e6e1;
-  --primary-foreground: #0c0c0e;
-  --secondary: #2b2b30;
-  --secondary-foreground: #e8e6e1;
-  --muted-foreground: #a8a5a0;
-  --accent: #2b2b30;
-  --accent-foreground: #e8e6e1;
+  --surface: #2a2e35;
+  --surface-hover: #31353d;
+  --border: #383d46;
+  --border-strong: #4a505b;
+  --muted: #333841;
+  --muted-dim: #868d99;
+  --background: #2a2e35;
+  --foreground: #d9dde3;
+  --card: #2a2e35;
+  --card-foreground: #d9dde3;
+  --popover: #31353d;
+  --popover-foreground: #d9dde3;
+  --primary: #d9dde3;
+  --primary-foreground: #262a30;
+  --secondary: #333841;
+  --secondary-foreground: #d9dde3;
+  --muted-foreground: #a4aab4;
+  --accent: #333841;
+  --accent-foreground: #d9dde3;
   --destructive: oklch(0.704 0.191 22.216);
   --input: oklch(1 0 0 / 15%);
   --brand: #2200ff;
   --brand-foreground: #ffffff;
-  --ring: #c4c1bb;
-  --selection: #33333a;
-  --selection-foreground: #e8e6e1;
-  --shadow-card: 0 0 rgb(0 0 0 / 0);
+  --ring: #aab1bc;
+  --selection: #3d434d;
+  --selection-foreground: #d9dde3;
+  --neu-light: rgb(255 255 255 / 0.05);
+  --neu-dark: rgb(0 0 0 / 0.45);
+  --shadow-card: var(--shadow-neu);
   --chart-1: oklch(0.87 0 0);
   --chart-2: oklch(0.556 0 0);
   --chart-3: oklch(0.439 0 0);
   --chart-4: oklch(0.371 0 0);
   --chart-5: oklch(0.269 0 0);
-  --sidebar: #141416;
-  --sidebar-foreground: #e8e6e1;
-  --sidebar-primary: #e8e6e1;
-  --sidebar-primary-foreground: #0c0c0e;
-  --sidebar-accent: #2b2b30;
-  --sidebar-accent-foreground: #e8e6e1;
-  --sidebar-border: #26262a;
-  --sidebar-ring: #7a7772;
+  --sidebar: #2a2e35;
+  --sidebar-foreground: #d9dde3;
+  --sidebar-primary: #d9dde3;
+  --sidebar-primary-foreground: #262a30;
+  --sidebar-accent: #333841;
+  --sidebar-accent-foreground: #d9dde3;
+  --sidebar-border: #383d46;
+  --sidebar-ring: #868d99;
 }
 
 @layer base {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -66,13 +66,13 @@ function EventRow({
 }) {
   return (
     <li
-      className="animate-in fade-in slide-in-from-bottom-1 fill-mode-both duration-300 border-b border-border motion-reduce:animate-none"
+      className="animate-in fade-in slide-in-from-bottom-1 fill-mode-both duration-300 motion-reduce:animate-none"
       style={{ animationDelay: `${Math.min(index, 10) * 40}ms` }}
     >
       <Link
         href={`/${event.slug}`}
         className={cn(
-          "group flex items-center gap-6 px-2 py-7 transition-colors hover:bg-surface focus-visible:bg-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/60 sm:gap-10 sm:px-4",
+          "group neu-raised flex items-center gap-6 rounded-3xl bg-card px-6 py-7 transition-all hover:neu-inset focus-visible:neu-inset focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/60 sm:gap-10 sm:px-8",
           past && "opacity-60 transition-opacity hover:opacity-100",
         )}
       >
@@ -167,7 +167,7 @@ export default function Home() {
     <div className="flex min-h-screen flex-col">
       <SiteHeader />
       <main id="main-content" className="flex-1">
-        <section className="-mt-15.25 border-b border-border/65">
+        <section className="-mt-15.25">
           {/* The section pulls up behind the translucent header bar
               (-mt-15.25) so the background runs to the top of the page; the
               hero is 61px taller to compensate and the scene shows through
@@ -176,7 +176,7 @@ export default function Home() {
               by project swaps it cleanly on theme change while the copy stays
               mounted. The scene's mouse interactivity listens on window, so
               the copy sitting above it doesn't block it. */}
-          <div className="relative h-[520px] overflow-hidden bg-background dark:bg-[#131313] sm:h-[486px]">
+          <div className="relative h-[520px] overflow-hidden bg-background sm:h-[486px]">
             {heroProjectId ? (
               <div className="absolute inset-0" aria-hidden>
                 {/* Dev fetches fresh scene data on every load; deploys pin
@@ -209,14 +209,14 @@ export default function Home() {
 
           {events === undefined ? (
             <div
-              className="mt-4 border-t border-border"
+              className="mt-6 flex flex-col gap-5"
               role="status"
               aria-label="Loading active events"
             >
               {[0, 1, 2].map((i) => (
                 <div
                   key={i}
-                  className="flex items-center gap-6 border-b border-border px-2 py-7 sm:gap-10 sm:px-4"
+                  className="neu-inset flex items-center gap-6 rounded-3xl px-6 py-7 sm:gap-10 sm:px-8"
                 >
                   <div className="flex min-w-0 flex-1 flex-col gap-2">
                     <Skeleton className="h-5 w-2/3 rounded-sm" />
@@ -226,7 +226,7 @@ export default function Home() {
               ))}
             </div>
           ) : events.length === 0 ? (
-            <Empty className="mt-6 border border-dashed border-border-strong py-16">
+            <Empty className="neu-inset mt-6 rounded-3xl py-16">
               <EmptyHeader>
                 <EmptyMedia variant="icon">
                   <Ticket />
@@ -244,7 +244,7 @@ export default function Home() {
                   No active events right now.
                 </p>
               ) : (
-                <ul className="mt-4 border-t border-border">
+                <ul className="mt-6 flex flex-col gap-5">
                   {current.map((event, index) => (
                     <EventRow
                       key={event._id}
@@ -265,7 +265,7 @@ export default function Home() {
                       {String(past.length).padStart(2, "0")}
                     </span>
                   </div>
-                  <ul className="mt-4 border-t border-border">
+                  <ul className="mt-6 flex flex-col gap-5">
                     {past.map((event, index) => (
                       <EventRow
                         key={event._id}

--- a/components/ClaimPage.tsx
+++ b/components/ClaimPage.tsx
@@ -602,7 +602,7 @@ function QrPanel({
         </div>
       </CardHeader>
       <CardContent className="flex flex-1 flex-col items-center justify-center gap-5 py-(--card-spacing)">
-        <div className="rounded-lg border border-border bg-background p-4 text-foreground">
+        <div className="neu-inset rounded-2xl bg-background p-4 text-foreground">
           {url ? (
             <QRCodeSVG
               value={url}
@@ -645,7 +645,7 @@ function Receipt({
 }) {
   return (
     <div
-      className="receipt-edge receipt-print rounded-t-xl border border-border bg-surface pb-10 motion-reduce:animate-none"
+      className="receipt-edge receipt-print neu-raised rounded-t-3xl bg-surface pb-10 motion-reduce:animate-none"
       role="status"
     >
       <div className="flex flex-col gap-6 p-6 sm:p-8">
@@ -679,7 +679,7 @@ function Receipt({
           </Badge>
         ) : null}
 
-        <div className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-300 py-2 motion-reduce:animate-none">
+        <div className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-300 neu-inset rounded-2xl px-5 py-4 motion-reduce:animate-none">
           <div className="text-xs text-muted-dim">
             {codeType ? `Your “${codeType}” code` : "Your credit code"}
           </div>

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -4,19 +4,19 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/20 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 items-center justify-center rounded-full border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/20 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/80",
+        default: "bg-primary text-primary-foreground neu-raised-sm hover:bg-primary/90 active:neu-inset-sm",
         brand:
-          "bg-brand text-brand-foreground hover:bg-brand/85 hover:shadow-[0_2px_16px_-4px_var(--brand)]",
+          "bg-brand text-brand-foreground shadow-[4px_4px_9px_var(--neu-dark),-4px_-4px_9px_var(--neu-light)] hover:bg-brand/90 active:shadow-[inset_3px_3px_7px_rgb(0_0_0/0.35),inset_-3px_-3px_7px_rgb(255_255_255/0.15)]",
         outline:
-          "border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
+          "bg-background neu-raised-sm hover:text-foreground active:neu-inset-sm aria-expanded:neu-inset-sm aria-expanded:text-foreground aria-pressed:neu-inset-sm",
         secondary:
-          "bg-secondary text-secondary-foreground hover:bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_5%)] aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
+          "bg-secondary text-secondary-foreground neu-raised-sm hover:bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_5%)] active:neu-inset-sm aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
         ghost:
-          "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
+          "hover:neu-inset-sm hover:text-foreground aria-expanded:neu-inset-sm aria-expanded:text-foreground",
         destructive:
           "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
         link: "text-primary underline-offset-4 hover:underline",
@@ -24,14 +24,12 @@ const buttonVariants = cva(
       size: {
         default:
           "h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
-        xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
-        sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
-        lg: "h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        xs: "h-6 gap-1 rounded-full px-2 text-xs has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
+        sm: "h-7 gap-1 rounded-full px-2.5 text-[0.8rem] has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
+        lg: "h-11 gap-2 px-4 has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3",
         icon: "size-8",
-        "icon-xs":
-          "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
-        "icon-sm":
-          "size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg",
+        "icon-xs": "size-6 rounded-full [&_svg:not([class*='size-'])]:size-3",
+        "icon-sm": "size-7 rounded-full",
         "icon-lg": "size-9",
       },
     },

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -12,7 +12,7 @@ function Card({
       data-slot="card"
       data-size={size}
       className={cn(
-        "group/card flex flex-col gap-(--card-spacing) overflow-hidden rounded-xl bg-card py-(--card-spacing) text-sm text-card-foreground shadow-(--shadow-card) ring-1 ring-foreground/10 [--card-spacing:--spacing(4)] has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:[--card-spacing:--spacing(3)] data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
+        "group/card flex flex-col gap-(--card-spacing) overflow-hidden rounded-3xl bg-card py-(--card-spacing) text-sm text-card-foreground shadow-(--shadow-card) [--card-spacing:--spacing(4)] has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:[--card-spacing:--spacing(3)] data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
Explores a Soft Neumorphism design direction across the user-facing pages (home + claim), keeping all functionality intact.

- `globals.css`: replaces the "Paper" palette with a single low-contrast tonal field (porcelain grey `#e0e5ec` light / charcoal-slate `#2a2e35` dark) where background, card, and surface share one tone. Adds paired-shadow tokens (`--shadow-neu`, `--shadow-neu-sm`, inset variants, built from `--neu-light`/`--neu-dark`) and `neu-raised` / `neu-inset` utilities; `--shadow-card` now points at the neumorphic pair. `--radius` bumped 0.625rem → 1rem.
- `Card`: `rounded-3xl`, drops the hairline ring — depth comes from the shadow pair instead of borders.
- `Button`: pillowy — `rounded-full` everywhere, raised variants press to inset on `:active` (brand keeps its blue fill with a matching soft shadow), `lg` grows to h-11.
- Home page: event rows become raised pillow cards (pressing inset on hover/focus) instead of a bordered list; skeleton/empty states render as inset wells.
- Claim page: receipt is a raised stub with the code in an inset well; QR frame inset.


Link to Devin session: https://app.devin.ai/sessions/e9226af6fb0942e3957a0fbe7a96c8a0
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->