### PR TITLE
Swiss Minimal colorway: Forest

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -6,7 +6,7 @@
 
 /* Light mode (default) — Swiss / International Minimal: a pure white field
    on the neutral grey axis, near-black ink, hairline rules, and a single
-   restrained Swiss-red accent reserved for the claim flow. No warm cast,
+   restrained forest-green accent reserved for the claim flow. No warm cast,
    no soft tints — structure comes from the grid, not from color. */
 :root {
   --surface: #f5f5f5;
@@ -30,10 +30,10 @@
   --accent-foreground: #111111;
   --destructive: oklch(0.577 0.245 27.325);
   --input: oklch(0 0 0 / 8%);
-  --brand: #e30613;
+  --brand: #14532d;
   --brand-foreground: #ffffff;
-  --ring: #111111;
-  --selection: #e4e4e4;
+  --ring: #14532d;
+  --selection: #dcebe1;
   --selection-foreground: #111111;
   /* No shadows — the flat page and hairline rules carry all the depth. */
   --shadow-card: 0 0 rgb(0 0 0 / 0);
@@ -114,7 +114,7 @@ body {
 }
 
 /* Neutral, not brand: selection is incidental, so it shouldn't compete with
-   the one red accent on screen. */
+   the one green accent on screen. */
 ::selection {
   background: var(--selection);
   color: var(--selection-foreground);
@@ -169,7 +169,7 @@ input:-webkit-autofill:focus {
   }
 }
 
-/* Brand pulse: a slow breath reserved for the one brand-blue element in view. */
+/* Brand pulse: a slow breath reserved for the one brand-green element in view. */
 @utility animate-brand-pulse {
   animation: brand-pulse 3.2s ease-in-out infinite;
 }
@@ -185,7 +185,7 @@ input:-webkit-autofill:focus {
 }
 
 /* Dark mode — the same neutral axis inverted: near-black field, off-white
-   ink, hairline greys, and the identical Swiss-red accent. */
+   ink, hairline greys, and the identical forest-green accent. */
 .dark {
   --surface: #161616;
   --surface-hover: #1d1d1d;
@@ -208,10 +208,10 @@ input:-webkit-autofill:focus {
   --accent-foreground: #f2f2f2;
   --destructive: oklch(0.704 0.191 22.216);
   --input: oklch(1 0 0 / 15%);
-  --brand: #e30613;
+  --brand: #1a5632;
   --brand-foreground: #ffffff;
-  --ring: #c8c8c8;
-  --selection: #333333;
+  --ring: #1a5632;
+  --selection: #1e3a2a;
   --selection-foreground: #f2f2f2;
   --shadow-card: 0 0 rgb(0 0 0 / 0);
   --chart-1: oklch(0.87 0 0);


### PR DESCRIPTION
## Summary
Forest colorway for the Swiss Minimal direction: swaps the single Swiss-red accent for deep forest green in `app/globals.css`, keeping the neutral grid/type/sharp-corner base untouched.

- `:root`: `--brand #e30613 → #14532d`, `--ring #111111 → #14532d`, `--selection → #dcebe1` (faint paper-green tint)
- `.dark`: `--brand → #1a5632` (slightly lifted for dark contrast), `--ring → #1a5632`, `--selection → #1e3a2a`

Token-only change — no markup or logic touched; home and claim pages unaffected functionally. Lint and `tsc --noEmit` pass.

Link to Devin session: https://app.devin.ai/sessions/9c2d1b0e702c4d51a27355bae7982986
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/129" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->