### PR TITLE
Editorial Print colorway: Ivory & Ink

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,57 +4,55 @@
 
 @custom-variant dark (&:is(.dark *));
 
-/* Light mode (default) — "Paper": a white page field with warm off-neutrals
-   in the tints and borders rather than the pure grey axis, and ink (#22211E)
-   instead of near-black so text stays short of a harsh 19:1. Surface is a
-   neutral grey one step off white — hovers and the receipt stub read as a
-   quiet press of the field rather than a cream block. The blue accent is
-   reserved for the claim flow only. */
+/* Light mode (default) — "Ivory & Ink": a warm ivory page field, the color
+   of uncoated stock, with near-black ink type. Tints and borders sit on the
+   same warm-grey axis so rules read as printed hairlines on paper rather
+   than UI chrome. The blue accent is reserved for the claim flow only. */
 :root {
-  --surface: #f6f6f6;
-  --surface-hover: #f0f0f0;
-  --border: #eae7df;
-  --border-strong: #d5cfc2;
-  --muted: #f1efe8;
-  --muted-dim: #78716a;
-  --background: #ffffff;
-  --foreground: #22211e;
-  --card: #ffffff;
-  --card-foreground: #22211e;
-  --popover: #ffffff;
-  --popover-foreground: #22211e;
-  --primary: #22211e;
-  --primary-foreground: #faf9f5;
-  --secondary: #f1efe8;
-  --secondary-foreground: #22211e;
-  --muted-foreground: #57534a;
-  --accent: #f1efe8;
-  --accent-foreground: #22211e;
+  --surface: #f1ecdf;
+  --surface-hover: #ebe5d6;
+  --border: #e3ddcd;
+  --border-strong: #cfc7b2;
+  --muted: #efe9db;
+  --muted-dim: #7a7365;
+  --background: #f7f3ea;
+  --foreground: #191813;
+  --card: #f7f3ea;
+  --card-foreground: #191813;
+  --popover: #faf7f0;
+  --popover-foreground: #191813;
+  --primary: #191813;
+  --primary-foreground: #f7f3ea;
+  --secondary: #efe9db;
+  --secondary-foreground: #191813;
+  --muted-foreground: #55503f;
+  --accent: #efe9db;
+  --accent-foreground: #191813;
   --destructive: oklch(0.577 0.245 27.325);
   --input: oklch(0 0 0 / 8%);
   --brand: #2200ff;
   --brand-foreground: #ffffff;
-  --ring: #44403a;
-  --selection: #e6e1d5;
-  --selection-foreground: #22211e;
+  --ring: #43402f;
+  --selection: #e6dfc9;
+  --selection-foreground: #191813;
   /* Soft two-layer card shadow: invisible as "shadow", read as depth. Dark
      mode zeroes it out and relies on surface contrast instead. */
   --shadow-card:
-    0 1px 2px rgb(34 33 30 / 0.04), 0 4px 12px -2px rgb(34 33 30 / 0.04);
+    0 1px 2px rgb(25 24 19 / 0.04), 0 4px 12px -2px rgb(25 24 19 / 0.04);
   --chart-1: oklch(0.269 0 0);
   --chart-2: oklch(0.439 0 0);
   --chart-3: oklch(0.556 0 0);
   --chart-4: oklch(0.708 0 0);
   --chart-5: oklch(0.87 0 0);
   --radius: 0.625rem;
-  --sidebar: #ffffff;
-  --sidebar-foreground: #22211e;
-  --sidebar-primary: #22211e;
-  --sidebar-primary-foreground: #faf9f5;
-  --sidebar-accent: #f1efe8;
-  --sidebar-accent-foreground: #22211e;
-  --sidebar-border: #e7e3da;
-  --sidebar-ring: #78716a;
+  --sidebar: #f7f3ea;
+  --sidebar-foreground: #191813;
+  --sidebar-primary: #191813;
+  --sidebar-primary-foreground: #f7f3ea;
+  --sidebar-accent: #efe9db;
+  --sidebar-accent-foreground: #191813;
+  --sidebar-border: #e3ddcd;
+  --sidebar-ring: #7a7365;
 }
 
 @theme inline {
@@ -204,50 +202,51 @@ input:-webkit-autofill:focus {
   }
 }
 
-/* Dark mode — "Paper" after dark: the near-black picks up a faint cool cast
-   while the text stays warm off-white, and contrast drops from 18:1 to ~16:1
-   to stop white type haloing on OLED. */
+/* Dark mode — "Ivory & Ink" inverted: a deep charcoal-ink page with ivory
+   type, keeping the warm cast of the paper palette so the two themes read
+   as the same stock under different light. Contrast stays short of pure
+   white-on-black to stop type haloing on OLED. */
 .dark {
-  --surface: #141416;
-  --surface-hover: #1a1a1d;
-  --border: #26262a;
-  --border-strong: #3a3a40;
-  --muted: #212125;
-  --muted-dim: #7a7772;
-  --background: #0c0c0e;
-  --foreground: #e8e6e1;
-  --card: #141416;
-  --card-foreground: #e8e6e1;
-  --popover: #1a1a1d;
-  --popover-foreground: #e8e6e1;
-  --primary: #e8e6e1;
-  --primary-foreground: #0c0c0e;
-  --secondary: #2b2b30;
-  --secondary-foreground: #e8e6e1;
-  --muted-foreground: #a8a5a0;
-  --accent: #2b2b30;
-  --accent-foreground: #e8e6e1;
+  --surface: #201f1c;
+  --surface-hover: #262521;
+  --border: #32302a;
+  --border-strong: #47443c;
+  --muted: #2b2a25;
+  --muted-dim: #8a8578;
+  --background: #171613;
+  --foreground: #f0ebdd;
+  --card: #201f1c;
+  --card-foreground: #f0ebdd;
+  --popover: #262521;
+  --popover-foreground: #f0ebdd;
+  --primary: #f0ebdd;
+  --primary-foreground: #171613;
+  --secondary: #34322b;
+  --secondary-foreground: #f0ebdd;
+  --muted-foreground: #b3ada0;
+  --accent: #34322b;
+  --accent-foreground: #f0ebdd;
   --destructive: oklch(0.704 0.191 22.216);
   --input: oklch(1 0 0 / 15%);
   --brand: #2200ff;
   --brand-foreground: #ffffff;
-  --ring: #c4c1bb;
-  --selection: #33333a;
-  --selection-foreground: #e8e6e1;
+  --ring: #cdc7b6;
+  --selection: #3d3a31;
+  --selection-foreground: #f0ebdd;
   --shadow-card: 0 0 rgb(0 0 0 / 0);
   --chart-1: oklch(0.87 0 0);
   --chart-2: oklch(0.556 0 0);
   --chart-3: oklch(0.439 0 0);
   --chart-4: oklch(0.371 0 0);
   --chart-5: oklch(0.269 0 0);
-  --sidebar: #141416;
-  --sidebar-foreground: #e8e6e1;
-  --sidebar-primary: #e8e6e1;
-  --sidebar-primary-foreground: #0c0c0e;
-  --sidebar-accent: #2b2b30;
-  --sidebar-accent-foreground: #e8e6e1;
-  --sidebar-border: #26262a;
-  --sidebar-ring: #7a7772;
+  --sidebar: #201f1c;
+  --sidebar-foreground: #f0ebdd;
+  --sidebar-primary: #f0ebdd;
+  --sidebar-primary-foreground: #171613;
+  --sidebar-accent: #34322b;
+  --sidebar-accent-foreground: #f0ebdd;
+  --sidebar-border: #32302a;
+  --sidebar-ring: #8a8578;
 }
 
 @layer base {


### PR DESCRIPTION
## Summary
Applies the "Ivory & Ink" colorway to the Editorial Print direction by retinting the `:root` and `.dark` token blocks in `app/globals.css` — color tokens only, no layout/typography/backend changes.

- Light: warm ivory paper page (`--background: #f7f3ea`) with near-black ink type (`#191813`); surfaces, borders, muted tints, selection all shift to the same warm-grey axis (e.g. `--border: #e3ddcd`, `--border-strong: #cfc7b2`).
- Dark: deep warm charcoal page (`--background: #171613`, surfaces `#201f1c`) with ivory type (`#f0ebdd`), keeping the same warm cast so both themes read as the same paper stock.
- `--brand: #2200ff` untouched — the blue accent stays reserved for the claim flow.

`npm run lint` and `npx tsc --noEmit` pass.

Link to Devin session: https://app.devin.ai/sessions/6c44b95d5e554c1ab824e6c7a14d5f2d
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/135" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->