### PR TITLE
Cyberpunk Neon colorway: Toxic Green

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -6,40 +6,40 @@
 
 /* Cyberpunk Neon — a dark HUD field with neon accents. The colorway is
    defined by the three --neon-* hues below; everything else derives from
-   them. Default theme (no .dark class) is "night city": deep indigo-black
-   field, cool blue-tinted neutrals. */
+   them. Default theme (no .dark class) is "toxic spill": deep green-black
+   field, green-tinted neutrals. */
 :root {
-  /* Colorway: magenta / cyan / ultraviolet. Swap these three to re-skin. */
-  --neon-primary: #ff2ecb;
-  --neon-secondary: #00e5ff;
-  --neon-tertiary: #9d4dff;
+  /* Colorway: acid green / chartreuse-lime / hazard yellow-green. Swap these three to re-skin. */
+  --neon-primary: #39ff14;
+  --neon-secondary: #ccff33;
+  --neon-tertiary: #9acd00;
 
-  --surface: #10101c;
-  --surface-hover: #161628;
-  --border: #20203a;
-  --border-strong: #34345c;
-  --muted: #16162a;
-  --muted-dim: #6b7a99;
-  --background: #0a0a14;
-  --foreground: #e8f0ff;
-  --card: #10101c;
-  --card-foreground: #e8f0ff;
-  --popover: #141424;
-  --popover-foreground: #e8f0ff;
-  --primary: #e8f0ff;
-  --primary-foreground: #0a0a14;
-  --secondary: #1c1c34;
-  --secondary-foreground: #e8f0ff;
-  --muted-foreground: #9aa8c7;
-  --accent: #1c1c34;
-  --accent-foreground: #e8f0ff;
+  --surface: #0e1a0e;
+  --surface-hover: #142614;
+  --border: #1e3a1e;
+  --border-strong: #2f5c2f;
+  --muted: #142a14;
+  --muted-dim: #6b996b;
+  --background: #081408;
+  --foreground: #e8ffe8;
+  --card: #0e1a0e;
+  --card-foreground: #e8ffe8;
+  --popover: #122412;
+  --popover-foreground: #e8ffe8;
+  --primary: #e8ffe8;
+  --primary-foreground: #081408;
+  --secondary: #1a341a;
+  --secondary-foreground: #e8ffe8;
+  --muted-foreground: #9ac79a;
+  --accent: #1a341a;
+  --accent-foreground: #e8ffe8;
   --destructive: oklch(0.704 0.191 22.216);
   --input: oklch(1 0 0 / 12%);
   --brand: var(--neon-primary);
   --brand-foreground: #ffffff;
   --ring: var(--neon-secondary);
-  --selection: #2a1a3e;
-  --selection-foreground: #e8f0ff;
+  --selection: #1a3e1a;
+  --selection-foreground: #e8ffe8;
   /* Cards read as glowing panels rather than shadowed paper. */
   --shadow-card:
     0 0 20px -8px color-mix(in srgb, var(--neon-primary) 35%, transparent),
@@ -50,14 +50,14 @@
   --chart-4: oklch(0.708 0 0);
   --chart-5: oklch(0.87 0 0);
   --radius: 0.625rem;
-  --sidebar: #10101c;
-  --sidebar-foreground: #e8f0ff;
-  --sidebar-primary: #e8f0ff;
-  --sidebar-primary-foreground: #0a0a14;
-  --sidebar-accent: #1c1c34;
-  --sidebar-accent-foreground: #e8f0ff;
-  --sidebar-border: #20203a;
-  --sidebar-ring: #6b7a99;
+  --sidebar: #0e1a0e;
+  --sidebar-foreground: #e8ffe8;
+  --sidebar-primary: #e8ffe8;
+  --sidebar-primary-foreground: #081408;
+  --sidebar-accent: #1a341a;
+  --sidebar-accent-foreground: #e8ffe8;
+  --sidebar-border: #1e3a1e;
+  --sidebar-ring: #6b996b;
 }
 
 @theme inline {
@@ -290,32 +290,32 @@ input:-webkit-autofill:focus {
    black field for OLED. The neon hues stay identical; only the neutrals
    sink. */
 .dark {
-  --surface: #0b0b15;
-  --surface-hover: #121220;
-  --border: #1a1a30;
-  --border-strong: #2c2c50;
-  --muted: #111120;
-  --muted-dim: #5e6c8c;
-  --background: #050509;
-  --foreground: #e8f0ff;
-  --card: #0b0b15;
-  --card-foreground: #e8f0ff;
-  --popover: #10101e;
-  --popover-foreground: #e8f0ff;
-  --primary: #e8f0ff;
-  --primary-foreground: #050509;
-  --secondary: #17172b;
-  --secondary-foreground: #e8f0ff;
-  --muted-foreground: #93a2c2;
-  --accent: #17172b;
-  --accent-foreground: #e8f0ff;
+  --surface: #0a150a;
+  --surface-hover: #102010;
+  --border: #183018;
+  --border-strong: #285028;
+  --muted: #0f200f;
+  --muted-dim: #5e8c5e;
+  --background: #050905;
+  --foreground: #e8ffe8;
+  --card: #0a150a;
+  --card-foreground: #e8ffe8;
+  --popover: #0e1e0e;
+  --popover-foreground: #e8ffe8;
+  --primary: #e8ffe8;
+  --primary-foreground: #050905;
+  --secondary: #152b15;
+  --secondary-foreground: #e8ffe8;
+  --muted-foreground: #93c293;
+  --accent: #152b15;
+  --accent-foreground: #e8ffe8;
   --destructive: oklch(0.704 0.191 22.216);
   --input: oklch(1 0 0 / 15%);
   --brand: var(--neon-primary);
   --brand-foreground: #ffffff;
   --ring: var(--neon-secondary);
-  --selection: #241536;
-  --selection-foreground: #e8f0ff;
+  --selection: #153615;
+  --selection-foreground: #e8ffe8;
   --shadow-card:
     0 0 24px -8px color-mix(in srgb, var(--neon-primary) 40%, transparent),
     0 0 48px -16px color-mix(in srgb, var(--neon-secondary) 30%, transparent);
@@ -324,14 +324,14 @@ input:-webkit-autofill:focus {
   --chart-3: var(--neon-tertiary);
   --chart-4: oklch(0.371 0 0);
   --chart-5: oklch(0.269 0 0);
-  --sidebar: #0b0b15;
-  --sidebar-foreground: #e8f0ff;
-  --sidebar-primary: #e8f0ff;
-  --sidebar-primary-foreground: #050509;
-  --sidebar-accent: #17172b;
-  --sidebar-accent-foreground: #e8f0ff;
-  --sidebar-border: #1a1a30;
-  --sidebar-ring: #5e6c8c;
+  --sidebar: #0a150a;
+  --sidebar-foreground: #e8ffe8;
+  --sidebar-primary: #e8ffe8;
+  --sidebar-primary-foreground: #050905;
+  --sidebar-accent: #152b15;
+  --sidebar-accent-foreground: #e8ffe8;
+  --sidebar-border: #183018;
+  --sidebar-ring: #5e8c5e;
 }
 
 @layer base {


### PR DESCRIPTION
## Summary
Pure palette variation of the Cyberpunk Neon theme (#115) — no layout, component, or functional changes; only CSS custom properties in `app/globals.css`.

Colorway vars:
- `--neon-primary`: `#ff2ecb` → `#39ff14` (acid/radioactive green)
- `--neon-secondary`: `#00e5ff` → `#ccff33` (chartreuse-lime)
- `--neon-tertiary`: `#9d4dff` → `#9acd00` (dark hazard yellow-green)

Tinted neutrals in both `:root` and `.dark` shifted from indigo/blue-black to green-black for cohesion (background/surface/border/muted/selection/sidebar, e.g. `--background` `#0a0a14` → `#081408`, foregrounds `#e8f0ff` → `#e8ffe8`). Derived values (`--brand`, `--ring`, `--shadow-card`, charts) pick up the new hues automatically via `var(--neon-*)`.

`npm run lint` and `npx tsc --noEmit` pass.

Link to Devin session: https://app.devin.ai/sessions/430df25509b443b7a264fbe39ee19930
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/169" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->