### PR TITLE
Glassmorphism colorway: Violet Haze

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -59,11 +59,11 @@
      Colorways retint the app by swapping only the aurora + glass variables. */
   --glass-border: rgb(255 255 255 / 0.65);
   --glass-glow:
-    0 8px 32px rgb(31 38 68 / 0.12),
+    0 8px 32px rgb(76 42 110 / 0.14),
     inset 0 1px 0 rgb(255 255 255 / 0.85);
-  --aurora-1: #c7d2fe;
-  --aurora-2: #fbcfe8;
-  --aurora-3: #bae6fd;
+  --aurora-1: #ddd0fb;
+  --aurora-2: #f5c9ea;
+  --aurora-3: #e4c6f7;
 }
 
 @theme inline {
@@ -256,13 +256,13 @@ input:-webkit-autofill:focus {
   --sidebar-accent-foreground: #e8e6e1;
   --sidebar-border: #26262a;
   --sidebar-ring: #7a7772;
-  --glass-border: rgb(255 255 255 / 0.12);
+  --glass-border: rgb(216 180 254 / 0.16);
   --glass-glow:
-    0 8px 32px rgb(0 0 0 / 0.45),
-    inset 0 1px 0 rgb(255 255 255 / 0.08);
-  --aurora-1: #2b2e5e;
-  --aurora-2: #4a2350;
-  --aurora-3: #123a4a;
+    0 8px 32px rgb(24 8 40 / 0.5),
+    inset 0 1px 0 rgb(232 213 255 / 0.1);
+  --aurora-1: #3b2270;
+  --aurora-2: #55184e;
+  --aurora-3: #6d2a8a;
 }
 
 @layer base {


### PR DESCRIPTION
## Summary
Retints the variable-driven glassmorphism system in `app/globals.css` to the Violet Haze colorway — no component changes.

- Light (`:root`): auroras become soft lavender `#ddd0fb` / blush `#f5c9ea` / lilac `#e4c6f7`; glass glow shadow shifts to a violet cast (`rgb(76 42 110 / 0.14)`).
- Dark (`.dark`): auroras become violet `#3b2270` / plum `#55184e` / magenta-orchid `#6d2a8a` for a nebula glow; glass border tinted lilac (`rgb(216 180 254 / 0.16)`), glow deepened to `rgb(24 8 40 / 0.5)` with a lavender inset highlight.

Foreground/background text tokens are untouched, so contrast is unchanged in both modes.

Link to Devin session: https://app.devin.ai/sessions/656ab12de592400982ba03039b99650c
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/124" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->