### PR TITLE
Design direction: Organic Nature

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,57 +4,55 @@
 
 @custom-variant dark (&:is(.dark *));
 
-/* Light mode (default) — "Paper": a white page field with warm off-neutrals
-   in the tints and borders rather than the pure grey axis, and ink (#22211E)
-   instead of near-black so text stays short of a harsh 19:1. Surface is a
-   neutral grey one step off white — hovers and the receipt stub read as a
-   quiet press of the field rather than a cream block. The blue accent is
-   reserved for the claim flow only. */
+/* Light mode (default) — "Meadow": a warm cream field with mossy greens and
+   earthy neutrals. Ink is a deep moss-brown rather than black, borders lean
+   toward dried grass, and the green brand accent is reserved for the claim
+   flow. Generous radii keep every surface soft and organic. */
 :root {
-  --surface: #f6f6f6;
-  --surface-hover: #f0f0f0;
-  --border: #eae7df;
-  --border-strong: #d5cfc2;
-  --muted: #f1efe8;
-  --muted-dim: #78716a;
-  --background: #ffffff;
-  --foreground: #22211e;
-  --card: #ffffff;
-  --card-foreground: #22211e;
-  --popover: #ffffff;
-  --popover-foreground: #22211e;
-  --primary: #22211e;
-  --primary-foreground: #faf9f5;
-  --secondary: #f1efe8;
-  --secondary-foreground: #22211e;
-  --muted-foreground: #57534a;
-  --accent: #f1efe8;
-  --accent-foreground: #22211e;
-  --destructive: oklch(0.577 0.245 27.325);
-  --input: oklch(0 0 0 / 8%);
-  --brand: #2200ff;
+  --surface: #f1ecdf;
+  --surface-hover: #eae4d2;
+  --border: #e2dac4;
+  --border-strong: #c9bd9f;
+  --muted: #ece6d6;
+  --muted-dim: #8b8468;
+  --background: #f8f5ec;
+  --foreground: #2e3324;
+  --card: #fdfbf4;
+  --card-foreground: #2e3324;
+  --popover: #fdfbf4;
+  --popover-foreground: #2e3324;
+  --primary: #3f5233;
+  --primary-foreground: #f8f5ec;
+  --secondary: #e6e9d8;
+  --secondary-foreground: #2e3324;
+  --muted-foreground: #5f6550;
+  --accent: #e6e9d8;
+  --accent-foreground: #2e3324;
+  --destructive: oklch(0.577 0.19 35);
+  --input: oklch(0.3 0.03 120 / 10%);
+  --brand: #4a7c46;
   --brand-foreground: #ffffff;
-  --ring: #44403a;
-  --selection: #e6e1d5;
-  --selection-foreground: #22211e;
+  --ring: #6b7a55;
+  --selection: #dfe5cc;
+  --selection-foreground: #2e3324;
   /* Soft two-layer card shadow: invisible as "shadow", read as depth. Dark
      mode zeroes it out and relies on surface contrast instead. */
   --shadow-card:
-    0 1px 2px rgb(34 33 30 / 0.04), 0 4px 12px -2px rgb(34 33 30 / 0.04);
-  --chart-1: oklch(0.269 0 0);
-  --chart-2: oklch(0.439 0 0);
-  --chart-3: oklch(0.556 0 0);
-  --chart-4: oklch(0.708 0 0);
-  --chart-5: oklch(0.87 0 0);
-  --radius: 0.625rem;
-  --sidebar: #ffffff;
-  --sidebar-foreground: #22211e;
-  --sidebar-primary: #22211e;
-  --sidebar-primary-foreground: #faf9f5;
-  --sidebar-accent: #f1efe8;
-  --sidebar-accent-foreground: #22211e;
-  --sidebar-border: #e7e3da;
-  --sidebar-ring: #78716a;
+    0 1px 2px rgb(46 51 36 / 0.05), 0 6px 16px -4px rgb(46 51 36 / 0.06);
+  --chart-1: oklch(0.45 0.08 135);
+  --chart-2: oklch(0.55 0.09 90);
+  --chart-3: oklch(0.62 0.1 55);
+  --chart-4: oklch(0.7 0.07 150);
+  --chart-5: oklch(0.82 0.05 110);
+  --radius: 1.1rem;
+  --sidebar: #fdfbf4;
+  --sidebar-foreground: #2e3324;
+  --sidebar-primary: #3f5233;
+  --sidebar-primary-foreground: #f8f5ec;
+  --sidebar-accent: #e6e9d8;
+  --sidebar-accent-foreground: #2e3324;
+  --sidebar-border: #e2dac4;
+  --sidebar-ring: #8b8468;
 }
 
 @theme inline {
@@ -68,9 +66,8 @@
   --color-muted-dim: var(--muted-dim);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
-  /* Headings share the body face — hierarchy comes from weight, size, and
-     tracking rather than a second display family. */
-  --font-heading: var(--font-geist-sans);
+  /* Headings use a calm rounded face; body stays on Geist for legibility. */
+  --font-heading: var(--font-nunito);
   --color-brand: var(--brand);
   --color-brand-foreground: var(--brand-foreground);
   --color-sidebar-ring: var(--sidebar-ring);
@@ -147,6 +144,25 @@ input:-webkit-autofill:focus {
   background-size: 28px 28px;
 }
 
+/* Organic blob: an asymmetric, hand-drawn-feeling silhouette that slowly
+   breathes between two shapes. Pair with a soft brand/secondary tint and
+   blur for ambient botanical backdrops. */
+@utility blob {
+  border-radius: 62% 38% 55% 45% / 48% 60% 40% 52%;
+  animation: blob-drift 18s ease-in-out infinite alternate;
+}
+
+@keyframes blob-drift {
+  from {
+    border-radius: 62% 38% 55% 45% / 48% 60% 40% 52%;
+    transform: translate3d(0, 0, 0) rotate(0deg) scale(1);
+  }
+  to {
+    border-radius: 42% 58% 38% 62% / 58% 42% 62% 38%;
+    transform: translate3d(2%, -3%, 0) rotate(6deg) scale(1.06);
+  }
+}
+
 /* Receipt edge: scalloped bottom, like a stub torn off a perforated roll. */
 @utility receipt-edge {
   mask-image: radial-gradient(circle at 8px 100%, transparent 5px, black 5.5px);
@@ -184,50 +200,50 @@ input:-webkit-autofill:focus {
   }
 }
 
-/* Dark mode — "Paper" after dark: the near-black picks up a faint cool cast
-   while the text stays warm off-white, and contrast drops from 18:1 to ~16:1
-   to stop white type haloing on OLED. */
+/* Dark mode — "Forest floor": deep green-cast near-blacks with warm parchment
+   type, like moonlight through a canopy. Contrast stays around ~14:1 so pale
+   type doesn't halo on OLED. */
 .dark {
-  --surface: #141416;
-  --surface-hover: #1a1a1d;
-  --border: #26262a;
-  --border-strong: #3a3a40;
-  --muted: #212125;
-  --muted-dim: #7a7772;
-  --background: #0c0c0e;
-  --foreground: #e8e6e1;
-  --card: #141416;
-  --card-foreground: #e8e6e1;
-  --popover: #1a1a1d;
-  --popover-foreground: #e8e6e1;
-  --primary: #e8e6e1;
-  --primary-foreground: #0c0c0e;
-  --secondary: #2b2b30;
-  --secondary-foreground: #e8e6e1;
-  --muted-foreground: #a8a5a0;
-  --accent: #2b2b30;
-  --accent-foreground: #e8e6e1;
-  --destructive: oklch(0.704 0.191 22.216);
+  --surface: #1d2317;
+  --surface-hover: #242b1c;
+  --border: #2b3321;
+  --border-strong: #434e32;
+  --muted: #232a1b;
+  --muted-dim: #8b8b72;
+  --background: #14180f;
+  --foreground: #e9e6d6;
+  --card: #1d2317;
+  --card-foreground: #e9e6d6;
+  --popover: #242b1c;
+  --popover-foreground: #e9e6d6;
+  --primary: #cbd6b2;
+  --primary-foreground: #14180f;
+  --secondary: #313a25;
+  --secondary-foreground: #e9e6d6;
+  --muted-foreground: #aaac94;
+  --accent: #313a25;
+  --accent-foreground: #e9e6d6;
+  --destructive: oklch(0.68 0.16 35);
   --input: oklch(1 0 0 / 15%);
-  --brand: #2200ff;
-  --brand-foreground: #ffffff;
-  --ring: #c4c1bb;
-  --selection: #33333a;
-  --selection-foreground: #e8e6e1;
+  --brand: #7fae6d;
+  --brand-foreground: #14200f;
+  --ring: #a5b088;
+  --selection: #38402b;
+  --selection-foreground: #e9e6d6;
   --shadow-card: 0 0 rgb(0 0 0 / 0);
-  --chart-1: oklch(0.87 0 0);
-  --chart-2: oklch(0.556 0 0);
-  --chart-3: oklch(0.439 0 0);
-  --chart-4: oklch(0.371 0 0);
-  --chart-5: oklch(0.269 0 0);
-  --sidebar: #141416;
-  --sidebar-foreground: #e8e6e1;
-  --sidebar-primary: #e8e6e1;
-  --sidebar-primary-foreground: #0c0c0e;
-  --sidebar-accent: #2b2b30;
-  --sidebar-accent-foreground: #e8e6e1;
-  --sidebar-border: #26262a;
-  --sidebar-ring: #7a7772;
+  --chart-1: oklch(0.85 0.06 130);
+  --chart-2: oklch(0.62 0.08 110);
+  --chart-3: oklch(0.5 0.07 90);
+  --chart-4: oklch(0.42 0.06 145);
+  --chart-5: oklch(0.32 0.04 120);
+  --sidebar: #1d2317;
+  --sidebar-foreground: #e9e6d6;
+  --sidebar-primary: #cbd6b2;
+  --sidebar-primary-foreground: #14180f;
+  --sidebar-accent: #313a25;
+  --sidebar-accent-foreground: #e9e6d6;
+  --sidebar-border: #2b3321;
+  --sidebar-ring: #8b8b72;
 }
 
 @layer base {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Geist, Geist_Mono, Nunito } from "next/font/google";
 import { ClerkProvider } from "@clerk/nextjs";
 import ConvexClientProvider from "@/components/ConvexClientProvider";
 import { ThemeProvider } from "@/components/ThemeProvider";
@@ -17,6 +17,11 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
+const nunito = Nunito({
+  variable: "--font-nunito",
+  subsets: ["latin"],
+});
+
 export const metadata: Metadata = {
   title: getAppName(),
   description: "Claim credits for hackathons, conferences, and meetups.",
@@ -26,9 +31,9 @@ export const metadata: Metadata = {
 // page background automatically.
 const clerkAppearance: React.ComponentProps<typeof ClerkProvider>["appearance"] = {
   variables: {
-    colorPrimary: "#2200ff",
+    colorPrimary: "#4a7c46",
     colorPrimaryForeground: "#ffffff",
-    borderRadius: "0.625rem",
+    borderRadius: "1.1rem",
     fontFamily: "var(--font-geist-sans), system-ui, sans-serif",
   },
   options: {
@@ -49,7 +54,7 @@ export default function RootLayout({
     <ClerkProvider appearance={clerkAppearance}>
       <html
         lang="en"
-        className={`${geistSans.variable} ${geistMono.variable} h-full overscroll-none antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} ${nunito.variable} h-full overscroll-none antialiased`}
         suppressHydrationWarning
       >
         <body className="flex min-h-full flex-col overscroll-none">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,13 +1,11 @@
 "use client";
 
-import { useSyncExternalStore } from "react";
 import Link from "next/link";
 import { BadgeCheck, Ticket } from "lucide-react";
-import { useTheme } from "next-themes";
 import { useConvexAuth, useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { daysUntilEvent, formatEventDate } from "@/lib/event-date";
-import UnicornSceneEmbed from "@/components/UnicornSceneEmbed";
+import OrganicBackdrop from "@/components/OrganicBackdrop";
 import SiteHeader from "@/components/SiteHeader";
 import SiteFooter from "@/components/SiteFooter";
 import { Badge } from "@/components/ui/badge";
@@ -20,30 +18,6 @@ import {
   EmptyDescription,
 } from "@/components/ui/empty";
 import { cn } from "@/lib/utils";
-
-// The hero background is a theme-paired Unicorn Studio WebGL scene
-// (experiment). A Unicorn project publishes exactly one authored design and
-// the SDK has no color-scheme awareness, so a light-authored project shows
-// its light design in dark mode too — each theme therefore needs its own
-// project ID here.
-const UNICORN_PROJECTS = {
-  light: "wEz2vCJgsynwCYSb3HgR",
-  dark: "aEdLurlqLEmU1DUjAaUz",
-} as const;
-
-// Bump this whenever a scene is republished in Unicorn Studio. Deployed
-// builds read scene data through Unicorn's CDN, which caches for months and
-// doesn't reliably purge on republish; the update param below is part of the
-// CDN cache key, so bumping the version makes deploys fetch the new design.
-// Dev skips the param (and the CDN): without it the SDK cache-busts every
-// load, so republishes show up on a plain refresh.
-const UNICORN_CACHE_VERSION = 2;
-
-const isProdBuild = process.env.NODE_ENV === "production";
-
-// Stable no-op subscription for the hydration gate below: the snapshot never
-// changes on the client, we only care that the server snapshot is false.
-const emptySubscribe = () => () => {};
 
 interface EventItem {
   _id: string;
@@ -72,7 +46,7 @@ function EventRow({
       <Link
         href={`/${event.slug}`}
         className={cn(
-          "group flex items-center gap-6 px-2 py-7 transition-colors hover:bg-surface focus-visible:bg-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/60 sm:gap-10 sm:px-4",
+          "group flex items-center gap-6 rounded-3xl px-2 py-7 transition-colors hover:bg-surface focus-visible:bg-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/60 sm:gap-10 sm:px-4",
           past && "opacity-60 transition-opacity hover:opacity-100",
         )}
       >
@@ -110,23 +84,6 @@ export default function Home() {
     mine?.map((item) => item.event?._id).filter(Boolean) ?? [],
   );
 
-  // The scene choice needs JS (the server doesn't know the theme, while the
-  // hydration render already does), so gate it behind hydration to keep both
-  // trees identical; the copy and scrim flip with pure dark: variants and
-  // render correctly from the first paint. Until hydration the plain
-  // theme-tinted shell stands in for both themes.
-  const { resolvedTheme } = useTheme();
-  const hydrated = useSyncExternalStore(
-    emptySubscribe,
-    () => true,
-    () => false,
-  );
-  const heroProjectId = hydrated
-    ? resolvedTheme === "light"
-      ? UNICORN_PROJECTS.light
-      : UNICORN_PROJECTS.dark
-    : undefined;
-
   // Dated events that have passed sink into their own dimmed group; undated
   // events are treated as current. Active events order soonest-first, with
   // undated ones following in their arrival (newest created) order; past
@@ -150,14 +107,14 @@ export default function Home() {
   // copy centered in the visible area.
   const heroCopy = (
     <div className="relative mx-auto flex h-full w-full max-w-5xl flex-col justify-center px-4 pt-15.25 sm:px-6">
-      <p className="eyebrow animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 text-black/60 dark:text-white/60 motion-reduce:animate-none">
+      <p className="eyebrow animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 text-brand motion-reduce:animate-none">
         {process.env.NEXT_PUBLIC_IS_DEVIN ? "Devin " : ""}Event credit
         distribution
       </p>
-      <h1 className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-100 mt-6 max-w-2xl font-heading text-5xl leading-[0.95] font-semibold tracking-[-0.03em] text-balance text-black dark:text-white motion-reduce:animate-none sm:text-7xl">
+      <h1 className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-100 mt-6 max-w-2xl font-heading text-5xl leading-[1] font-bold tracking-tight text-balance text-foreground motion-reduce:animate-none sm:text-7xl">
         Claim your credits.
       </h1>
-      <p className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-200 mt-6 max-w-md text-sm leading-relaxed text-black/70 dark:text-white/70 motion-reduce:animate-none">
+      <p className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-200 mt-6 max-w-md text-sm leading-relaxed text-muted-foreground motion-reduce:animate-none">
         Sign in, then select your event to claim your credits.
       </p>
     </div>
@@ -170,34 +127,10 @@ export default function Home() {
         <section className="-mt-15.25 border-b border-border/65">
           {/* The section pulls up behind the translucent header bar
               (-mt-15.25) so the background runs to the top of the page; the
-              hero is 61px taller to compensate and the scene shows through
-              the bar's frosted fill. The theme's Unicorn Studio scene renders
-              behind the copy and a soft theme-matched scrim; keying the scene
-              by project swaps it cleanly on theme change while the copy stays
-              mounted. The scene's mouse interactivity listens on window, so
-              the copy sitting above it doesn't block it. */}
-          <div className="relative h-[520px] overflow-hidden bg-background dark:bg-[#131313] sm:h-[486px]">
-            {heroProjectId ? (
-              <div className="absolute inset-0" aria-hidden>
-                {/* Dev fetches fresh scene data on every load; deploys pin
-                    the CDN to UNICORN_CACHE_VERSION — see the constant. */}
-                <UnicornSceneEmbed
-                  key={heroProjectId}
-                  projectId={
-                    isProdBuild
-                      ? `${heroProjectId}?update=${UNICORN_CACHE_VERSION}`
-                      : heroProjectId
-                  }
-                  production={isProdBuild}
-                />
-              </div>
-            ) : null}
-            {/* Soft scrim keeps the headline legible over the scenes; tune
-                or remove once the look settles. */}
-            <div
-              className="absolute inset-0 bg-white/20 dark:bg-black/20"
-              aria-hidden
-            />
+              hero is 61px taller to compensate and the backdrop shows through
+              the bar's frosted fill. */}
+          <div className="relative h-[520px] overflow-hidden bg-background sm:h-[486px]">
+            <OrganicBackdrop />
             {heroCopy}
           </div>
         </section>

--- a/components/ClaimPage.tsx
+++ b/components/ClaimPage.tsx
@@ -26,6 +26,7 @@ import {
   formatEventDate,
 } from "@/lib/event-date";
 import { copyText } from "@/lib/clipboard";
+import OrganicBackdrop from "@/components/OrganicBackdrop";
 import SiteHeader from "@/components/SiteHeader";
 import SiteFooter from "@/components/SiteFooter";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -189,10 +190,7 @@ export default function ClaimPage({
         id="main-content"
         className="relative flex flex-1 items-center justify-center px-4 py-10 sm:px-6 sm:py-16"
       >
-        <div
-          aria-hidden
-          className="pointer-events-none absolute inset-0 bg-dotgrid [mask-image:radial-gradient(ellipse_60%_60%_at_50%_45%,black,transparent)]"
-        />
+        <OrganicBackdrop />
         <div className="relative w-full max-w-md">
           {previewMode ? (
             <Alert className="mb-4">

--- a/components/OrganicBackdrop.tsx
+++ b/components/OrganicBackdrop.tsx
@@ -1,0 +1,47 @@
+import { cn } from "@/lib/utils";
+
+/* Ambient botanical backdrop: a few soft, slowly-breathing blobs in theme
+   tints plus a faint hand-drawn branch in one corner. Purely decorative —
+   always render behind content with pointer-events disabled. */
+export default function OrganicBackdrop({
+  className,
+}: {
+  className?: string;
+}) {
+  return (
+    <div
+      aria-hidden
+      className={cn(
+        "pointer-events-none absolute inset-0 overflow-hidden",
+        className,
+      )}
+    >
+      <div className="blob absolute -top-24 -left-20 h-80 w-96 bg-brand/15 blur-2xl motion-reduce:animate-none" />
+      <div className="blob absolute top-1/3 -right-28 h-96 w-[28rem] bg-secondary/80 blur-2xl [animation-delay:-6s] motion-reduce:animate-none" />
+      <div className="blob absolute -bottom-32 left-1/4 h-72 w-80 bg-brand/10 blur-3xl [animation-delay:-12s] motion-reduce:animate-none" />
+      <BranchSketch className="absolute right-6 bottom-4 h-40 w-40 text-brand/25 sm:right-12 sm:h-56 sm:w-56" />
+    </div>
+  );
+}
+
+/* A loose, hand-drawn branch with leaves — irregular strokes on purpose. */
+function BranchSketch({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 120 120"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden
+    >
+      <path d="M18 112 C 34 88, 52 66, 78 42 C 88 33, 98 24, 106 14" />
+      <path d="M50 70 C 42 62, 40 52, 44 44 C 54 46, 60 54, 58 63 C 55 67, 52 69, 50 70 Z" />
+      <path d="M72 48 C 78 36, 88 32, 97 34 C 96 44, 88 52, 78 52 C 75 51, 73 50, 72 48 Z" />
+      <path d="M34 90 C 24 86, 18 78, 19 68 C 29 68, 37 75, 38 84 C 37 87, 35 89, 34 90 Z" />
+      <path d="M88 30 C 87 22, 90 14, 97 10 C 102 16, 101 25, 95 30 C 92 31, 90 31, 88 30 Z" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
Explores an organic/nature design direction across the user-facing pages, functionality unchanged.

- `globals.css`: light theme becomes "Meadow" (warm cream `#f8f5ec`, moss ink, dried-grass borders, leaf-green brand `#4a7c46`), dark theme becomes "Forest floor" (green-cast blacks, parchment type, `--brand: #7fae6d`). Radius bumped to `1.1rem` for soft rounded surfaces, and a new `blob` utility animates a hand-drawn-feeling silhouette (`blob-drift` keyframes morph border-radius/rotation).
- New `OrganicBackdrop` component: three blurred, slowly-breathing brand/secondary blobs plus a hand-drawn `BranchSketch` SVG accent; used behind the home hero (replacing the Unicorn Studio WebGL scene and its theme/hydration gating) and the claim page (replacing the dot grid).
- `font-heading` now maps to Nunito (added in `layout.tsx`); Clerk `colorPrimary`/`borderRadius` follow the new palette.

Colorway variants will follow as separate PRs targeting this branch.

Link to Devin session: https://app.devin.ai/sessions/56ff213ee2a04e7183cb2255f6426921
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/118" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->