### PR TITLE
Allow hiding an event at creation time

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -13,6 +13,7 @@ import { cn } from "@/lib/utils";
 import { Alert, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Dialog,
   DialogContent,
@@ -198,6 +199,7 @@ function NewEventDialog() {
   const [description, setDescription] = useState("");
   const [eventDate, setEventDate] = useState("");
   const [claimInstructions, setClaimInstructions] = useState("");
+  const [hidden, setHidden] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
@@ -212,6 +214,7 @@ function NewEventDialog() {
         description: description || undefined,
         eventDate: eventDate || undefined,
         claimInstructions: claimInstructions || undefined,
+        hidden: hidden || undefined,
       });
       toast.success(`Event "${name}" created`);
       router.push(`/admin/events/${id}`);
@@ -299,6 +302,16 @@ function NewEventDialog() {
               <FieldDescription>
                 Optional — shown to attendees after they claim a code.
               </FieldDescription>
+            </Field>
+            <Field orientation="horizontal">
+              <Checkbox
+                id="event-hidden"
+                checked={hidden}
+                onCheckedChange={(checked) => setHidden(checked === true)}
+              />
+              <FieldLabel htmlFor="event-hidden" className="font-normal">
+                Hide from home page
+              </FieldLabel>
             </Field>
           </FieldGroup>
           {error ? (

--- a/convex/events.ts
+++ b/convex/events.ts
@@ -166,6 +166,7 @@ export const create = mutation({
     description: v.optional(v.string()),
     eventDate: v.optional(v.string()),
     claimInstructions: v.optional(v.string()),
+    hidden: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     await requireAdmin(ctx);
@@ -186,6 +187,7 @@ export const create = mutation({
       description: args.description?.trim() || undefined,
       eventDate: normalizeEventDate(args.eventDate),
       claimInstructions: args.claimInstructions?.trim() || undefined,
+      hidden: args.hidden || undefined,
     });
     return { id, slug };
   },


### PR DESCRIPTION
## Summary
Follow-up to #104: the "Hide from home page" option is now also available in the New event dialog, so an event can be created hidden instead of having to hide it after creation.

- `events.create` accepts `hidden: v.optional(v.boolean())` and stores it (as `undefined` when off, matching `events.update`)
- New event dialog (`NewEventDialog` in `app/admin/page.tsx`) gains the same checkbox used in the Event details form

Link to Devin session: https://app.devin.ai/sessions/35524e6607e544329c06534f87171fc5
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/171" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->