### PR TITLE
Playful Arcade colorway: Retro NES

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,59 +4,58 @@
 
 @custom-variant dark (&:is(.dark *));
 
-/* Light mode (default) — "Paper": a white page field with warm off-neutrals
-   in the tints and borders rather than the pure grey axis, and ink (#22211E)
-   instead of near-black so text stays short of a harsh 19:1. Surface is a
-   neutral grey one step off white — hovers and the receipt stub read as a
-   quiet press of the field rather than a cream block. The blue accent is
+/* Light mode (default) — "Retro NES": the console shell itself. A two-tone
+   grey field (the light case grey over slightly darker panel grey) with
+   near-black ink, NES red as the one loud accent, and the rest of the 8-bit
+   primaries (blue, gold) kept muted like faded cartridge labels. The blue is
    reserved for the claim flow only. */
 :root {
-  --surface: #f6f6f6;
-  --surface-hover: #f0f0f0;
-  --border: #eae7df;
-  --border-strong: #d5cfc2;
-  --muted: #f1efe8;
-  --muted-dim: #78716a;
-  --background: #ffffff;
-  --foreground: #22211e;
-  --card: #ffffff;
-  --card-foreground: #22211e;
-  --popover: #ffffff;
-  --popover-foreground: #22211e;
-  --primary: #22211e;
-  --primary-foreground: #faf9f5;
-  --secondary: #f1efe8;
-  --secondary-foreground: #22211e;
-  --muted-foreground: #57534a;
-  --accent: #f1efe8;
-  --accent-foreground: #22211e;
+  --surface: #e6e5e2;
+  --surface-hover: #dedddA;
+  --border: #d3d2ce;
+  --border-strong: #adaca7;
+  --muted: #e2e1de;
+  --muted-dim: #6c6b67;
+  --background: #f0efec;
+  --foreground: #1c1c1c;
+  --card: #f0efec;
+  --card-foreground: #1c1c1c;
+  --popover: #f6f5f3;
+  --popover-foreground: #1c1c1c;
+  --primary: #1c1c1c;
+  --primary-foreground: #f0efec;
+  --secondary: #e2e1de;
+  --secondary-foreground: #1c1c1c;
+  --muted-foreground: #52514e;
+  --accent: #e2e1de;
+  --accent-foreground: #1c1c1c;
   --destructive: oklch(0.577 0.245 27.325);
   --input: oklch(0 0 0 / 8%);
-  --brand: #2200ff;
+  --brand: #2c4bbf;
   --brand-foreground: #ffffff;
-  --ring: #44403a;
-  --arcade-accent: #ff2e88;
-  --arcade-accent-2: #ffc700;
-  --selection: #e6e1d5;
-  --selection-foreground: #22211e;
+  --ring: #3c3b38;
+  --arcade-accent: #c11a24;
+  --arcade-accent-2: #d19a1a;
+  --selection: #d0cfcb;
+  --selection-foreground: #1c1c1c;
   /* Soft two-layer card shadow: invisible as "shadow", read as depth. Dark
      mode zeroes it out and relies on surface contrast instead. */
   --shadow-card:
-    0 1px 2px rgb(34 33 30 / 0.04), 0 4px 12px -2px rgb(34 33 30 / 0.04);
+    0 1px 2px rgb(28 28 28 / 0.05), 0 4px 12px -2px rgb(28 28 28 / 0.05);
   --chart-1: oklch(0.269 0 0);
   --chart-2: oklch(0.439 0 0);
   --chart-3: oklch(0.556 0 0);
   --chart-4: oklch(0.708 0 0);
   --chart-5: oklch(0.87 0 0);
   --radius: 0.625rem;
-  --sidebar: #ffffff;
-  --sidebar-foreground: #22211e;
-  --sidebar-primary: #22211e;
-  --sidebar-primary-foreground: #faf9f5;
-  --sidebar-accent: #f1efe8;
-  --sidebar-accent-foreground: #22211e;
-  --sidebar-border: #e7e3da;
-  --sidebar-ring: #78716a;
+  --sidebar: #f0efec;
+  --sidebar-foreground: #1c1c1c;
+  --sidebar-primary: #1c1c1c;
+  --sidebar-primary-foreground: #f0efec;
+  --sidebar-accent: #e2e1de;
+  --sidebar-accent-foreground: #1c1c1c;
+  --sidebar-border: #d3d2ce;
+  --sidebar-ring: #6c6b67;
 }
 
 @theme inline {
@@ -249,52 +248,52 @@ input:-webkit-autofill:focus {
   }
 }
 
-/* Dark mode — "Paper" after dark: the near-black picks up a faint cool cast
-   while the text stays warm off-white, and contrast drops from 18:1 to ~16:1
-   to stop white type haloing on OLED. */
+/* Dark mode — "Retro NES" after dark: the console's black faceplate. Flat
+   near-black greys, console-grey text, the NES red and gold accents lifted
+   just enough to hold contrast on the dark field. */
 .dark {
-  --surface: #141416;
-  --surface-hover: #1a1a1d;
-  --border: #26262a;
-  --border-strong: #3a3a40;
-  --muted: #212125;
-  --muted-dim: #7a7772;
-  --background: #0c0c0e;
-  --foreground: #e8e6e1;
-  --card: #141416;
-  --card-foreground: #e8e6e1;
-  --popover: #1a1a1d;
-  --popover-foreground: #e8e6e1;
-  --primary: #e8e6e1;
-  --primary-foreground: #0c0c0e;
-  --secondary: #2b2b30;
-  --secondary-foreground: #e8e6e1;
-  --muted-foreground: #a8a5a0;
-  --accent: #2b2b30;
-  --accent-foreground: #e8e6e1;
+  --surface: #161617;
+  --surface-hover: #1c1c1e;
+  --border: #29292b;
+  --border-strong: #414144;
+  --muted: #222224;
+  --muted-dim: #7c7b78;
+  --background: #0e0e0f;
+  --foreground: #dcdbd7;
+  --card: #161617;
+  --card-foreground: #dcdbd7;
+  --popover: #1c1c1e;
+  --popover-foreground: #dcdbd7;
+  --primary: #dcdbd7;
+  --primary-foreground: #0e0e0f;
+  --secondary: #2c2c2e;
+  --secondary-foreground: #dcdbd7;
+  --muted-foreground: #a5a4a0;
+  --accent: #2c2c2e;
+  --accent-foreground: #dcdbd7;
   --destructive: oklch(0.704 0.191 22.216);
   --input: oklch(1 0 0 / 15%);
-  --brand: #2200ff;
+  --brand: #5f7ad9;
   --brand-foreground: #ffffff;
-  --ring: #c4c1bb;
-  --arcade-accent: #ff2e88;
-  --arcade-accent-2: #ffc700;
-  --selection: #33333a;
-  --selection-foreground: #e8e6e1;
+  --ring: #c2c1bd;
+  --arcade-accent: #d5333c;
+  --arcade-accent-2: #e0ab24;
+  --selection: #35353a;
+  --selection-foreground: #dcdbd7;
   --shadow-card: 0 0 rgb(0 0 0 / 0);
   --chart-1: oklch(0.87 0 0);
   --chart-2: oklch(0.556 0 0);
   --chart-3: oklch(0.439 0 0);
   --chart-4: oklch(0.371 0 0);
   --chart-5: oklch(0.269 0 0);
-  --sidebar: #141416;
-  --sidebar-foreground: #e8e6e1;
-  --sidebar-primary: #e8e6e1;
-  --sidebar-primary-foreground: #0c0c0e;
-  --sidebar-accent: #2b2b30;
-  --sidebar-accent-foreground: #e8e6e1;
-  --sidebar-border: #26262a;
-  --sidebar-ring: #7a7772;
+  --sidebar: #161617;
+  --sidebar-foreground: #dcdbd7;
+  --sidebar-primary: #dcdbd7;
+  --sidebar-primary-foreground: #0e0e0f;
+  --sidebar-accent: #2c2c2e;
+  --sidebar-accent-foreground: #dcdbd7;
+  --sidebar-border: #29292b;
+  --sidebar-ring: #7c7b78;
 }
 
 @layer base {


### PR DESCRIPTION
## Summary
Applies the "Retro NES" colorway to the Playful Arcade direction — CSS-variable changes in `app/globals.css` only, no markup or functionality changes.

- Light mode: console-shell greys (`--background: #f0efec`, `--surface: #e6e5e2`, grey borders) with near-black ink `#1c1c1c`.
- Dark mode: flat black faceplate greys (`#0e0e0f` / `#161617`) with console-grey text `#dcdbd7`.
- Muted 8-bit primaries: `--arcade-accent` NES red (`#c11a24` light / `#d5333c` dark), `--arcade-accent-2` gold (`#d19a1a` / `#e0ab24`) — these drive the `bg-marquee-stripes` utility; `--brand` becomes muted NES blue (`#2c4bbf` / `#5f7ad9`), still reserved for the claim flow.

Lint and `tsc --noEmit` pass.

Link to Devin session: https://app.devin.ai/sessions/a13655b804c746bebfec4b334b8c33c6
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/156" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->