### PR TITLE
Add live /swarm dashboard for nested Devin swarm demo

### DIFF
--- a/app/swarm/page.tsx
+++ b/app/swarm/page.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { useQuery } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import SiteHeader from "@/components/SiteHeader";
+import SiteFooter from "@/components/SiteFooter";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+
+interface Agent {
+  _id: string;
+  sessionId: string;
+  name: string;
+  level: number;
+  parentSessionId?: string;
+  role: string;
+  status: string;
+  task?: string;
+  detail?: string;
+  eventsStocked?: number;
+  pagesQAd?: number;
+  updatedAt: number;
+}
+
+const STATUS_STYLES: Record<string, string> = {
+  spawning: "bg-amber-500 animate-pulse",
+  working: "bg-blue-500 animate-pulse",
+  done: "bg-emerald-500",
+  failed: "bg-red-500",
+};
+
+function StatusDot({ status }: { status: string }) {
+  return (
+    <span
+      className={cn(
+        "inline-block size-2 shrink-0 rounded-full",
+        STATUS_STYLES[status] ?? "bg-muted-foreground",
+      )}
+      aria-label={status}
+    />
+  );
+}
+
+function AgentRow({ agent, depth }: { agent: Agent; depth: number }) {
+  return (
+    <li
+      className="flex items-center gap-3 border-b border-border px-2 py-3 text-sm"
+      style={{ paddingLeft: `${depth * 24 + 8}px` }}
+    >
+      <StatusDot status={agent.status} />
+      <span className="font-medium">{agent.name}</span>
+      <Badge variant="secondary">L{agent.level}</Badge>
+      <span className="text-muted-foreground">{agent.role}</span>
+      {agent.task ? (
+        <span className="hidden truncate text-xs text-muted-foreground sm:inline">
+          {agent.task}
+        </span>
+      ) : null}
+      <span className="ml-auto flex shrink-0 items-center gap-3 font-mono text-xs text-muted-dim tabular-nums">
+        {agent.eventsStocked ? <span>{agent.eventsStocked} stocked</span> : null}
+        {agent.pagesQAd ? <span>{agent.pagesQAd} QA&apos;d</span> : null}
+        <span>{agent.status}</span>
+      </span>
+    </li>
+  );
+}
+
+function Tree({
+  agents,
+  parent,
+  depth,
+}: {
+  agents: Agent[];
+  parent: string | undefined;
+  depth: number;
+}) {
+  const children = agents.filter((a) => (a.parentSessionId ?? "") === (parent ?? ""));
+  if (children.length === 0) return null;
+  return (
+    <>
+      {children.map((agent) => (
+        <div key={agent._id}>
+          <ul>
+            <AgentRow agent={agent} depth={depth} />
+          </ul>
+          <Tree agents={agents} parent={agent.sessionId} depth={depth + 1} />
+        </div>
+      ))}
+    </>
+  );
+}
+
+export default function SwarmPage() {
+  const board = useQuery(api.swarm.board);
+  const agents = (board?.agents ?? []) as Agent[];
+
+  const knownIds = new Set(agents.map((a) => a.sessionId));
+  const roots = agents.filter(
+    (a) => !a.parentSessionId || !knownIds.has(a.parentSessionId),
+  );
+  const nonRoots = new Set(roots.map((r) => r.sessionId));
+  const counts = {
+    total: agents.length,
+    done: agents.filter((a) => a.status === "done").length,
+    working: agents.filter(
+      (a) => a.status === "working" || a.status === "spawning",
+    ).length,
+    failed: agents.filter((a) => a.status === "failed").length,
+    stocked: agents.reduce((n, a) => n + (a.eventsStocked ?? 0), 0),
+    qad: agents.reduce((n, a) => n + (a.pagesQAd ?? 0), 0),
+  };
+  const levels = new Map<number, number>();
+  for (const a of agents) levels.set(a.level, (levels.get(a.level) ?? 0) + 1);
+
+  return (
+    <div className="flex min-h-screen flex-col">
+      <SiteHeader />
+      <main id="main-content" className="flex-1">
+        <section className="mx-auto w-full max-w-5xl px-4 py-14 sm:px-6">
+          <p className="eyebrow text-muted-foreground">Live swarm dashboard</p>
+          <h1 className="mt-4 font-heading text-4xl font-semibold tracking-tight">
+            Swarm
+          </h1>
+
+          <div className="mt-8 grid grid-cols-2 gap-4 sm:grid-cols-6">
+            {(
+              [
+                ["Agents", counts.total],
+                ["Active", counts.working],
+                ["Done", counts.done],
+                ["Failed", counts.failed],
+                ["Events stocked", counts.stocked],
+                ["Pages QA'd", counts.qad],
+              ] as const
+            ).map(([label, value]) => (
+              <div key={label} className="border border-border p-4">
+                <div className="text-xs text-muted-foreground">{label}</div>
+                <div className="mt-1 font-mono text-2xl tabular-nums">
+                  {value}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-4 flex flex-wrap gap-2">
+            {[...levels.entries()]
+              .sort((a, b) => a[0] - b[0])
+              .map(([level, count]) => (
+                <Badge key={level} variant="secondary">
+                  Level {level}: {count}
+                </Badge>
+              ))}
+          </div>
+
+          <h2 className="mt-12 text-sm font-medium text-muted-foreground">
+            Agent tree
+          </h2>
+          {board === undefined ? (
+            <div className="mt-4 border-t border-border">
+              {[0, 1, 2, 3].map((i) => (
+                <div key={i} className="border-b border-border px-2 py-3">
+                  <Skeleton className="h-4 w-2/3 rounded-sm" />
+                </div>
+              ))}
+            </div>
+          ) : agents.length === 0 ? (
+            <p className="mt-4 text-sm text-muted-foreground">
+              No swarm agents have reported yet.
+            </p>
+          ) : (
+            <div className="mt-4 border-t border-border">
+              {roots.map((root) => (
+                <div key={root._id}>
+                  <ul>
+                    <AgentRow agent={root} depth={0} />
+                  </ul>
+                  {nonRoots.has(root.sessionId) ? (
+                    <Tree
+                      agents={agents}
+                      parent={root.sessionId}
+                      depth={1}
+                    />
+                  ) : null}
+                </div>
+              ))}
+            </div>
+          )}
+
+          <h2 className="mt-12 text-sm font-medium text-muted-foreground">
+            Stocked events
+          </h2>
+          {board === undefined ? null : board.events.length === 0 ? (
+            <p className="mt-4 text-sm text-muted-foreground">
+              No events stocked yet.
+            </p>
+          ) : (
+            <ul className="mt-4 border-t border-border">
+              {board.events.map((event) => (
+                <li
+                  key={event._id}
+                  className="flex items-center gap-4 border-b border-border px-2 py-3 text-sm"
+                >
+                  <a href={`/${event.slug}`} className="font-medium underline-offset-4 hover:underline">
+                    {event.name}
+                  </a>
+                  <span className="font-mono text-xs text-muted-dim">
+                    /{event.slug}
+                  </span>
+                  <span className="ml-auto font-mono text-xs text-muted-dim tabular-nums">
+                    {event.codeCount} codes
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      </main>
+      <SiteFooter />
+    </div>
+  );
+}

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -18,6 +18,7 @@ import type * as emails from "../emails.js";
 import type * as eventAdmins from "../eventAdmins.js";
 import type * as events from "../events.js";
 import type * as notifications from "../notifications.js";
+import type * as swarm from "../swarm.js";
 import type * as waitlist from "../waitlist.js";
 
 import type {
@@ -37,6 +38,7 @@ declare const fullApi: ApiFromModules<{
   eventAdmins: typeof eventAdmins;
   events: typeof events;
   notifications: typeof notifications;
+  swarm: typeof swarm;
   waitlist: typeof waitlist;
 }>;
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -98,6 +98,32 @@ export default defineSchema({
     .index("by_event_email", ["eventId", "email"])
     .index("by_email", ["email"]),
 
+  // Live status board for swarm demo sessions. Each agent upserts its own
+  // row keyed by its Devin session id; parentSessionId links the tree.
+  swarmAgents: defineTable({
+    sessionId: v.string(),
+    name: v.string(),
+    level: v.number(),
+    parentSessionId: v.optional(v.string()),
+    role: v.string(),
+    status: v.string(),
+    task: v.optional(v.string()),
+    detail: v.optional(v.string()),
+    eventsStocked: v.optional(v.number()),
+    pagesQAd: v.optional(v.number()),
+    updatedAt: v.number(),
+  }).index("by_session", ["sessionId"]),
+
+  // Events created by swarm agents (always hidden), so QA agents can
+  // discover slugs to verify without an admin identity.
+  swarmEvents: defineTable({
+    sessionId: v.string(),
+    eventId: v.id("events"),
+    slug: v.string(),
+    name: v.string(),
+    codeCount: v.number(),
+  }).index("by_slug", ["slug"]),
+
   auditLogs: defineTable({
     eventId: v.id("events"),
     action: v.string(),

--- a/convex/swarm.ts
+++ b/convex/swarm.ts
@@ -1,0 +1,114 @@
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+
+// Swarm demo endpoints. These are intentionally public (no admin identity):
+// swarm agents run on separate machines and report over the Convex HTTP API.
+// Everything they create is scoped to hidden events tracked in swarmEvents.
+
+function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/[\s_]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+export const report = mutation({
+  args: {
+    sessionId: v.string(),
+    name: v.string(),
+    level: v.number(),
+    parentSessionId: v.optional(v.string()),
+    role: v.string(),
+    status: v.string(),
+    task: v.optional(v.string()),
+    detail: v.optional(v.string()),
+    eventsStocked: v.optional(v.number()),
+    pagesQAd: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("swarmAgents")
+      .withIndex("by_session", (q) => q.eq("sessionId", args.sessionId))
+      .unique();
+    const doc = { ...args, updatedAt: Date.now() };
+    if (existing) {
+      await ctx.db.patch(existing._id, doc);
+    } else {
+      await ctx.db.insert("swarmAgents", doc);
+    }
+  },
+});
+
+export const stockEvent = mutation({
+  args: {
+    sessionId: v.string(),
+    name: v.string(),
+    description: v.optional(v.string()),
+    codeCount: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const codeCount = Math.max(1, Math.min(50, Math.floor(args.codeCount)));
+    const base = slugify(args.name);
+    if (!base) throw new Error("Event name must contain letters or numbers");
+    let slug = base;
+    while (
+      await ctx.db
+        .query("events")
+        .withIndex("by_slug", (q) => q.eq("slug", slug))
+        .unique()
+    ) {
+      slug = `${base}-${Math.random().toString(36).slice(2, 8)}`;
+    }
+    const eventId = await ctx.db.insert("events", {
+      name: args.name.trim(),
+      slug,
+      description: args.description?.trim() || undefined,
+      hidden: true,
+      codeTypes: [""],
+    });
+    for (let i = 0; i < codeCount; i++) {
+      const code = `SWARM-${slug.slice(0, 12)}-${(i + 1)
+        .toString()
+        .padStart(3, "0")}-${Math.random().toString(36).slice(2, 8).toUpperCase()}`;
+      await ctx.db.insert("codes", { eventId, code });
+    }
+    await ctx.db.insert("swarmEvents", {
+      sessionId: args.sessionId,
+      eventId,
+      slug,
+      name: args.name.trim(),
+      codeCount,
+    });
+    return { eventId, slug, codeCount };
+  },
+});
+
+export const stockedEvents = query({
+  args: {},
+  handler: async (ctx) => {
+    return await ctx.db.query("swarmEvents").order("desc").collect();
+  },
+});
+
+export const board = query({
+  args: {},
+  handler: async (ctx) => {
+    const agents = await ctx.db.query("swarmAgents").collect();
+    const events = await ctx.db.query("swarmEvents").order("desc").collect();
+    return {
+      agents: agents.sort(
+        (a, b) => a.level - b.level || a._creationTime - b._creationTime
+      ),
+      events: events.map((e) => ({
+        _id: e._id,
+        slug: e.slug,
+        name: e.name,
+        codeCount: e.codeCount,
+        sessionId: e.sessionId,
+      })),
+    };
+  },
+});


### PR DESCRIPTION
## Summary
Adds a live `/swarm` page and public Convex endpoints so a tree of Devin sessions (running on separate machines, no Clerk identity) can report progress and stock demo events over the Convex HTTP API.

- `convex/swarm.ts` (intentionally public, demo-scoped):
  - `report({sessionId, name, level, parentSessionId?, role, status, task?, eventsStocked?, pagesQAd?})` — upserts one `swarmAgents` row per session id.
  - `stockEvent({sessionId, name, description?, codeCount})` — creates a **hidden** event with a pool of unclaimed `SWARM-*` codes (capped at 50) and records it in `swarmEvents` so QA agents can discover slugs without admin access. Hidden events stay off the home page but their `/<slug>` claim pages work.
  - `board` query — agents (sorted by level) + stocked events.
- `app/swarm/page.tsx` — client page subscribed to `swarm.board`: stat tiles (agents/active/done/failed/events stocked/pages QA'd), per-level counts, an indented agent tree linked via `parentSessionId`, and the stocked-event list; updates live via Convex reactivity.
- Schema: new `swarmAgents` (index `by_session`) and `swarmEvents` (index `by_slug`) tables.

Link to Devin session: https://app.devin.ai/sessions/a0d0f052570f4f02af6b09db8e4954df
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/172" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->