### PR TITLE
Glassmorphism colorway: Aurora

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -59,11 +59,11 @@
      Colorways retint the app by swapping only the aurora + glass variables. */
   --glass-border: rgb(255 255 255 / 0.65);
   --glass-glow:
-    0 8px 32px rgb(31 38 68 / 0.12),
+    0 8px 32px rgb(22 64 58 / 0.14),
     inset 0 1px 0 rgb(255 255 255 / 0.85);
-  --aurora-1: #c7d2fe;
-  --aurora-2: #fbcfe8;
-  --aurora-3: #bae6fd;
+  --aurora-1: #a7f3d0;
+  --aurora-2: #99e6e0;
+  --aurora-3: #d5ccfa;
 }
 
 @theme inline {
@@ -256,13 +256,13 @@ input:-webkit-autofill:focus {
   --sidebar-accent-foreground: #e8e6e1;
   --sidebar-border: #26262a;
   --sidebar-ring: #7a7772;
-  --glass-border: rgb(255 255 255 / 0.12);
+  --glass-border: rgb(148 245 210 / 0.16);
   --glass-glow:
-    0 8px 32px rgb(0 0 0 / 0.45),
-    inset 0 1px 0 rgb(255 255 255 / 0.08);
-  --aurora-1: #2b2e5e;
-  --aurora-2: #4a2350;
-  --aurora-3: #123a4a;
+    0 8px 32px rgb(2 26 22 / 0.5),
+    inset 0 1px 0 rgb(167 243 208 / 0.1);
+  --aurora-1: #0b3d33;
+  --aurora-2: #103c4a;
+  --aurora-3: #2b2a5e;
 }
 
 @layer base {


### PR DESCRIPTION
## Summary
Retints the glassmorphism variables in `app/globals.css` for a northern-lights Aurora colorway — no component changes.

- Light `:root`: aurora tints become soft mint `#a7f3d0` / teal `#99e6e0` / lavender `#d5ccfa`; `--glass-glow` ambient shadow shifts to a cool teal-green cast.
- Dark `.dark`: aurora tints become deep emerald `#0b3d33` / teal `#103c4a` / indigo `#2b2a5e`; `--glass-border` and inset highlight take a faint mint tint, glow deepens to a green-black.

Text/foreground variables untouched, so contrast is unchanged in both modes.

Link to Devin session: https://app.devin.ai/sessions/6669f2b54e5a4fdaa4766135960bd396
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/120" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->