### PR TITLE
Neo-Brutalist colorway: Mint

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,36 +4,36 @@
 
 @custom-variant dark (&:is(.dark *));
 
-/* Light mode (default) — Neo-Brutalist: a stark white field, pure ink-black
-   borders and type, zero radius, and hard offset shadows. Contrast is the
-   whole palette; the brand blue stays as the single loud accent. */
+/* Light mode (default) — Neo-Brutalist, Mint colorway: pale mint field,
+   pure ink-black borders and type, zero radius, and hard offset shadows.
+   Fresh mint green is the single loud accent. */
 :root {
-  --surface: #f4f4f0;
-  --surface-hover: #ecece6;
+  --surface: #e4fbf1;
+  --surface-hover: #d3f7e7;
   --border: #000000;
   --border-strong: #000000;
-  --muted: #efefe9;
-  --muted-dim: #55524c;
-  --background: #ffffff;
+  --muted: #dcf9ec;
+  --muted-dim: #3c5a4d;
+  --background: #f2fdf8;
   --foreground: #000000;
-  --card: #ffffff;
+  --card: #f2fdf8;
   --card-foreground: #000000;
-  --popover: #ffffff;
+  --popover: #f2fdf8;
   --popover-foreground: #000000;
   --primary: #000000;
-  --primary-foreground: #ffffff;
-  --secondary: #efefe9;
+  --primary-foreground: #3dffb4;
+  --secondary: #dcf9ec;
   --secondary-foreground: #000000;
-  --muted-foreground: #44413c;
-  --accent: #efefe9;
+  --muted-foreground: #2f4a3e;
+  --accent: #c9f5e2;
   --accent-foreground: #000000;
   --destructive: oklch(0.577 0.245 27.325);
   --input: oklch(0 0 0 / 8%);
-  --brand: #2200ff;
-  --brand-foreground: #ffffff;
+  --brand: #00e5a0;
+  --brand-foreground: #000000;
   --ring: #000000;
-  --selection: #000000;
-  --selection-foreground: #ffffff;
+  --selection: #00e5a0;
+  --selection-foreground: #000000;
   /* Hard offset shadow: an opaque block, not a blur — the signature
      neo-brutalist "lifted slab" read. */
   --shadow-card: 8px 8px 0 0 var(--border-strong);
@@ -43,14 +43,14 @@
   --chart-4: oklch(0.708 0 0);
   --chart-5: oklch(0.87 0 0);
   --radius: 0rem;
-  --sidebar: #ffffff;
-  --sidebar-foreground: #22211e;
-  --sidebar-primary: #22211e;
-  --sidebar-primary-foreground: #faf9f5;
-  --sidebar-accent: #f1efe8;
-  --sidebar-accent-foreground: #22211e;
-  --sidebar-border: #e7e3da;
-  --sidebar-ring: #78716a;
+  --sidebar: #f2fdf8;
+  --sidebar-foreground: #1e2b25;
+  --sidebar-primary: #1e2b25;
+  --sidebar-primary-foreground: #f2fdf8;
+  --sidebar-accent: #d3f7e7;
+  --sidebar-accent-foreground: #1e2b25;
+  --sidebar-border: #b9e8d6;
+  --sidebar-ring: #5f8674;
 }
 
 @theme inline {
@@ -109,8 +109,7 @@ body {
   font-family: var(--font-sans), system-ui, sans-serif;
 }
 
-/* Neutral, not brand: selection is incidental, so it shouldn't compete with
-   the one blue thing on screen. */
+/* Selection joins the colorway: a mint highlight with ink-black text. */
 ::selection {
   background: var(--selection);
   color: var(--selection-foreground);
@@ -182,7 +181,7 @@ input:-webkit-autofill:focus {
   }
 }
 
-/* Brand pulse: a slow breath reserved for the one brand-blue element in view. */
+/* Brand pulse: a slow breath reserved for the one brand-mint element in view. */
 @utility animate-brand-pulse {
   animation: brand-pulse 3.2s ease-in-out infinite;
 }
@@ -197,34 +196,34 @@ input:-webkit-autofill:focus {
   }
 }
 
-/* Dark mode — Neo-Brutalist inverted: pure black field, pure white ink
-   borders, same hard offset shadows drawn in white. */
+/* Dark mode — Neo-Brutalist inverted, Mint colorway: near-black field with a
+   faint green cast, mint ink borders, same hard offset shadows drawn in mint. */
 .dark {
-  --surface: #121212;
-  --surface-hover: #1b1b1b;
-  --border: #ffffff;
-  --border-strong: #ffffff;
-  --muted: #1b1b1b;
-  --muted-dim: #b3b3b3;
-  --background: #000000;
-  --foreground: #ffffff;
-  --card: #000000;
-  --card-foreground: #ffffff;
-  --popover: #000000;
-  --popover-foreground: #ffffff;
-  --primary: #ffffff;
+  --surface: #0d1712;
+  --surface-hover: #142219;
+  --border: #3dffb4;
+  --border-strong: #3dffb4;
+  --muted: #142219;
+  --muted-dim: #8fc4ac;
+  --background: #060b09;
+  --foreground: #e8fff5;
+  --card: #060b09;
+  --card-foreground: #e8fff5;
+  --popover: #060b09;
+  --popover-foreground: #e8fff5;
+  --primary: #3dffb4;
   --primary-foreground: #000000;
-  --secondary: #1b1b1b;
-  --secondary-foreground: #ffffff;
-  --muted-foreground: #cfcfcf;
-  --accent: #1b1b1b;
-  --accent-foreground: #ffffff;
+  --secondary: #142219;
+  --secondary-foreground: #e8fff5;
+  --muted-foreground: #b9e8d6;
+  --accent: #142219;
+  --accent-foreground: #e8fff5;
   --destructive: oklch(0.704 0.191 22.216);
   --input: oklch(1 0 0 / 15%);
-  --brand: #2200ff;
-  --brand-foreground: #ffffff;
-  --ring: #ffffff;
-  --selection: #ffffff;
+  --brand: #3dffb4;
+  --brand-foreground: #000000;
+  --ring: #3dffb4;
+  --selection: #3dffb4;
   --selection-foreground: #000000;
   --shadow-card: 8px 8px 0 0 var(--border-strong);
   --chart-1: oklch(0.87 0 0);
@@ -232,14 +231,14 @@ input:-webkit-autofill:focus {
   --chart-3: oklch(0.439 0 0);
   --chart-4: oklch(0.371 0 0);
   --chart-5: oklch(0.269 0 0);
-  --sidebar: #141416;
-  --sidebar-foreground: #e8e6e1;
-  --sidebar-primary: #e8e6e1;
-  --sidebar-primary-foreground: #0c0c0e;
-  --sidebar-accent: #2b2b30;
-  --sidebar-accent-foreground: #e8e6e1;
-  --sidebar-border: #26262a;
-  --sidebar-ring: #7a7772;
+  --sidebar: #0d1712;
+  --sidebar-foreground: #e8fff5;
+  --sidebar-primary: #e8fff5;
+  --sidebar-primary-foreground: #060b09;
+  --sidebar-accent: #1c3327;
+  --sidebar-accent-foreground: #e8fff5;
+  --sidebar-border: #1c3327;
+  --sidebar-ring: #5f8674;
 }
 
 @layer base {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -150,7 +150,7 @@ export default function Home() {
   // copy centered in the visible area.
   const heroCopy = (
     <div className="relative mx-auto flex h-full w-full max-w-5xl flex-col justify-center px-4 pt-15.25 sm:px-6">
-      <p className="eyebrow animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 w-fit border-2 border-black bg-white px-2.5 py-1.5 text-black shadow-[3px_3px_0_0_#000] dark:border-white dark:bg-black dark:text-white dark:shadow-[3px_3px_0_0_#fff] motion-reduce:animate-none">
+      <p className="eyebrow animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 w-fit border-2 border-black bg-brand px-2.5 py-1.5 text-black shadow-[3px_3px_0_0_#000] dark:border-black dark:shadow-[3px_3px_0_0_#000] motion-reduce:animate-none">
         {process.env.NEXT_PUBLIC_IS_DEVIN ? "Devin " : ""}Event credit
         distribution
       </p>


### PR DESCRIPTION
## Summary
Mint colorway for the Neo-Brutalist theme — token changes in `app/globals.css` only, plus one class tweak; no logic/layout changes.

Light mode: pale mint field (`--background: #f2fdf8`, surfaces/muted in `#e4fbf1`/`#dcf9ec` territory), `--brand: #00e5a0` with black foreground, mint `--selection`, black-ink borders and hard shadows unchanged.

Dark mode: near-black green-cast field (`#060b09`), mint ink (`--border`/`--border-strong`/`--ring`/`--primary`/`--brand: #3dffb4`) so the hard offset shadows now draw in mint instead of white.

Class tweak: the hero eyebrow chip in `app/page.tsx` becomes a `bg-brand` mint chip with black border/shadow in both modes (was white/black inverted).

`npm run lint` and `npx tsc --noEmit` pass.

Link to Devin session: https://app.devin.ai/sessions/4417458a34a44c1fb49b110864f9fcf6
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/140" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->