### PR TITLE
Cyberpunk Neon colorway: Ultraviolet

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -9,37 +9,38 @@
    them. Default theme (no .dark class) is "night city": deep indigo-black
    field, cool blue-tinted neutrals. */
 :root {
-  /* Colorway: magenta / cyan / ultraviolet. Swap these three to re-skin. */
-  --neon-primary: #ff2ecb;
-  --neon-secondary: #00e5ff;
-  --neon-tertiary: #9d4dff;
+  /* Colorway: electric violet / lavender glow / deep indigo. Swap these
+     three to re-skin. */
+  --neon-primary: #8f00ff;
+  --neon-secondary: #c4b0ff;
+  --neon-tertiary: #3629b8;
 
-  --surface: #10101c;
-  --surface-hover: #161628;
-  --border: #20203a;
-  --border-strong: #34345c;
-  --muted: #16162a;
-  --muted-dim: #6b7a99;
-  --background: #0a0a14;
-  --foreground: #e8f0ff;
-  --card: #10101c;
-  --card-foreground: #e8f0ff;
-  --popover: #141424;
-  --popover-foreground: #e8f0ff;
-  --primary: #e8f0ff;
-  --primary-foreground: #0a0a14;
-  --secondary: #1c1c34;
-  --secondary-foreground: #e8f0ff;
-  --muted-foreground: #9aa8c7;
-  --accent: #1c1c34;
-  --accent-foreground: #e8f0ff;
+  --surface: #12101c;
+  --surface-hover: #191628;
+  --border: #24203a;
+  --border-strong: #3a345c;
+  --muted: #18162a;
+  --muted-dim: #746b99;
+  --background: #0c0a14;
+  --foreground: #ede8ff;
+  --card: #12101c;
+  --card-foreground: #ede8ff;
+  --popover: #161424;
+  --popover-foreground: #ede8ff;
+  --primary: #ede8ff;
+  --primary-foreground: #0c0a14;
+  --secondary: #201c34;
+  --secondary-foreground: #ede8ff;
+  --muted-foreground: #a49ac7;
+  --accent: #201c34;
+  --accent-foreground: #ede8ff;
   --destructive: oklch(0.704 0.191 22.216);
   --input: oklch(1 0 0 / 12%);
   --brand: var(--neon-primary);
   --brand-foreground: #ffffff;
   --ring: var(--neon-secondary);
-  --selection: #2a1a3e;
-  --selection-foreground: #e8f0ff;
+  --selection: #2e1a48;
+  --selection-foreground: #ede8ff;
   /* Cards read as glowing panels rather than shadowed paper. */
   --shadow-card:
     0 0 20px -8px color-mix(in srgb, var(--neon-primary) 35%, transparent),
@@ -50,14 +51,14 @@
   --chart-4: oklch(0.708 0 0);
   --chart-5: oklch(0.87 0 0);
   --radius: 0.625rem;
-  --sidebar: #10101c;
-  --sidebar-foreground: #e8f0ff;
-  --sidebar-primary: #e8f0ff;
-  --sidebar-primary-foreground: #0a0a14;
-  --sidebar-accent: #1c1c34;
-  --sidebar-accent-foreground: #e8f0ff;
-  --sidebar-border: #20203a;
-  --sidebar-ring: #6b7a99;
+  --sidebar: #12101c;
+  --sidebar-foreground: #ede8ff;
+  --sidebar-primary: #ede8ff;
+  --sidebar-primary-foreground: #0c0a14;
+  --sidebar-accent: #201c34;
+  --sidebar-accent-foreground: #ede8ff;
+  --sidebar-border: #24203a;
+  --sidebar-ring: #746b99;
 }
 
 @theme inline {
@@ -290,32 +291,32 @@ input:-webkit-autofill:focus {
    black field for OLED. The neon hues stay identical; only the neutrals
    sink. */
 .dark {
-  --surface: #0b0b15;
-  --surface-hover: #121220;
-  --border: #1a1a30;
-  --border-strong: #2c2c50;
-  --muted: #111120;
-  --muted-dim: #5e6c8c;
-  --background: #050509;
-  --foreground: #e8f0ff;
-  --card: #0b0b15;
-  --card-foreground: #e8f0ff;
-  --popover: #10101e;
-  --popover-foreground: #e8f0ff;
-  --primary: #e8f0ff;
-  --primary-foreground: #050509;
-  --secondary: #17172b;
-  --secondary-foreground: #e8f0ff;
-  --muted-foreground: #93a2c2;
-  --accent: #17172b;
-  --accent-foreground: #e8f0ff;
+  --surface: #0d0b15;
+  --surface-hover: #141220;
+  --border: #1d1a30;
+  --border-strong: #302c50;
+  --muted: #131120;
+  --muted-dim: #665e8c;
+  --background: #060509;
+  --foreground: #ede8ff;
+  --card: #0d0b15;
+  --card-foreground: #ede8ff;
+  --popover: #12101e;
+  --popover-foreground: #ede8ff;
+  --primary: #ede8ff;
+  --primary-foreground: #060509;
+  --secondary: #19172b;
+  --secondary-foreground: #ede8ff;
+  --muted-foreground: #9d93c2;
+  --accent: #19172b;
+  --accent-foreground: #ede8ff;
   --destructive: oklch(0.704 0.191 22.216);
   --input: oklch(1 0 0 / 15%);
   --brand: var(--neon-primary);
   --brand-foreground: #ffffff;
   --ring: var(--neon-secondary);
-  --selection: #241536;
-  --selection-foreground: #e8f0ff;
+  --selection: #281540;
+  --selection-foreground: #ede8ff;
   --shadow-card:
     0 0 24px -8px color-mix(in srgb, var(--neon-primary) 40%, transparent),
     0 0 48px -16px color-mix(in srgb, var(--neon-secondary) 30%, transparent);
@@ -324,14 +325,14 @@ input:-webkit-autofill:focus {
   --chart-3: var(--neon-tertiary);
   --chart-4: oklch(0.371 0 0);
   --chart-5: oklch(0.269 0 0);
-  --sidebar: #0b0b15;
-  --sidebar-foreground: #e8f0ff;
-  --sidebar-primary: #e8f0ff;
-  --sidebar-primary-foreground: #050509;
-  --sidebar-accent: #17172b;
-  --sidebar-accent-foreground: #e8f0ff;
-  --sidebar-border: #1a1a30;
-  --sidebar-ring: #5e6c8c;
+  --sidebar: #0d0b15;
+  --sidebar-foreground: #ede8ff;
+  --sidebar-primary: #ede8ff;
+  --sidebar-primary-foreground: #060509;
+  --sidebar-accent: #19172b;
+  --sidebar-accent-foreground: #ede8ff;
+  --sidebar-border: #1d1a30;
+  --sidebar-ring: #665e8c;
 }
 
 @layer base {


### PR DESCRIPTION
## Summary
Pure palette variation of the Cyberpunk Neon theme (`app/globals.css` only — no layout/component changes).

Colorway vars:
```
--neon-primary:   #ff2ecb → #8f00ff  (electric violet)
--neon-secondary: #00e5ff → #c4b0ff  (lavender/periwinkle glow)
--neon-tertiary:  #9d4dff → #3629b8  (deep indigo)
```

Tinted neutrals in `:root` and `.dark` (background/surface/border/muted/selection/sidebar, plus the `#e8f0ff → #ede8ff` foregrounds) are shifted from blue-tinted toward violet-black for cohesion; all derived glows/panels pick up the new hues automatically via `color-mix` on the neon vars.

Lint and `tsc --noEmit` pass.

Link to Devin session: https://app.devin.ai/sessions/6babeeae14034719b72e827db797bb1e
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/163" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->