### PR TITLE
Playful Arcade colorway: Pastel Puzzle

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,45 +4,45 @@
 
 @custom-variant dark (&:is(.dark *));
 
-/* Light mode (default) — "Paper": a white page field with warm off-neutrals
-   in the tints and borders rather than the pure grey axis, and ink (#22211E)
-   instead of near-black so text stays short of a harsh 19:1. Surface is a
-   neutral grey one step off white — hovers and the receipt stub read as a
-   quiet press of the field rather than a cream block. The blue accent is
-   reserved for the claim flow only. */
+/* Light mode (default) — "Pastel Puzzle": a soft candy-shop field of mint,
+   lavender, baby blue and lemon, in the gentle key of a Kirby/Puyo puzzle
+   game. The page sits on a mint-tinted white, tints and borders lean
+   lavender rather than grey, and the ink is a deep plum so text stays soft
+   but readable. Brand is a saturated puzzle-purple; the marquee stripes
+   alternate mint and lemon pastels, and selection is baby blue. */
 :root {
-  --surface: #f6f6f6;
-  --surface-hover: #f0f0f0;
-  --border: #eae7df;
-  --border-strong: #d5cfc2;
-  --muted: #f1efe8;
-  --muted-dim: #78716a;
-  --background: #ffffff;
-  --foreground: #22211e;
+  --surface: #f3f8f2;
+  --surface-hover: #eaf3ea;
+  --border: #e3e0f2;
+  --border-strong: #c9c3e6;
+  --muted: #eef0fa;
+  --muted-dim: #7b7590;
+  --background: #fbfdfa;
+  --foreground: #3a3352;
   --card: #ffffff;
-  --card-foreground: #22211e;
+  --card-foreground: #3a3352;
   --popover: #ffffff;
-  --popover-foreground: #22211e;
-  --primary: #22211e;
-  --primary-foreground: #faf9f5;
-  --secondary: #f1efe8;
-  --secondary-foreground: #22211e;
-  --muted-foreground: #57534a;
-  --accent: #f1efe8;
-  --accent-foreground: #22211e;
+  --popover-foreground: #3a3352;
+  --primary: #3a3352;
+  --primary-foreground: #f7fbf5;
+  --secondary: #eef0fa;
+  --secondary-foreground: #3a3352;
+  --muted-foreground: #5f5878;
+  --accent: #e4f4ec;
+  --accent-foreground: #3a3352;
   --destructive: oklch(0.577 0.245 27.325);
   --input: oklch(0 0 0 / 8%);
-  --brand: #2200ff;
+  --brand: #7c6bd6;
   --brand-foreground: #ffffff;
-  --ring: #44403a;
-  --arcade-accent: #ff2e88;
-  --arcade-accent-2: #ffc700;
-  --selection: #e6e1d5;
-  --selection-foreground: #22211e;
+  --ring: #7c6bd6;
+  --arcade-accent: #a5e6c3;
+  --arcade-accent-2: #f7edb2;
+  --selection: #d9ecf9;
+  --selection-foreground: #3a3352;
   /* Soft two-layer card shadow: invisible as "shadow", read as depth. Dark
      mode zeroes it out and relies on surface contrast instead. */
   --shadow-card:
-    0 1px 2px rgb(34 33 30 / 0.04), 0 4px 12px -2px rgb(34 33 30 / 0.04);
+    0 1px 2px rgb(58 51 82 / 0.05), 0 4px 12px -2px rgb(58 51 82 / 0.05);
   --chart-1: oklch(0.269 0 0);
   --chart-2: oklch(0.439 0 0);
   --chart-3: oklch(0.556 0 0);
@@ -50,13 +50,13 @@
   --chart-5: oklch(0.87 0 0);
   --radius: 0.625rem;
   --sidebar: #ffffff;
-  --sidebar-foreground: #22211e;
-  --sidebar-primary: #22211e;
-  --sidebar-primary-foreground: #faf9f5;
-  --sidebar-accent: #f1efe8;
-  --sidebar-accent-foreground: #22211e;
-  --sidebar-border: #e7e3da;
-  --sidebar-ring: #78716a;
+  --sidebar-foreground: #3a3352;
+  --sidebar-primary: #3a3352;
+  --sidebar-primary-foreground: #f7fbf5;
+  --sidebar-accent: #eef0fa;
+  --sidebar-accent-foreground: #3a3352;
+  --sidebar-border: #e3e0f2;
+  --sidebar-ring: #7b7590;
 }
 
 @theme inline {
@@ -249,52 +249,53 @@ input:-webkit-autofill:focus {
   }
 }
 
-/* Dark mode — "Paper" after dark: the near-black picks up a faint cool cast
-   while the text stays warm off-white, and contrast drops from 18:1 to ~16:1
-   to stop white type haloing on OLED. */
+/* Dark mode — "Pastel Puzzle" after dark: a dusky indigo-plum field rather
+   than pure black, with the pastels kept as soft glows — text is a pale
+   lavender-white, and the mint/lavender accents brighten slightly to stay
+   candy-like against the deep ground. */
 .dark {
-  --surface: #141416;
-  --surface-hover: #1a1a1d;
-  --border: #26262a;
-  --border-strong: #3a3a40;
-  --muted: #212125;
-  --muted-dim: #7a7772;
-  --background: #0c0c0e;
-  --foreground: #e8e6e1;
-  --card: #141416;
-  --card-foreground: #e8e6e1;
-  --popover: #1a1a1d;
-  --popover-foreground: #e8e6e1;
-  --primary: #e8e6e1;
-  --primary-foreground: #0c0c0e;
-  --secondary: #2b2b30;
-  --secondary-foreground: #e8e6e1;
-  --muted-foreground: #a8a5a0;
-  --accent: #2b2b30;
-  --accent-foreground: #e8e6e1;
+  --surface: #221f33;
+  --surface-hover: #2a2740;
+  --border: #322e4a;
+  --border-strong: #46415f;
+  --muted: #2a2740;
+  --muted-dim: #8d87a6;
+  --background: #181526;
+  --foreground: #e9e6f5;
+  --card: #221f33;
+  --card-foreground: #e9e6f5;
+  --popover: #2a2740;
+  --popover-foreground: #e9e6f5;
+  --primary: #e9e6f5;
+  --primary-foreground: #181526;
+  --secondary: #322e4a;
+  --secondary-foreground: #e9e6f5;
+  --muted-foreground: #b3adc9;
+  --accent: #322e4a;
+  --accent-foreground: #e9e6f5;
   --destructive: oklch(0.704 0.191 22.216);
   --input: oklch(1 0 0 / 15%);
-  --brand: #2200ff;
-  --brand-foreground: #ffffff;
-  --ring: #c4c1bb;
-  --arcade-accent: #ff2e88;
-  --arcade-accent-2: #ffc700;
-  --selection: #33333a;
-  --selection-foreground: #e8e6e1;
+  --brand: #a596ec;
+  --brand-foreground: #181526;
+  --ring: #a596ec;
+  --arcade-accent: #8fdcb2;
+  --arcade-accent-2: #ece0a0;
+  --selection: #3d3760;
+  --selection-foreground: #e9e6f5;
   --shadow-card: 0 0 rgb(0 0 0 / 0);
   --chart-1: oklch(0.87 0 0);
   --chart-2: oklch(0.556 0 0);
   --chart-3: oklch(0.439 0 0);
   --chart-4: oklch(0.371 0 0);
   --chart-5: oklch(0.269 0 0);
-  --sidebar: #141416;
-  --sidebar-foreground: #e8e6e1;
-  --sidebar-primary: #e8e6e1;
-  --sidebar-primary-foreground: #0c0c0e;
-  --sidebar-accent: #2b2b30;
-  --sidebar-accent-foreground: #e8e6e1;
-  --sidebar-border: #26262a;
-  --sidebar-ring: #7a7772;
+  --sidebar: #221f33;
+  --sidebar-foreground: #e9e6f5;
+  --sidebar-primary: #e9e6f5;
+  --sidebar-primary-foreground: #181526;
+  --sidebar-accent: #322e4a;
+  --sidebar-accent-foreground: #e9e6f5;
+  --sidebar-border: #322e4a;
+  --sidebar-ring: #8d87a6;
 }
 
 @layer base {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -189,7 +189,7 @@ export default function Home() {
               by project swaps it cleanly on theme change while the copy stays
               mounted. The scene's mouse interactivity listens on window, so
               the copy sitting above it doesn't block it. */}
-          <div className="relative h-[520px] overflow-hidden bg-background dark:bg-[#131313] sm:h-[486px]">
+          <div className="relative h-[520px] overflow-hidden bg-background dark:bg-[#1c1930] sm:h-[486px]">
             {heroProjectId ? (
               <div className="absolute inset-0" aria-hidden>
                 {/* Dev fetches fresh scene data on every load; deploys pin


### PR DESCRIPTION
## Summary
Applies the "Pastel Puzzle" colorway to the Playful Arcade direction — soft Kirby/Puyo-style pastels: mint, lavender, baby blue, lemon. Styling-only; all changes are CSS token swaps in `app/globals.css` (`:root` + `.dark`) plus one hardcoded hero background in `app/page.tsx`.

- Light: mint-white page (`--background: #fbfdfa`), lavender-leaning borders/tints, deep plum ink (`--foreground: #3a3352`), puzzle-purple `--brand: #7c6bd6`, baby-blue `--selection`.
- Marquee stripes (`bg-marquee-stripes`): `--arcade-accent` mint `#a5e6c3` / `--arcade-accent-2` lemon `#f7edb2`.
- Dark: dusky indigo-plum ground (`#181526`/`#221f33`) with pale lavender text and slightly brightened mint/lemon accents; `--brand` lightens to `#a596ec` with dark foreground for contrast.
- `app/page.tsx`: hero scene `dark:bg-[#131313]` → `dark:bg-[#1c1930]` to match the plum dark ground.

Lint and `tsc --noEmit` pass.

Link to Devin session: https://app.devin.ai/sessions/6d4f4a9ebc134e438895958c4d46bbe0
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/158" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->