### PR TITLE
Design direction: Neo-Brutalist

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,49 +4,45 @@
 
 @custom-variant dark (&:is(.dark *));
 
-/* Light mode (default) — "Paper": a white page field with warm off-neutrals
-   in the tints and borders rather than the pure grey axis, and ink (#22211E)
-   instead of near-black so text stays short of a harsh 19:1. Surface is a
-   neutral grey one step off white — hovers and the receipt stub read as a
-   quiet press of the field rather than a cream block. The blue accent is
-   reserved for the claim flow only. */
+/* Light mode (default) — Neo-Brutalist: a stark white field, pure ink-black
+   borders and type, zero radius, and hard offset shadows. Contrast is the
+   whole palette; the brand blue stays as the single loud accent. */
 :root {
-  --surface: #f6f6f6;
-  --surface-hover: #f0f0f0;
-  --border: #eae7df;
-  --border-strong: #d5cfc2;
-  --muted: #f1efe8;
-  --muted-dim: #78716a;
+  --surface: #f4f4f0;
+  --surface-hover: #ecece6;
+  --border: #000000;
+  --border-strong: #000000;
+  --muted: #efefe9;
+  --muted-dim: #55524c;
   --background: #ffffff;
-  --foreground: #22211e;
+  --foreground: #000000;
   --card: #ffffff;
-  --card-foreground: #22211e;
+  --card-foreground: #000000;
   --popover: #ffffff;
-  --popover-foreground: #22211e;
-  --primary: #22211e;
-  --primary-foreground: #faf9f5;
-  --secondary: #f1efe8;
-  --secondary-foreground: #22211e;
-  --muted-foreground: #57534a;
-  --accent: #f1efe8;
-  --accent-foreground: #22211e;
+  --popover-foreground: #000000;
+  --primary: #000000;
+  --primary-foreground: #ffffff;
+  --secondary: #efefe9;
+  --secondary-foreground: #000000;
+  --muted-foreground: #44413c;
+  --accent: #efefe9;
+  --accent-foreground: #000000;
   --destructive: oklch(0.577 0.245 27.325);
   --input: oklch(0 0 0 / 8%);
   --brand: #2200ff;
   --brand-foreground: #ffffff;
-  --ring: #44403a;
-  --selection: #e6e1d5;
-  --selection-foreground: #22211e;
-  /* Soft two-layer card shadow: invisible as "shadow", read as depth. Dark
-     mode zeroes it out and relies on surface contrast instead. */
-  --shadow-card:
-    0 1px 2px rgb(34 33 30 / 0.04), 0 4px 12px -2px rgb(34 33 30 / 0.04);
+  --ring: #000000;
+  --selection: #000000;
+  --selection-foreground: #ffffff;
+  /* Hard offset shadow: an opaque block, not a blur — the signature
+     neo-brutalist "lifted slab" read. */
+  --shadow-card: 8px 8px 0 0 var(--border-strong);
   --chart-1: oklch(0.269 0 0);
   --chart-2: oklch(0.439 0 0);
   --chart-3: oklch(0.556 0 0);
   --chart-4: oklch(0.708 0 0);
   --chart-5: oklch(0.87 0 0);
-  --radius: 0.625rem;
+  --radius: 0rem;
   --sidebar: #ffffff;
   --sidebar-foreground: #22211e;
   --sidebar-primary: #22211e;
@@ -132,18 +128,35 @@ input:-webkit-autofill:focus {
   transition: background-color 9999999s ease-in-out 0s;
 }
 
-/* Micro-label: the recurring uppercase mono eyebrow used across the app. */
+/* Micro-label: the recurring uppercase mono eyebrow used across the app.
+   Heavier here — labels read as stamped block lettering. */
 @utility eyebrow {
   font-family: var(--font-mono), monospace;
   font-size: 10px;
-  font-weight: 500;
+  font-weight: 700;
   letter-spacing: 0.18em;
   text-transform: uppercase;
 }
 
+/* Hard offset shadow blocks in three weights. */
+@utility shadow-brutal {
+  box-shadow: 8px 8px 0 0 var(--border-strong);
+}
+
+@utility shadow-brutal-sm {
+  box-shadow: 4px 4px 0 0 var(--border-strong);
+}
+
+@utility shadow-brutal-xs {
+  box-shadow: 2px 2px 0 0 var(--border-strong);
+}
+
 /* Faint dot grid backdrop for hero surfaces. */
 @utility bg-dotgrid {
-  background-image: radial-gradient(var(--border) 1px, transparent 1px);
+  background-image: radial-gradient(
+    color-mix(in srgb, var(--border) 25%, transparent) 1px,
+    transparent 1px
+  );
   background-size: 28px 28px;
 }
 
@@ -184,37 +197,36 @@ input:-webkit-autofill:focus {
   }
 }
 
-/* Dark mode — "Paper" after dark: the near-black picks up a faint cool cast
-   while the text stays warm off-white, and contrast drops from 18:1 to ~16:1
-   to stop white type haloing on OLED. */
+/* Dark mode — Neo-Brutalist inverted: pure black field, pure white ink
+   borders, same hard offset shadows drawn in white. */
 .dark {
-  --surface: #141416;
-  --surface-hover: #1a1a1d;
-  --border: #26262a;
-  --border-strong: #3a3a40;
-  --muted: #212125;
-  --muted-dim: #7a7772;
-  --background: #0c0c0e;
-  --foreground: #e8e6e1;
-  --card: #141416;
-  --card-foreground: #e8e6e1;
-  --popover: #1a1a1d;
-  --popover-foreground: #e8e6e1;
-  --primary: #e8e6e1;
-  --primary-foreground: #0c0c0e;
-  --secondary: #2b2b30;
-  --secondary-foreground: #e8e6e1;
-  --muted-foreground: #a8a5a0;
-  --accent: #2b2b30;
-  --accent-foreground: #e8e6e1;
+  --surface: #121212;
+  --surface-hover: #1b1b1b;
+  --border: #ffffff;
+  --border-strong: #ffffff;
+  --muted: #1b1b1b;
+  --muted-dim: #b3b3b3;
+  --background: #000000;
+  --foreground: #ffffff;
+  --card: #000000;
+  --card-foreground: #ffffff;
+  --popover: #000000;
+  --popover-foreground: #ffffff;
+  --primary: #ffffff;
+  --primary-foreground: #000000;
+  --secondary: #1b1b1b;
+  --secondary-foreground: #ffffff;
+  --muted-foreground: #cfcfcf;
+  --accent: #1b1b1b;
+  --accent-foreground: #ffffff;
   --destructive: oklch(0.704 0.191 22.216);
   --input: oklch(1 0 0 / 15%);
   --brand: #2200ff;
   --brand-foreground: #ffffff;
-  --ring: #c4c1bb;
-  --selection: #33333a;
-  --selection-foreground: #e8e6e1;
-  --shadow-card: 0 0 rgb(0 0 0 / 0);
+  --ring: #ffffff;
+  --selection: #ffffff;
+  --selection-foreground: #000000;
+  --shadow-card: 8px 8px 0 0 var(--border-strong);
   --chart-1: oklch(0.87 0 0);
   --chart-2: oklch(0.556 0 0);
   --chart-3: oklch(0.439 0 0);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -66,7 +66,7 @@ function EventRow({
 }) {
   return (
     <li
-      className="animate-in fade-in slide-in-from-bottom-1 fill-mode-both duration-300 border-b border-border motion-reduce:animate-none"
+      className="animate-in fade-in slide-in-from-bottom-1 fill-mode-both duration-300 border-b-2 border-border motion-reduce:animate-none"
       style={{ animationDelay: `${Math.min(index, 10) * 40}ms` }}
     >
       <Link
@@ -77,7 +77,7 @@ function EventRow({
         )}
       >
         <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 font-heading text-xl font-medium tracking-tight sm:text-2xl">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 font-heading text-xl font-bold tracking-tight uppercase sm:text-2xl">
             {event.name}
             {claimed ? (
               <Badge variant="secondary" className="gap-1">
@@ -150,14 +150,14 @@ export default function Home() {
   // copy centered in the visible area.
   const heroCopy = (
     <div className="relative mx-auto flex h-full w-full max-w-5xl flex-col justify-center px-4 pt-15.25 sm:px-6">
-      <p className="eyebrow animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 text-black/60 dark:text-white/60 motion-reduce:animate-none">
+      <p className="eyebrow animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 w-fit border-2 border-black bg-white px-2.5 py-1.5 text-black shadow-[3px_3px_0_0_#000] dark:border-white dark:bg-black dark:text-white dark:shadow-[3px_3px_0_0_#fff] motion-reduce:animate-none">
         {process.env.NEXT_PUBLIC_IS_DEVIN ? "Devin " : ""}Event credit
         distribution
       </p>
-      <h1 className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-100 mt-6 max-w-2xl font-heading text-5xl leading-[0.95] font-semibold tracking-[-0.03em] text-balance text-black dark:text-white motion-reduce:animate-none sm:text-7xl">
+      <h1 className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-100 mt-6 max-w-2xl font-heading text-5xl leading-[0.92] font-black tracking-[-0.02em] uppercase text-balance text-black dark:text-white motion-reduce:animate-none sm:text-7xl">
         Claim your credits.
       </h1>
-      <p className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-200 mt-6 max-w-md text-sm leading-relaxed text-black/70 dark:text-white/70 motion-reduce:animate-none">
+      <p className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-200 mt-6 max-w-md text-sm font-medium leading-relaxed text-black/80 dark:text-white/80 motion-reduce:animate-none">
         Sign in, then select your event to claim your credits.
       </p>
     </div>
@@ -167,7 +167,7 @@ export default function Home() {
     <div className="flex min-h-screen flex-col">
       <SiteHeader />
       <main id="main-content" className="flex-1">
-        <section className="-mt-15.25 border-b border-border/65">
+        <section className="-mt-15.25 border-b-4 border-border">
           {/* The section pulls up behind the translucent header bar
               (-mt-15.25) so the background runs to the top of the page; the
               hero is 61px taller to compensate and the scene shows through
@@ -203,20 +203,20 @@ export default function Home() {
         </section>
 
         <section className="mx-auto w-full max-w-5xl px-4 py-14 sm:px-6 sm:py-20">
-          <h2 className="text-sm font-medium text-muted-foreground">
+          <h2 className="text-sm font-bold tracking-wide uppercase">
             Active events
           </h2>
 
           {events === undefined ? (
             <div
-              className="mt-4 border-t border-border"
+              className="mt-4 border-t-2 border-border"
               role="status"
               aria-label="Loading active events"
             >
               {[0, 1, 2].map((i) => (
                 <div
                   key={i}
-                  className="flex items-center gap-6 border-b border-border px-2 py-7 sm:gap-10 sm:px-4"
+                  className="flex items-center gap-6 border-b-2 border-border px-2 py-7 sm:gap-10 sm:px-4"
                 >
                   <div className="flex min-w-0 flex-1 flex-col gap-2">
                     <Skeleton className="h-5 w-2/3 rounded-sm" />
@@ -226,7 +226,7 @@ export default function Home() {
               ))}
             </div>
           ) : events.length === 0 ? (
-            <Empty className="mt-6 border border-dashed border-border-strong py-16">
+            <Empty className="mt-6 border-2 border-dashed border-border-strong py-16">
               <EmptyHeader>
                 <EmptyMedia variant="icon">
                   <Ticket />
@@ -244,7 +244,7 @@ export default function Home() {
                   No active events right now.
                 </p>
               ) : (
-                <ul className="mt-4 border-t border-border">
+                <ul className="mt-4 border-t-2 border-border">
                   {current.map((event, index) => (
                     <EventRow
                       key={event._id}
@@ -258,14 +258,14 @@ export default function Home() {
               {past.length > 0 ? (
                 <>
                   <div className="mt-14 flex items-baseline justify-between">
-                    <h2 className="text-sm font-medium text-muted-foreground">
+                    <h2 className="text-sm font-bold tracking-wide uppercase">
                       Past events
                     </h2>
                     <span className="font-mono text-xs text-muted-dim tabular-nums">
                       {String(past.length).padStart(2, "0")}
                     </span>
                   </div>
-                  <ul className="mt-4 border-t border-border">
+                  <ul className="mt-4 border-t-2 border-border">
                     {past.map((event, index) => (
                       <EventRow
                         key={event._id}

--- a/components/ClaimPage.tsx
+++ b/components/ClaimPage.tsx
@@ -253,7 +253,7 @@ export default function ClaimPage({
             >
               <CardHeader className="gap-4 pt-(--card-spacing)">
                 <div className="flex items-start justify-between gap-3">
-                  <CardTitle className="font-heading text-3xl font-semibold tracking-[-0.02em] text-balance">
+                  <CardTitle className="font-heading text-3xl font-black tracking-[-0.02em] uppercase text-balance">
                     {event.name}
                   </CardTitle>
                   <Button
@@ -585,7 +585,7 @@ function QrPanel({
         <div className="flex items-start justify-between gap-3">
           <div className="flex flex-col gap-2">
             <span className="eyebrow text-muted-foreground">Scan to claim</span>
-            <CardTitle className="font-heading text-2xl font-semibold tracking-[-0.02em] text-balance">
+            <CardTitle className="font-heading text-2xl font-black tracking-[-0.02em] uppercase text-balance">
               {eventName}
             </CardTitle>
           </div>
@@ -602,7 +602,7 @@ function QrPanel({
         </div>
       </CardHeader>
       <CardContent className="flex flex-1 flex-col items-center justify-center gap-5 py-(--card-spacing)">
-        <div className="rounded-lg border border-border bg-background p-4 text-foreground">
+        <div className="rounded-lg border-2 border-border bg-background p-4 text-foreground">
           {url ? (
             <QRCodeSVG
               value={url}
@@ -645,7 +645,7 @@ function Receipt({
 }) {
   return (
     <div
-      className="receipt-edge receipt-print rounded-t-xl border border-border bg-surface pb-10 motion-reduce:animate-none"
+      className="receipt-edge receipt-print rounded-t-xl border-2 border-border bg-surface pb-10 motion-reduce:animate-none"
       role="status"
     >
       <div className="flex flex-col gap-6 p-6 sm:p-8">
@@ -660,7 +660,7 @@ function Receipt({
         </div>
 
         <div>
-          <h1 className="font-heading text-2xl font-semibold tracking-tight text-balance">
+          <h1 className="font-heading text-2xl font-black tracking-tight uppercase text-balance">
             {eventName}
           </h1>
           {creditAmount ? (

--- a/components/HeaderBar.tsx
+++ b/components/HeaderBar.tsx
@@ -1,14 +1,14 @@
-// Site-wide sticky nav bar: a frosted, borderless strip that's present from
-// first paint. Page content (like the home hero scene) runs underneath and
-// shows through the half-strength fill and blur — no scroll state, so it
-// renders on the server with zero client JS.
+// Site-wide sticky nav bar: a frosted strip ruled off with a thick bottom
+// border. Page content (like the home hero scene) runs underneath and shows
+// through the half-strength fill and blur — no scroll state, so it renders
+// on the server with zero client JS.
 export default function HeaderBar({
   children,
 }: {
   children: React.ReactNode;
 }) {
   return (
-    <header className="sticky top-0 z-40 bg-background/30 backdrop-blur-md">
+    <header className="sticky top-0 z-40 border-b-2 border-border bg-background/30 backdrop-blur-md">
       {children}
     </header>
   );

--- a/components/SiteFooter.tsx
+++ b/components/SiteFooter.tsx
@@ -13,7 +13,7 @@ function GitHubMark({ className }: { className?: string }) {
 
 export default function SiteFooter() {
   return (
-    <footer className="border-t border-border">
+    <footer className="border-t-2 border-border">
       <div className="mx-auto flex min-h-14 max-w-5xl items-center justify-between gap-4 px-4 py-3 sm:px-6">
         <a
           href="https://github.com/dabit3/vending-machine"

--- a/components/ui/alert.tsx
+++ b/components/ui/alert.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const alertVariants = cva(
-  "group/alert relative grid w-full gap-0.5 rounded-lg border px-2.5 py-2 text-left text-sm has-data-[slot=alert-action]:relative has-data-[slot=alert-action]:pr-18 has-[>svg]:grid-cols-[auto_1fr] has-[>svg]:gap-x-2 *:[svg]:row-span-2 *:[svg]:translate-y-0.5 *:[svg]:text-current *:[svg:not([class*='size-'])]:size-4",
+  "group/alert relative grid w-full gap-0.5 rounded-lg border-2 border-border-strong shadow-brutal-sm px-2.5 py-2 text-left text-sm has-data-[slot=alert-action]:relative has-data-[slot=alert-action]:pr-18 has-[>svg]:grid-cols-[auto_1fr] has-[>svg]:gap-x-2 *:[svg]:row-span-2 *:[svg]:translate-y-0.5 *:[svg]:text-current *:[svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -5,13 +5,13 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const badgeVariants = cva(
-  "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/20 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
+  "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-bold uppercase tracking-wide whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/20 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
   {
     variants: {
       variant: {
         default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
         secondary:
-          "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
+          "border-border-strong bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
         destructive:
           "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
         outline:

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -4,17 +4,18 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/20 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border-2 border-transparent bg-clip-padding text-sm font-bold uppercase tracking-wide whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/20 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/80",
+        default:
+          "border-border-strong bg-primary text-primary-foreground shadow-brutal-sm hover:translate-x-0.5 hover:translate-y-0.5 hover:shadow-brutal-xs active:translate-x-1 active:translate-y-1 active:shadow-none",
         brand:
-          "bg-brand text-brand-foreground hover:bg-brand/85 hover:shadow-[0_2px_16px_-4px_var(--brand)]",
+          "border-border-strong bg-brand text-brand-foreground shadow-brutal-sm hover:translate-x-0.5 hover:translate-y-0.5 hover:shadow-brutal-xs active:translate-x-1 active:translate-y-1 active:shadow-none",
         outline:
-          "border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
+          "border-border-strong bg-background shadow-brutal-sm hover:translate-x-0.5 hover:translate-y-0.5 hover:bg-muted hover:text-foreground hover:shadow-brutal-xs active:translate-x-1 active:translate-y-1 active:shadow-none aria-expanded:bg-muted aria-expanded:text-foreground",
         secondary:
-          "bg-secondary text-secondary-foreground hover:bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_5%)] aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
+          "border-border-strong bg-secondary text-secondary-foreground shadow-brutal-sm hover:translate-x-0.5 hover:translate-y-0.5 hover:bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_5%)] hover:shadow-brutal-xs active:translate-x-1 active:translate-y-1 active:shadow-none aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
         ghost:
           "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
         destructive:

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -12,7 +12,7 @@ function Card({
       data-slot="card"
       data-size={size}
       className={cn(
-        "group/card flex flex-col gap-(--card-spacing) overflow-hidden rounded-xl bg-card py-(--card-spacing) text-sm text-card-foreground shadow-(--shadow-card) ring-1 ring-foreground/10 [--card-spacing:--spacing(4)] has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:[--card-spacing:--spacing(3)] data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
+        "group/card flex flex-col gap-(--card-spacing) overflow-hidden rounded-xl bg-card py-(--card-spacing) text-sm text-card-foreground shadow-(--shadow-card) border-2 border-border-strong [--card-spacing:--spacing(4)] has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:[--card-spacing:--spacing(3)] data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
Explores a NEO-BRUTALIST design direction across the user-facing pages (home + claim): thick black borders, hard offset shadows, chunky uppercase typography, zero radius, stark contrast. All functionality unchanged — restyling only.

Key mechanics (so colorway variants only need token tweaks):
- `globals.css` tokens drive the look: `--border`/`--border-strong` → pure ink (`#000` light / `#fff` dark), `--radius: 0` (zeroes every derived radius), `--shadow-card: 8px 8px 0 0 var(--border-strong)` (opaque slab, no blur). Dark mode is a straight inversion.
- New utilities `shadow-brutal` / `shadow-brutal-sm` / `shadow-brutal-xs` — hard offset blocks keyed to `--border-strong`.
- ui primitives: `Card` swaps its hairline ring for `border-2 border-border-strong`; `Button` solid variants gain 2px borders + hard shadow that collapses on hover/active (press-into-page interaction); `Badge`/`Button` go bold uppercase; `Alert` gets `border-2` + `shadow-brutal-sm`.
- Home hero: boxed stamped eyebrow chip, `font-black uppercase` headline; event lists ruled with 2px black dividers; header/footer get thick rules.
- Receipt/QR panels: 2px ink borders, black chunky titles (scallop mask on the receipt keeps its shadow off).

Brand blue `#2200ff` remains the single loud accent — the intended knob for colorway variants.

Link to Devin session: https://app.devin.ai/sessions/79cbed392f0943baa2d52b47fc965152
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/119" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->