### PR TITLE
Soft Neumorphism colorway: Sand

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5,42 +5,42 @@
 @custom-variant dark (&:is(.dark *));
 
 /* Light mode (default) — "Soft Neumorphism": one low-contrast tonal field
-   (a cool porcelain grey) where every surface is the same material as the
+   (a warm desert sand) where every surface is the same material as the
    page. Depth comes from paired shadows — a light source at the top-left
    casts a dark shadow below-right and a highlight above-left — so elements
    read as extruded from or pressed into the field rather than layered on
    top of it. */
 :root {
-  --surface: #e0e5ec;
-  --surface-hover: #d8dee7;
-  --border: #cfd6e0;
-  --border-strong: #b7c0cd;
-  --muted: #d4dae3;
-  --muted-dim: #7d8694;
-  --background: #e0e5ec;
-  --foreground: #33383f;
-  --card: #e0e5ec;
-  --card-foreground: #33383f;
-  --popover: #e4e9f0;
-  --popover-foreground: #33383f;
-  --primary: #3c424b;
-  --primary-foreground: #eef1f6;
-  --secondary: #d4dae3;
-  --secondary-foreground: #33383f;
-  --muted-foreground: #5b626d;
-  --accent: #d4dae3;
-  --accent-foreground: #33383f;
+  --surface: #ece5d8;
+  --surface-hover: #e4dcce;
+  --border: #ddd3c2;
+  --border-strong: #c6b9a2;
+  --muted: #e2d9c8;
+  --muted-dim: #8f8570;
+  --background: #ece5d8;
+  --foreground: #3f382c;
+  --card: #ece5d8;
+  --card-foreground: #3f382c;
+  --popover: #f0e9dd;
+  --popover-foreground: #3f382c;
+  --primary: #4a4232;
+  --primary-foreground: #f5f0e6;
+  --secondary: #e2d9c8;
+  --secondary-foreground: #3f382c;
+  --muted-foreground: #6b6350;
+  --accent: #e2d9c8;
+  --accent-foreground: #3f382c;
   --destructive: oklch(0.577 0.245 27.325);
   --input: oklch(0 0 0 / 8%);
-  --brand: #2200ff;
+  --brand: #b45309;
   --brand-foreground: #ffffff;
-  --ring: #4d5560;
-  --selection: #c8d0dc;
-  --selection-foreground: #33383f;
+  --ring: #5d5541;
+  --selection: #ded2ba;
+  --selection-foreground: #3f382c;
   /* Neumorphic shadow pairs: a dark drop below-right + a light highlight
      above-left reads as extrusion; the inset pair reads as a press. */
-  --neu-light: rgb(255 255 255 / 0.85);
-  --neu-dark: rgb(163 177 198 / 0.65);
+  --neu-light: rgb(255 252 240 / 0.9);
+  --neu-dark: rgb(196 178 143 / 0.65);
   --shadow-neu:
     8px 8px 18px var(--neu-dark), -8px -8px 18px var(--neu-light);
   --shadow-neu-sm:
@@ -56,14 +56,14 @@
   --chart-4: oklch(0.708 0 0);
   --chart-5: oklch(0.87 0 0);
   --radius: 1rem;
-  --sidebar: #e0e5ec;
-  --sidebar-foreground: #33383f;
-  --sidebar-primary: #3c424b;
-  --sidebar-primary-foreground: #eef1f6;
-  --sidebar-accent: #d4dae3;
-  --sidebar-accent-foreground: #33383f;
-  --sidebar-border: #cfd6e0;
-  --sidebar-ring: #7d8694;
+  --sidebar: #ece5d8;
+  --sidebar-foreground: #3f382c;
+  --sidebar-primary: #4a4232;
+  --sidebar-primary-foreground: #f5f0e6;
+  --sidebar-accent: #e2d9c8;
+  --sidebar-accent-foreground: #3f382c;
+  --sidebar-border: #ddd3c2;
+  --sidebar-ring: #8f8570;
 }
 
 @theme inline {
@@ -211,52 +211,52 @@ input:-webkit-autofill:focus {
   }
 }
 
-/* Dark mode — the same tonal field lowered to a soft charcoal-slate. The
+/* Dark mode — the same tonal field lowered to a warm coffee-charcoal. The
    highlight half of each shadow pair dims to a faint sheen so extrusion
    still reads without haloing. */
 .dark {
-  --surface: #2a2e35;
-  --surface-hover: #31353d;
-  --border: #383d46;
-  --border-strong: #4a505b;
-  --muted: #333841;
-  --muted-dim: #868d99;
-  --background: #2a2e35;
-  --foreground: #d9dde3;
-  --card: #2a2e35;
-  --card-foreground: #d9dde3;
-  --popover: #31353d;
-  --popover-foreground: #d9dde3;
-  --primary: #d9dde3;
-  --primary-foreground: #262a30;
-  --secondary: #333841;
-  --secondary-foreground: #d9dde3;
-  --muted-foreground: #a4aab4;
-  --accent: #333841;
-  --accent-foreground: #d9dde3;
+  --surface: #322b23;
+  --surface-hover: #3a332a;
+  --border: #423a30;
+  --border-strong: #564c3e;
+  --muted: #3c342a;
+  --muted-dim: #a2977f;
+  --background: #322b23;
+  --foreground: #e8e0d0;
+  --card: #322b23;
+  --card-foreground: #e8e0d0;
+  --popover: #3a332a;
+  --popover-foreground: #e8e0d0;
+  --primary: #e8e0d0;
+  --primary-foreground: #2d271f;
+  --secondary: #3c342a;
+  --secondary-foreground: #e8e0d0;
+  --muted-foreground: #b7ac96;
+  --accent: #3c342a;
+  --accent-foreground: #e8e0d0;
   --destructive: oklch(0.704 0.191 22.216);
   --input: oklch(1 0 0 / 15%);
-  --brand: #2200ff;
+  --brand: #b45309;
   --brand-foreground: #ffffff;
-  --ring: #aab1bc;
-  --selection: #3d434d;
-  --selection-foreground: #d9dde3;
-  --neu-light: rgb(255 255 255 / 0.05);
-  --neu-dark: rgb(0 0 0 / 0.45);
+  --ring: #beb29a;
+  --selection: #48402f;
+  --selection-foreground: #e8e0d0;
+  --neu-light: rgb(255 236 200 / 0.05);
+  --neu-dark: rgb(18 12 5 / 0.5);
   --shadow-card: var(--shadow-neu);
   --chart-1: oklch(0.87 0 0);
   --chart-2: oklch(0.556 0 0);
   --chart-3: oklch(0.439 0 0);
   --chart-4: oklch(0.371 0 0);
   --chart-5: oklch(0.269 0 0);
-  --sidebar: #2a2e35;
-  --sidebar-foreground: #d9dde3;
-  --sidebar-primary: #d9dde3;
-  --sidebar-primary-foreground: #262a30;
-  --sidebar-accent: #333841;
-  --sidebar-accent-foreground: #d9dde3;
-  --sidebar-border: #383d46;
-  --sidebar-ring: #868d99;
+  --sidebar: #322b23;
+  --sidebar-foreground: #e8e0d0;
+  --sidebar-primary: #e8e0d0;
+  --sidebar-primary-foreground: #2d271f;
+  --sidebar-accent: #3c342a;
+  --sidebar-accent-foreground: #e8e0d0;
+  --sidebar-border: #423a30;
+  --sidebar-ring: #a2977f;
 }
 
 @layer base {


### PR DESCRIPTION
## Summary
Retints the Soft Neumorphism theme to a warm desert-sand colorway — color values only in `app/globals.css`; shadow geometry, radii, and utilities untouched.

**Light** — soft beige field `#ece5d8` (surface/card/sidebar all share it), warm ink `#3f382c`, muted text `#6b6350`, borders `#ddd3c2`/`#c6b9a2`. Amber-tinted shadow pair: `--neu-dark: rgb(196 178 143 / 0.65)` (deeper saturated sand), `--neu-light: rgb(255 252 240 / 0.9)` (warm cream highlight).

**Dark** — warm coffee-charcoal field `#322b23`, cream text `#e8e0d0`, muted `#b7ac96`. Shadows: warm black `rgb(18 12 5 / 0.5)` + faint amber sheen `rgb(255 236 200 / 0.05)`.

**Brand** switched from `#2200ff` to amber `#b45309` in both themes to suit the warm palette (white foreground kept).

Lint and `tsc --noEmit` pass.

Link to Devin session: https://app.devin.ai/sessions/d1d6e64edf7a4c9d9b229952056be9c5
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/170" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->