### PR TITLE
Swiss Minimal colorway: Classic Red

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -6,8 +6,9 @@
 
 /* Light mode (default) — Swiss / International Minimal: a pure white field
    on the neutral grey axis, near-black ink, hairline rules, and a single
-   restrained Swiss-red accent reserved for the claim flow. No warm cast,
-   no soft tints — structure comes from the grid, not from color. */
+   classic Swiss-red accent (Classic Red) reserved for the claim flow.
+   No warm cast, no soft tints — structure comes from the grid, not from
+   color. */
 :root {
   --surface: #f5f5f5;
   --surface-hover: #ededed;
@@ -32,9 +33,9 @@
   --input: oklch(0 0 0 / 8%);
   --brand: #e30613;
   --brand-foreground: #ffffff;
-  --ring: #111111;
-  --selection: #e4e4e4;
-  --selection-foreground: #111111;
+  --ring: #e30613;
+  --selection: #e30613;
+  --selection-foreground: #ffffff;
   /* No shadows — the flat page and hairline rules carry all the depth. */
   --shadow-card: 0 0 rgb(0 0 0 / 0);
   --chart-1: oklch(0.269 0 0);
@@ -113,8 +114,8 @@ body {
   font-family: var(--font-sans), system-ui, sans-serif;
 }
 
-/* Neutral, not brand: selection is incidental, so it shouldn't compete with
-   the one red accent on screen. */
+/* Classic Red: selection prints in the one accent color — a small, classic
+   Swiss gesture that keeps the rest of the page strictly neutral. */
 ::selection {
   background: var(--selection);
   color: var(--selection-foreground);
@@ -210,9 +211,9 @@ input:-webkit-autofill:focus {
   --input: oklch(1 0 0 / 15%);
   --brand: #e30613;
   --brand-foreground: #ffffff;
-  --ring: #c8c8c8;
-  --selection: #333333;
-  --selection-foreground: #f2f2f2;
+  --ring: #e30613;
+  --selection: #e30613;
+  --selection-foreground: #ffffff;
   --shadow-card: 0 0 rgb(0 0 0 / 0);
   --chart-1: oklch(0.87 0 0);
   --chart-2: oklch(0.556 0 0);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -122,7 +122,8 @@ export default function Home() {
             </div>
             <div className="grid gap-10 py-14 sm:grid-cols-12 sm:py-20">
               <h1 className="font-heading text-5xl leading-[0.95] font-bold tracking-[-0.04em] text-balance sm:col-span-8 sm:text-7xl">
-                Claim your credits.
+                Claim your credits
+                <span className="text-brand">.</span>
               </h1>
               <p className="self-end text-sm leading-relaxed text-muted-foreground sm:col-span-4">
                 Sign in, then select your event to claim your credits.

--- a/components/ClaimPage.tsx
+++ b/components/ClaimPage.tsx
@@ -646,9 +646,7 @@ function Receipt({
     >
       <div className="flex flex-col gap-6 p-6 sm:p-8">
         <div className="flex items-center justify-between">
-          <span className="eyebrow text-muted-foreground">
-            Code dispensed
-          </span>
+          <span className="eyebrow text-brand">Code dispensed</span>
           <span className="relative flex size-2">
             <span className="absolute inline-flex size-full animate-ping rounded-full bg-brand opacity-60 motion-reduce:animate-none [animation-duration:2.5s] [animation-iteration-count:3]" />
             <span className="relative inline-flex size-2 rounded-full bg-brand" />


### PR DESCRIPTION
## Summary
Classic Red colorway on top of the Swiss Minimal direction: keeps the pure white / near-black neutral base and leans fully into the #e30613 accent while keeping usage restrained.

- `app/globals.css` (`:root` and `.dark`): `--ring` moves from neutral to `#e30613`, and `--selection`/`--selection-foreground` become red-on-white (`#e30613` / `#ffffff`) in both modes, so focus rings and text selection print in the one accent color.
- `app/page.tsx`: hero headline terminal period rendered in `text-brand`.
- `components/ClaimPage.tsx`: receipt "Code dispensed" eyebrow rendered in `text-brand`.

No functional changes. `npm run lint` and `npx tsc --noEmit` pass.

Link to Devin session: https://app.devin.ai/sessions/8b863f09b5e64dbc80ab1b38aadad515
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/138" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->