### PR TITLE
Glassmorphism colorway: Sunset Ember

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -19,7 +19,7 @@
   --muted-dim: #78716a;
   --background: #ffffff;
   --foreground: #22211e;
-  --card: rgb(255 255 255 / 0.55);
+  --card: rgb(255 251 246 / 0.55);
   --card-foreground: #22211e;
   --popover: #ffffff;
   --popover-foreground: #22211e;
@@ -57,13 +57,13 @@
   --sidebar-ring: #78716a;
   /* Glass layer: frosted panels float over a soft ambient aurora field.
      Colorways retint the app by swapping only the aurora + glass variables. */
-  --glass-border: rgb(255 255 255 / 0.65);
+  --glass-border: rgb(255 250 245 / 0.68);
   --glass-glow:
-    0 8px 32px rgb(31 38 68 / 0.12),
-    inset 0 1px 0 rgb(255 255 255 / 0.85);
-  --aurora-1: #c7d2fe;
-  --aurora-2: #fbcfe8;
-  --aurora-3: #bae6fd;
+    0 8px 32px rgb(92 38 24 / 0.12),
+    inset 0 1px 0 rgb(255 250 244 / 0.85);
+  --aurora-1: #fed7aa;
+  --aurora-2: #fecaca;
+  --aurora-3: #fde4cf;
 }
 
 @theme inline {
@@ -224,7 +224,7 @@ input:-webkit-autofill:focus {
   --muted-dim: #7a7772;
   --background: #0c0c0e;
   --foreground: #e8e6e1;
-  --card: rgb(30 30 36 / 0.5);
+  --card: rgb(38 28 26 / 0.5);
   --card-foreground: #e8e6e1;
   --popover: #1a1a1d;
   --popover-foreground: #e8e6e1;
@@ -256,13 +256,13 @@ input:-webkit-autofill:focus {
   --sidebar-accent-foreground: #e8e6e1;
   --sidebar-border: #26262a;
   --sidebar-ring: #7a7772;
-  --glass-border: rgb(255 255 255 / 0.12);
+  --glass-border: rgb(255 214 186 / 0.14);
   --glass-glow:
-    0 8px 32px rgb(0 0 0 / 0.45),
-    inset 0 1px 0 rgb(255 255 255 / 0.08);
-  --aurora-1: #2b2e5e;
-  --aurora-2: #4a2350;
-  --aurora-3: #123a4a;
+    0 8px 32px rgb(24 8 4 / 0.45),
+    inset 0 1px 0 rgb(255 220 190 / 0.1);
+  --aurora-1: #5c2a12;
+  --aurora-2: #55203e;
+  --aurora-3: #3c1f4a;
 }
 
 @layer base {


### PR DESCRIPTION
## Summary
Retints the variable-driven glassmorphism system in `app/globals.css` to a Sunset Ember colorway — no component changes.

- Light (`:root`): aurora tints go apricot/coral/peach (`#fed7aa` / `#fecaca` / `#fde4cf`), glass border/highlight warm to near-white peach, glow shadow tinted burnt sienna (`rgb(92 38 24 / 0.12)`), `--card` warmed to `rgb(255 251 246 / 0.55)`.
- Dark (`.dark`): aurora goes smoldering burnt-orange/magenta/plum (`#5c2a12` / `#55203e` / `#3c1f4a`), glass border/highlight tinted ember (`rgb(255 214 186 / 0.14)`), glow deepened to warm black, `--card` warmed to `rgb(38 28 26 / 0.5)`.

Foreground/text tokens are untouched, so contrast in both modes is unchanged. `npm run lint` and `npx tsc --noEmit` pass.

Link to Devin session: https://app.devin.ai/sessions/d8f3c08e685d4780b9934c566c480f64
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/122" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->