### PR TITLE
Playful Arcade colorway: Vaporwave

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,59 +4,56 @@
 
 @custom-variant dark (&:is(.dark *));
 
-/* Light mode (default) — "Paper": a white page field with warm off-neutrals
-   in the tints and borders rather than the pure grey axis, and ink (#22211E)
-   instead of near-black so text stays short of a harsh 19:1. Surface is a
-   neutral grey one step off white — hovers and the receipt stub read as a
-   quiet press of the field rather than a cream block. The blue accent is
-   reserved for the claim flow only. */
+/* Light mode — "Vaporwave dawn": a pale lavender page field with cool
+   pink-violet tints, deep indigo-purple ink, and a sunset palette: hot
+   magenta brand, teal/pink neon arcade accents. */
 :root {
-  --surface: #f6f6f6;
-  --surface-hover: #f0f0f0;
-  --border: #eae7df;
-  --border-strong: #d5cfc2;
-  --muted: #f1efe8;
-  --muted-dim: #78716a;
-  --background: #ffffff;
-  --foreground: #22211e;
-  --card: #ffffff;
-  --card-foreground: #22211e;
-  --popover: #ffffff;
-  --popover-foreground: #22211e;
-  --primary: #22211e;
-  --primary-foreground: #faf9f5;
-  --secondary: #f1efe8;
-  --secondary-foreground: #22211e;
-  --muted-foreground: #57534a;
-  --accent: #f1efe8;
-  --accent-foreground: #22211e;
+  --surface: #f4effc;
+  --surface-hover: #ece4f9;
+  --border: #e4d9f3;
+  --border-strong: #c9b6e4;
+  --muted: #efe7fa;
+  --muted-dim: #7b6a99;
+  --background: #fbf8ff;
+  --foreground: #2b1b4d;
+  --card: #fbf8ff;
+  --card-foreground: #2b1b4d;
+  --popover: #fbf8ff;
+  --popover-foreground: #2b1b4d;
+  --primary: #2b1b4d;
+  --primary-foreground: #fdf6ff;
+  --secondary: #efe7fa;
+  --secondary-foreground: #2b1b4d;
+  --muted-foreground: #5c4a80;
+  --accent: #efe7fa;
+  --accent-foreground: #2b1b4d;
   --destructive: oklch(0.577 0.245 27.325);
   --input: oklch(0 0 0 / 8%);
-  --brand: #2200ff;
+  --brand: #d5008f;
   --brand-foreground: #ffffff;
-  --ring: #44403a;
-  --arcade-accent: #ff2e88;
-  --arcade-accent-2: #ffc700;
-  --selection: #e6e1d5;
-  --selection-foreground: #22211e;
+  --ring: #4d3b73;
+  --arcade-accent: #ff4fd8;
+  --arcade-accent-2: #00c2c7;
+  --selection: #e6d3f5;
+  --selection-foreground: #2b1b4d;
   /* Soft two-layer card shadow: invisible as "shadow", read as depth. Dark
      mode zeroes it out and relies on surface contrast instead. */
   --shadow-card:
-    0 1px 2px rgb(34 33 30 / 0.04), 0 4px 12px -2px rgb(34 33 30 / 0.04);
+    0 1px 2px rgb(43 27 77 / 0.05), 0 4px 12px -2px rgb(43 27 77 / 0.05);
   --chart-1: oklch(0.269 0 0);
   --chart-2: oklch(0.439 0 0);
   --chart-3: oklch(0.556 0 0);
   --chart-4: oklch(0.708 0 0);
   --chart-5: oklch(0.87 0 0);
   --radius: 0.625rem;
-  --sidebar: #ffffff;
-  --sidebar-foreground: #22211e;
-  --sidebar-primary: #22211e;
-  --sidebar-primary-foreground: #faf9f5;
-  --sidebar-accent: #f1efe8;
-  --sidebar-accent-foreground: #22211e;
-  --sidebar-border: #e7e3da;
-  --sidebar-ring: #78716a;
+  --sidebar: #fbf8ff;
+  --sidebar-foreground: #2b1b4d;
+  --sidebar-primary: #2b1b4d;
+  --sidebar-primary-foreground: #fdf6ff;
+  --sidebar-accent: #efe7fa;
+  --sidebar-accent-foreground: #2b1b4d;
+  --sidebar-border: #e4d9f3;
+  --sidebar-ring: #7b6a99;
 }
 
 @theme inline {
@@ -249,52 +246,51 @@ input:-webkit-autofill:focus {
   }
 }
 
-/* Dark mode — "Paper" after dark: the near-black picks up a faint cool cast
-   while the text stays warm off-white, and contrast drops from 18:1 to ~16:1
-   to stop white type haloing on OLED. */
+/* Dark mode — "Vaporwave dusk": deep purple night field with violet-tinted
+   surfaces, pale lilac type, and the neon pink/teal accents turned up. */
 .dark {
-  --surface: #141416;
-  --surface-hover: #1a1a1d;
-  --border: #26262a;
-  --border-strong: #3a3a40;
-  --muted: #212125;
-  --muted-dim: #7a7772;
-  --background: #0c0c0e;
-  --foreground: #e8e6e1;
-  --card: #141416;
-  --card-foreground: #e8e6e1;
-  --popover: #1a1a1d;
-  --popover-foreground: #e8e6e1;
-  --primary: #e8e6e1;
-  --primary-foreground: #0c0c0e;
-  --secondary: #2b2b30;
-  --secondary-foreground: #e8e6e1;
-  --muted-foreground: #a8a5a0;
-  --accent: #2b2b30;
-  --accent-foreground: #e8e6e1;
+  --surface: #1c1233;
+  --surface-hover: #241940;
+  --border: #322353;
+  --border-strong: #4a3575;
+  --muted: #281b45;
+  --muted-dim: #9a8ac0;
+  --background: #120a24;
+  --foreground: #ece4f8;
+  --card: #1c1233;
+  --card-foreground: #ece4f8;
+  --popover: #241940;
+  --popover-foreground: #ece4f8;
+  --primary: #ece4f8;
+  --primary-foreground: #120a24;
+  --secondary: #322353;
+  --secondary-foreground: #ece4f8;
+  --muted-foreground: #b9abd9;
+  --accent: #322353;
+  --accent-foreground: #ece4f8;
   --destructive: oklch(0.704 0.191 22.216);
   --input: oklch(1 0 0 / 15%);
-  --brand: #2200ff;
-  --brand-foreground: #ffffff;
-  --ring: #c4c1bb;
-  --arcade-accent: #ff2e88;
-  --arcade-accent-2: #ffc700;
-  --selection: #33333a;
-  --selection-foreground: #e8e6e1;
+  --brand: #ff54d7;
+  --brand-foreground: #23052e;
+  --ring: #cabbe8;
+  --arcade-accent: #ff54d7;
+  --arcade-accent-2: #22e0e4;
+  --selection: #45306e;
+  --selection-foreground: #ece4f8;
   --shadow-card: 0 0 rgb(0 0 0 / 0);
   --chart-1: oklch(0.87 0 0);
   --chart-2: oklch(0.556 0 0);
   --chart-3: oklch(0.439 0 0);
   --chart-4: oklch(0.371 0 0);
   --chart-5: oklch(0.269 0 0);
-  --sidebar: #141416;
-  --sidebar-foreground: #e8e6e1;
-  --sidebar-primary: #e8e6e1;
-  --sidebar-primary-foreground: #0c0c0e;
-  --sidebar-accent: #2b2b30;
-  --sidebar-accent-foreground: #e8e6e1;
-  --sidebar-border: #26262a;
-  --sidebar-ring: #7a7772;
+  --sidebar: #1c1233;
+  --sidebar-foreground: #ece4f8;
+  --sidebar-primary: #ece4f8;
+  --sidebar-primary-foreground: #120a24;
+  --sidebar-accent: #322353;
+  --sidebar-accent-foreground: #ece4f8;
+  --sidebar-border: #322353;
+  --sidebar-ring: #9a8ac0;
 }
 
 @layer base {


### PR DESCRIPTION
## Summary
Applies a Vaporwave colorway to the Playful Arcade direction — CSS-variable-only change in `app/globals.css` (no markup/logic changes).

- Light mode (`:root`): pale lavender field (`#fbf8ff` bg, lavender surfaces/borders), deep indigo-purple ink (`#2b1b4d`), magenta brand (`#d5008f`)
- Dark mode (`.dark`): deep purple night (`#120a24` bg, violet surfaces), pale lilac type (`#ece4f8`), neon pink brand (`#ff54d7` on dark plum)
- Arcade accents (marquee stripes): neon pink `#ff4fd8` / teal `#00c2c7` (light), `#ff54d7` / `#22e0e4` (dark) — replacing pink/yellow

`npm run lint` and `npx tsc --noEmit` pass.

Link to Devin session: https://app.devin.ai/sessions/28884883db5c4bd68c0d45d24ed88ac9
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/157" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->