### PR TITLE
Retro Terminal colorway: Red Alert

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,40 +4,42 @@
 
 @custom-variant dark (&:is(.dark *));
 
-/* Retro terminal / CRT — green phosphor on near-black glass. Light mode is
-   a "paper terminal": dark phosphor ink on a pale phosphor-tinted field, so
-   the theme toggle still means something. The phosphor hue drives every
-   accent; radius is zeroed so everything reads as character cells. */
+/* Retro terminal / CRT — RED ALERT: emergency-console red phosphor on
+   near-black glass. Light mode is a "paper terminal": dark red ink on a pale
+   red-tinted field, so the theme toggle still means something. The phosphor
+   hue drives every accent; radius is zeroed so everything reads as character
+   cells. Destructive is pushed toward orange so errors stay distinguishable
+   from the red brand hue. */
 :root {
-  --phosphor: #1a7a3c;
-  --phosphor-dim: #4a8a60;
-  --phosphor-bright: #0c5c2a;
-  --surface: #e9f2e9;
-  --surface-hover: #dfecdf;
-  --border: #b9d4bd;
-  --border-strong: #8db898;
-  --muted: #dcebde;
-  --muted-dim: #5c7a64;
-  --background: #f2f7f2;
-  --foreground: #123d22;
-  --card: #eef5ee;
-  --card-foreground: #123d22;
-  --popover: #eef5ee;
-  --popover-foreground: #123d22;
-  --primary: #123d22;
-  --primary-foreground: #f2f7f2;
-  --secondary: #dcebde;
-  --secondary-foreground: #123d22;
-  --muted-foreground: #3c6349;
-  --accent: #dcebde;
-  --accent-foreground: #123d22;
-  --destructive: oklch(0.577 0.245 27.325);
+  --phosphor: #b3261e;
+  --phosphor-dim: #a35a55;
+  --phosphor-bright: #8c1414;
+  --surface: #f5eae9;
+  --surface-hover: #efdfde;
+  --border: #dcb9b6;
+  --border-strong: #c08d88;
+  --muted: #eedcda;
+  --muted-dim: #855e5a;
+  --background: #f9f2f1;
+  --foreground: #4a1210;
+  --card: #f7eeed;
+  --card-foreground: #4a1210;
+  --popover: #f7eeed;
+  --popover-foreground: #4a1210;
+  --primary: #4a1210;
+  --primary-foreground: #f9f2f1;
+  --secondary: #eedcda;
+  --secondary-foreground: #4a1210;
+  --muted-foreground: #703c38;
+  --accent: #eedcda;
+  --accent-foreground: #4a1210;
+  --destructive: oklch(0.6 0.19 50);
   --input: oklch(0 0 0 / 8%);
-  --brand: #1a7a3c;
-  --brand-foreground: #f2f7f2;
-  --ring: #2a6b42;
-  --selection: #123d22;
-  --selection-foreground: #d8f5d8;
+  --brand: #b3261e;
+  --brand-foreground: #f9f2f1;
+  --ring: #8c2a24;
+  --selection: #4a1210;
+  --selection-foreground: #fadcda;
   --shadow-card: 0 0 rgb(0 0 0 / 0);
   --chart-1: oklch(0.269 0 0);
   --chart-2: oklch(0.439 0 0);
@@ -45,14 +47,14 @@
   --chart-4: oklch(0.708 0 0);
   --chart-5: oklch(0.87 0 0);
   --radius: 0rem;
-  --sidebar: #eef5ee;
-  --sidebar-foreground: #123d22;
-  --sidebar-primary: #123d22;
-  --sidebar-primary-foreground: #f2f7f2;
-  --sidebar-accent: #dcebde;
-  --sidebar-accent-foreground: #123d22;
-  --sidebar-border: #b9d4bd;
-  --sidebar-ring: #5c7a64;
+  --sidebar: #f7eeed;
+  --sidebar-foreground: #4a1210;
+  --sidebar-primary: #4a1210;
+  --sidebar-primary-foreground: #f9f2f1;
+  --sidebar-accent: #eedcda;
+  --sidebar-accent-foreground: #4a1210;
+  --sidebar-border: #dcb9b6;
+  --sidebar-ring: #855e5a;
 }
 
 @theme inline {
@@ -273,53 +275,54 @@ input:-webkit-autofill:focus {
   }
 }
 
-/* Dark mode — the real CRT: green phosphor burning on near-black glass. */
+/* Dark mode — the real CRT on red alert: red phosphor burning on near-black
+   warm-tinted glass. */
 .dark {
-  --phosphor: #33ff66;
-  --phosphor-dim: #1e9944;
-  --phosphor-bright: #7dffa3;
+  --phosphor: #ff3b3b;
+  --phosphor-dim: #99231f;
+  --phosphor-bright: #ff8a80;
   --scanline: rgb(0 0 0 / 0.22);
   --vignette: rgb(0 0 0 / 0.45);
-  --surface: #0a140c;
-  --surface-hover: #0e1c10;
-  --border: #143d1f;
-  --border-strong: #1e5c2e;
-  --muted: #0e1c10;
-  --muted-dim: #2e7a44;
-  --background: #050a06;
-  --foreground: #33ff66;
-  --card: #081109;
-  --card-foreground: #33ff66;
-  --popover: #0a140c;
-  --popover-foreground: #33ff66;
-  --primary: #33ff66;
-  --primary-foreground: #050a06;
-  --secondary: #0e1c10;
-  --secondary-foreground: #7dffa3;
-  --muted-foreground: #2e9950;
-  --accent: #0e1c10;
-  --accent-foreground: #7dffa3;
-  --destructive: oklch(0.704 0.191 22.216);
-  --input: oklch(0.7 0.2 150 / 15%);
-  --brand: #33ff66;
-  --brand-foreground: #050a06;
-  --ring: #33ff66;
-  --selection: #33ff66;
-  --selection-foreground: #050a06;
+  --surface: #140a0a;
+  --surface-hover: #1c0e0e;
+  --border: #3d1512;
+  --border-strong: #5c1f1a;
+  --muted: #1c0e0e;
+  --muted-dim: #7a2e28;
+  --background: #0a0505;
+  --foreground: #ff3b3b;
+  --card: #110808;
+  --card-foreground: #ff3b3b;
+  --popover: #140a0a;
+  --popover-foreground: #ff3b3b;
+  --primary: #ff3b3b;
+  --primary-foreground: #0a0505;
+  --secondary: #1c0e0e;
+  --secondary-foreground: #ff8a80;
+  --muted-foreground: #99342e;
+  --accent: #1c0e0e;
+  --accent-foreground: #ff8a80;
+  --destructive: oklch(0.75 0.18 55);
+  --input: oklch(0.7 0.2 25 / 15%);
+  --brand: #ff3b3b;
+  --brand-foreground: #0a0505;
+  --ring: #ff3b3b;
+  --selection: #ff3b3b;
+  --selection-foreground: #0a0505;
   --shadow-card: 0 0 rgb(0 0 0 / 0);
   --chart-1: oklch(0.87 0 0);
   --chart-2: oklch(0.556 0 0);
   --chart-3: oklch(0.439 0 0);
   --chart-4: oklch(0.371 0 0);
   --chart-5: oklch(0.269 0 0);
-  --sidebar: #081109;
-  --sidebar-foreground: #33ff66;
-  --sidebar-primary: #33ff66;
-  --sidebar-primary-foreground: #050a06;
-  --sidebar-accent: #0e1c10;
-  --sidebar-accent-foreground: #7dffa3;
-  --sidebar-border: #143d1f;
-  --sidebar-ring: #2e7a44;
+  --sidebar: #110808;
+  --sidebar-foreground: #ff3b3b;
+  --sidebar-primary: #ff3b3b;
+  --sidebar-primary-foreground: #0a0505;
+  --sidebar-accent: #1c0e0e;
+  --sidebar-accent-foreground: #ff8a80;
+  --sidebar-border: #3d1512;
+  --sidebar-ring: #7a2e28;
 }
 
 @layer base {


### PR DESCRIPTION
## Summary
Recolors the retro terminal theme from green phosphor to an emergency-console RED ALERT colorway. Pure recolor in `app/globals.css` — no component/structure changes.

- `.dark` (the real CRT): `--phosphor: #ff3b3b` with `--phosphor-dim: #99231f` / `--phosphor-bright: #ff8a80` on near-black warm-red-tinted glass (`--background: #0a0505`, surfaces/borders shifted to red-tinted equivalents).
- `:root` (paper terminal): dark red ink `#4a1210` on a pale red-tinted field `#f9f2f1`, phosphor `#b3261e`.
- `--destructive` shifted toward orange (light `oklch(0.6 0.19 50)`, dark `oklch(0.75 0.18 55)`) so errors stay distinguishable from the red brand hue.
- Scanline/vignette vars unchanged; palette comments updated.

`npm run lint` and `npx tsc --noEmit` both pass.

Link to Devin session: https://app.devin.ai/sessions/988257b2dca14dba988f551683cc9627
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/141" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->