### PR TITLE
Swiss Minimal colorway: Cobalt

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -6,7 +6,7 @@
 
 /* Light mode (default) — Swiss / International Minimal: a pure white field
    on the neutral grey axis, near-black ink, hairline rules, and a single
-   restrained Swiss-red accent reserved for the claim flow. No warm cast,
+   restrained cobalt-blue accent reserved for the claim flow. No warm cast,
    no soft tints — structure comes from the grid, not from color. */
 :root {
   --surface: #f5f5f5;
@@ -30,10 +30,10 @@
   --accent-foreground: #111111;
   --destructive: oklch(0.577 0.245 27.325);
   --input: oklch(0 0 0 / 8%);
-  --brand: #e30613;
+  --brand: #0032a0;
   --brand-foreground: #ffffff;
-  --ring: #111111;
-  --selection: #e4e4e4;
+  --ring: #0032a0;
+  --selection: #dbe4f7;
   --selection-foreground: #111111;
   /* No shadows — the flat page and hairline rules carry all the depth. */
   --shadow-card: 0 0 rgb(0 0 0 / 0);
@@ -113,8 +113,8 @@ body {
   font-family: var(--font-sans), system-ui, sans-serif;
 }
 
-/* Neutral, not brand: selection is incidental, so it shouldn't compete with
-   the one red accent on screen. */
+/* A whisper of cobalt: selection is incidental, so it carries only a faint
+   tint of the one accent on screen. */
 ::selection {
   background: var(--selection);
   color: var(--selection-foreground);
@@ -185,7 +185,7 @@ input:-webkit-autofill:focus {
 }
 
 /* Dark mode — the same neutral axis inverted: near-black field, off-white
-   ink, hairline greys, and the identical Swiss-red accent. */
+   ink, hairline greys, and a lifted cobalt accent for contrast on dark. */
 .dark {
   --surface: #161616;
   --surface-hover: #1d1d1d;
@@ -208,10 +208,10 @@ input:-webkit-autofill:focus {
   --accent-foreground: #f2f2f2;
   --destructive: oklch(0.704 0.191 22.216);
   --input: oklch(1 0 0 / 15%);
-  --brand: #e30613;
+  --brand: #2d5fd0;
   --brand-foreground: #ffffff;
-  --ring: #c8c8c8;
-  --selection: #333333;
+  --ring: #2d5fd0;
+  --selection: #1c2c50;
   --selection-foreground: #f2f2f2;
   --shadow-card: 0 0 rgb(0 0 0 / 0);
   --chart-1: oklch(0.87 0 0);


### PR DESCRIPTION
## Summary
Cobalt colorway for the Swiss Minimal direction: swaps the Swiss-red accent for deep cobalt blue in `app/globals.css` only — no markup or functional changes.

- `:root`: `--brand: #e30613 → #0032a0`, `--ring: #111111 → #0032a0`, `--selection: #e4e4e4 → #dbe4f7` (faint cobalt tint)
- `.dark`: `--brand → #2d5fd0` (lifted for contrast on near-black), `--ring → #2d5fd0`, `--selection → #1c2c50`

Neutral white/near-black base is untouched; still one accent, used sparingly. Lint and `tsc --noEmit` pass.

Link to Devin session: https://app.devin.ai/sessions/c0dca74f69c04ccc8d00698493f9f196
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->