### PR TITLE
Design direction: Playful Arcade

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -35,6 +35,8 @@
   --brand: #2200ff;
   --brand-foreground: #ffffff;
   --ring: #44403a;
+  --arcade-accent: #ff2e88;
+  --arcade-accent-2: #ffc700;
   --selection: #e6e1d5;
   --selection-foreground: #22211e;
   /* Soft two-layer card shadow: invisible as "shadow", read as depth. Dark
@@ -68,9 +70,8 @@
   --color-muted-dim: var(--muted-dim);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
-  /* Headings share the body face — hierarchy comes from weight, size, and
-     tracking rather than a second display family. */
-  --font-heading: var(--font-geist-sans);
+  /* Arcade direction: headings use the 8-bit display face. */
+  --font-heading: var(--font-arcade);
   --color-brand: var(--brand);
   --color-brand-foreground: var(--brand-foreground);
   --color-sidebar-ring: var(--sidebar-ring);
@@ -111,6 +112,70 @@
 
 body {
   font-family: var(--font-sans), system-ui, sans-serif;
+}
+
+/* Pixel frame: a chunky stepped border that reads as an 8-bit game-cabinet
+   bezel — hard offset shadow instead of blur, square corners. */
+@utility pixel-frame {
+  border-radius: 0;
+  border: 2px solid var(--foreground);
+  box-shadow: 4px 4px 0 0 var(--foreground);
+}
+
+/* CRT scanlines overlay for cabinet "screen" surfaces. Purely decorative,
+   kept faint so text contrast is unaffected. */
+@utility bg-scanlines {
+  background-image: repeating-linear-gradient(
+    0deg,
+    rgb(0 0 0 / 0.05) 0px,
+    rgb(0 0 0 / 0.05) 1px,
+    transparent 1px,
+    transparent 3px
+  );
+}
+
+/* Blinking block cursor / "INSERT COIN" blink — classic attract-mode step
+   blink, not a fade. */
+@utility animate-arcade-blink {
+  animation: arcade-blink 1.1s steps(1, end) infinite;
+}
+
+@keyframes arcade-blink {
+  0%,
+  49% {
+    opacity: 1;
+  }
+  50%,
+  100% {
+    opacity: 0;
+  }
+}
+
+/* Bouncy press: buttons and rows dip like a cabinet button on hover/press. */
+@utility arcade-bounce {
+  transition: transform 0.15s cubic-bezier(0.34, 1.56, 0.64, 1);
+  &:hover {
+    transform: translateY(-2px);
+  }
+  &:active {
+    transform: translateY(1px);
+  }
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+    &:hover,
+    &:active {
+      transform: none;
+    }
+  }
+}
+
+/* Marquee stripes: the angled hazard/awning stripes across cabinet tops. */
+@utility bg-marquee-stripes {
+  background-image: repeating-linear-gradient(
+    -45deg,
+    var(--arcade-accent) 0 10px,
+    var(--arcade-accent-2) 10px 20px
+  );
 }
 
 /* Neutral, not brand: selection is incidental, so it shouldn't compete with
@@ -212,6 +277,8 @@ input:-webkit-autofill:focus {
   --brand: #2200ff;
   --brand-foreground: #ffffff;
   --ring: #c4c1bb;
+  --arcade-accent: #ff2e88;
+  --arcade-accent-2: #ffc700;
   --selection: #33333a;
   --selection-foreground: #e8e6e1;
   --shadow-card: 0 0 rgb(0 0 0 / 0);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Geist, Geist_Mono, Press_Start_2P } from "next/font/google";
 import { ClerkProvider } from "@clerk/nextjs";
 import ConvexClientProvider from "@/components/ConvexClientProvider";
 import { ThemeProvider } from "@/components/ThemeProvider";
@@ -14,6 +14,14 @@ const geistSans = Geist({
 
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
+  subsets: ["latin"],
+});
+
+// 8-bit display face for the arcade direction: headings only — body copy
+// stays on Geist for legibility.
+const pressStart = Press_Start_2P({
+  variable: "--font-arcade",
+  weight: "400",
   subsets: ["latin"],
 });
 
@@ -49,7 +57,7 @@ export default function RootLayout({
     <ClerkProvider appearance={clerkAppearance}>
       <html
         lang="en"
-        className={`${geistSans.variable} ${geistMono.variable} h-full overscroll-none antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} ${pressStart.variable} h-full overscroll-none antialiased`}
         suppressHydrationWarning
       >
         <body className="flex min-h-full flex-col overscroll-none">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -76,8 +76,14 @@ function EventRow({
           past && "opacity-60 transition-opacity hover:opacity-100",
         )}
       >
+        <span
+          aria-hidden
+          className="shrink-0 font-heading text-xs text-muted-dim transition-transform duration-200 ease-out group-hover:translate-x-1 group-hover:text-brand"
+        >
+          ▶
+        </span>
         <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 font-heading text-xl font-medium tracking-tight sm:text-2xl">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 font-heading text-base leading-relaxed sm:text-lg">
             {event.name}
             {claimed ? (
               <Badge variant="secondary" className="gap-1">
@@ -154,11 +160,18 @@ export default function Home() {
         {process.env.NEXT_PUBLIC_IS_DEVIN ? "Devin " : ""}Event credit
         distribution
       </p>
-      <h1 className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-100 mt-6 max-w-2xl font-heading text-5xl leading-[0.95] font-semibold tracking-[-0.03em] text-balance text-black dark:text-white motion-reduce:animate-none sm:text-7xl">
+      <h1 className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-100 mt-6 max-w-2xl font-heading text-2xl leading-snug text-balance text-black dark:text-white motion-reduce:animate-none sm:text-4xl sm:leading-snug">
         Claim your credits.
+        <span
+          aria-hidden
+          className="animate-arcade-blink ml-2 inline-block h-[0.8em] w-[0.5em] translate-y-[0.08em] bg-brand align-baseline motion-reduce:animate-none"
+        />
       </h1>
       <p className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-200 mt-6 max-w-md text-sm leading-relaxed text-black/70 dark:text-white/70 motion-reduce:animate-none">
         Sign in, then select your event to claim your credits.
+      </p>
+      <p className="eyebrow animate-arcade-blink animate-in fade-in fill-mode-both duration-500 delay-300 mt-8 text-black/50 dark:text-white/50 motion-reduce:animate-none">
+        ● Insert coin — press start
       </p>
     </div>
   );
@@ -167,7 +180,7 @@ export default function Home() {
     <div className="flex min-h-screen flex-col">
       <SiteHeader />
       <main id="main-content" className="flex-1">
-        <section className="-mt-15.25 border-b border-border/65">
+        <section className="-mt-15.25 border-b-4 border-double border-border-strong">
           {/* The section pulls up behind the translucent header bar
               (-mt-15.25) so the background runs to the top of the page; the
               hero is 61px taller to compensate and the scene shows through
@@ -198,13 +211,17 @@ export default function Home() {
               className="absolute inset-0 bg-white/20 dark:bg-black/20"
               aria-hidden
             />
+            {/* CRT scanlines make the hero read as the cabinet's screen. */}
+            <div className="bg-scanlines absolute inset-0" aria-hidden />
             {heroCopy}
           </div>
+          {/* Cabinet marquee stripe under the "screen". */}
+          <div className="bg-marquee-stripes h-2" aria-hidden />
         </section>
 
         <section className="mx-auto w-full max-w-5xl px-4 py-14 sm:px-6 sm:py-20">
-          <h2 className="text-sm font-medium text-muted-foreground">
-            Active events
+          <h2 className="font-heading text-xs text-muted-foreground uppercase">
+            ★ Active events
           </h2>
 
           {events === undefined ? (
@@ -258,8 +275,8 @@ export default function Home() {
               {past.length > 0 ? (
                 <>
                   <div className="mt-14 flex items-baseline justify-between">
-                    <h2 className="text-sm font-medium text-muted-foreground">
-                      Past events
+                    <h2 className="font-heading text-xs text-muted-foreground uppercase">
+                      ■ Past events
                     </h2>
                     <span className="font-mono text-xs text-muted-dim tabular-nums">
                       {String(past.length).padStart(2, "0")}

--- a/components/ClaimPage.tsx
+++ b/components/ClaimPage.tsx
@@ -249,7 +249,7 @@ export default function ClaimPage({
               >
             <Card
               inert={showQr || undefined}
-              className="pixel-frame gap-0 py-0 backface-hidden [grid-area:1/1] [--card-spacing:--spacing(6)] sm:[--card-spacing:--spacing(8)]"
+              className="pixel-frame gap-0 rounded-none py-0 shadow-[4px_4px_0_0_var(--foreground)] backface-hidden [grid-area:1/1] [--card-spacing:--spacing(6)] sm:[--card-spacing:--spacing(8)]"
             >
               {/* Cabinet marquee across the top of the "machine". */}
               <div className="bg-marquee-stripes h-2 shrink-0" aria-hidden />
@@ -585,7 +585,7 @@ function QrPanel({
   return (
     <Card
       inert={hidden || undefined}
-      className="pixel-frame gap-0 rotate-y-180 py-0 backface-hidden [grid-area:1/1] [--card-spacing:--spacing(6)] sm:[--card-spacing:--spacing(8)]"
+      className="pixel-frame gap-0 rotate-y-180 rounded-none py-0 shadow-[4px_4px_0_0_var(--foreground)] backface-hidden [grid-area:1/1] [--card-spacing:--spacing(6)] sm:[--card-spacing:--spacing(8)]"
     >
       <div className="bg-marquee-stripes h-2 shrink-0" aria-hidden />
       <CardHeader className="gap-2 pt-(--card-spacing)">

--- a/components/ClaimPage.tsx
+++ b/components/ClaimPage.tsx
@@ -249,11 +249,13 @@ export default function ClaimPage({
               >
             <Card
               inert={showQr || undefined}
-              className="gap-0 py-0 backface-hidden [grid-area:1/1] [--card-spacing:--spacing(6)] sm:[--card-spacing:--spacing(8)]"
+              className="pixel-frame gap-0 py-0 backface-hidden [grid-area:1/1] [--card-spacing:--spacing(6)] sm:[--card-spacing:--spacing(8)]"
             >
+              {/* Cabinet marquee across the top of the "machine". */}
+              <div className="bg-marquee-stripes h-2 shrink-0" aria-hidden />
               <CardHeader className="gap-4 pt-(--card-spacing)">
                 <div className="flex items-start justify-between gap-3">
-                  <CardTitle className="font-heading text-3xl font-semibold tracking-[-0.02em] text-balance">
+                  <CardTitle className="font-heading text-lg leading-relaxed text-balance sm:text-xl">
                     {event.name}
                   </CardTitle>
                   <Button
@@ -311,7 +313,11 @@ export default function ClaimPage({
                       only dispensed to verified addresses.
                     </p>
                     <SignInButton mode="modal">
-                      <Button variant="brand" size="lg" className="w-full">
+                      <Button
+                        variant="brand"
+                        size="lg"
+                        className="arcade-bounce w-full"
+                      >
                         <LogIn data-icon="inline-start" />
                         Sign in to claim
                       </Button>
@@ -472,7 +478,7 @@ export default function ClaimPage({
                       variant="brand"
                       size="lg"
                       disabled={submitting || (mustChoose && !selectedType)}
-                      className="w-full"
+                      className="arcade-bounce w-full"
                       onClick={handleClaim}
                       aria-busy={submitting}
                       aria-live="polite"
@@ -483,7 +489,7 @@ export default function ClaimPage({
                           Checking the list...
                         </>
                       ) : (
-                        "Dispense my code"
+                        "\u25b6 Dispense my code"
                       )}
                     </Button>
                     {event.claimInstructions ? (
@@ -579,13 +585,14 @@ function QrPanel({
   return (
     <Card
       inert={hidden || undefined}
-      className="gap-0 rotate-y-180 py-0 backface-hidden [grid-area:1/1] [--card-spacing:--spacing(6)] sm:[--card-spacing:--spacing(8)]"
+      className="pixel-frame gap-0 rotate-y-180 py-0 backface-hidden [grid-area:1/1] [--card-spacing:--spacing(6)] sm:[--card-spacing:--spacing(8)]"
     >
+      <div className="bg-marquee-stripes h-2 shrink-0" aria-hidden />
       <CardHeader className="gap-2 pt-(--card-spacing)">
         <div className="flex items-start justify-between gap-3">
           <div className="flex flex-col gap-2">
             <span className="eyebrow text-muted-foreground">Scan to claim</span>
-            <CardTitle className="font-heading text-2xl font-semibold tracking-[-0.02em] text-balance">
+            <CardTitle className="font-heading text-base leading-relaxed text-balance sm:text-lg">
               {eventName}
             </CardTitle>
           </div>
@@ -645,9 +652,10 @@ function Receipt({
 }) {
   return (
     <div
-      className="receipt-edge receipt-print rounded-t-xl border border-border bg-surface pb-10 motion-reduce:animate-none"
+      className="receipt-edge receipt-print border-2 border-foreground bg-surface pb-10 motion-reduce:animate-none"
       role="status"
     >
+      <div className="bg-marquee-stripes h-2" aria-hidden />
       <div className="flex flex-col gap-6 p-6 sm:p-8">
         <div className="flex items-center justify-between">
           <span className="eyebrow text-muted-foreground">
@@ -660,7 +668,7 @@ function Receipt({
         </div>
 
         <div>
-          <h1 className="font-heading text-2xl font-semibold tracking-tight text-balance">
+          <h1 className="font-heading text-lg leading-relaxed text-balance sm:text-xl">
             {eventName}
           </h1>
           {creditAmount ? (
@@ -689,7 +697,12 @@ function Receipt({
         </div>
 
         <div className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500 delay-[450ms] flex flex-col gap-2 motion-reduce:animate-none">
-          <Button variant="brand" size="lg" onClick={() => onCopy(code)}>
+          <Button
+            variant="brand"
+            size="lg"
+            className="arcade-bounce"
+            onClick={() => onCopy(code)}
+          >
             {copied ? (
               <>
                 <Check


### PR DESCRIPTION
## Summary
Design-direction exploration: PLAYFUL ARCADE / PIXEL — 8-bit typography, game-cabinet framing, and bouncy micro-interactions across the home and claim pages. All functionality unchanged; styling only.

- `layout.tsx`: loads `Press_Start_2P` as `--font-arcade`; `globals.css` points `--font-heading` at it, so all headings render in the 8-bit face (sizes tuned down since the face runs large).
- `globals.css` adds arcade tokens/utilities: `--arcade-accent`/`--arcade-accent-2`, `pixel-frame` (square corners + 2px border + hard 4px offset shadow), `bg-scanlines` (faint CRT lines), `bg-marquee-stripes` (angled cabinet-marquee stripes), `animate-arcade-blink` (steps() attract-mode blink), `arcade-bounce` (springy hover/press, respects reduced motion).
- Home: hero becomes the cabinet "screen" — scanline overlay, blinking block cursor after the headline, blinking "● INSERT COIN — PRESS START" line, marquee stripe under the hero; event rows get a `▶` pointer that nudges on hover; section labels ("★ Active events") in the pixel face.
- Claim page: claim/QR cards get `pixel-frame` + marquee stripe tops, brand buttons get `arcade-bounce`, dispense button reads "▶ Dispense my code", receipt swaps rounded corners for a hard 2px frame + marquee stripe.

Base for the 5 colorway PRs that will target this branch.

Note: `npm run lint` and `npx tsc --noEmit` pass; local `next build` fails only on missing Convex env (pre-existing).

Link to Devin session: https://app.devin.ai/sessions/fe8534bb2ae64e838cd9a2171c2886ca
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/155" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->