### PR TITLE
Fix error when a code block name starts with "$"

### DIFF
--- a/convex/blockValues.ts
+++ b/convex/blockValues.ts
@@ -1,8 +1,30 @@
+// Convex object field names may not start with "$" or "_", so block names
+// beginning with those characters are stored under a space-prefixed key.
+// Block names are trimmed on write, so the escaped form cannot collide with
+// a real name.
+export function blockKey(codeType: string | undefined): string {
+  const key = codeType ?? "";
+  return /^[$_]/.test(key) ? ` ${key}` : key;
+}
+
+// Maps stored codeTypeValues keys back to the block names they represent.
+export function decodeBlockValues(
+  values: Record<string, string> | undefined
+): Record<string, string> | undefined {
+  if (!values) return values;
+  return Object.fromEntries(
+    Object.entries(values).map(([key, value]) => [
+      /^ [$_]/.test(key) ? key.slice(1) : key,
+      value,
+    ])
+  );
+}
+
 // The value shown for a code is its block's value, falling back to the
 // legacy event-wide creditAmount for events created before per-block values.
 export function blockValue(
   event: { codeTypeValues?: Record<string, string>; creditAmount?: string },
   codeType: string | undefined
 ): string | undefined {
-  return event.codeTypeValues?.[codeType ?? ""] ?? event.creditAmount;
+  return event.codeTypeValues?.[blockKey(codeType)] ?? event.creditAmount;
 }

--- a/convex/codes.ts
+++ b/convex/codes.ts
@@ -3,7 +3,7 @@ import type { Id } from "./_generated/dataModel";
 import { v } from "convex/values";
 import { requireEventAdmin } from "./admins";
 import { logAudit } from "./auditLog";
-import { blockValue } from "./blockValues";
+import { blockKey, blockValue } from "./blockValues";
 
 // Drop the type from the event's denormalized list when its last code is
 // removed.
@@ -23,7 +23,7 @@ export async function dropTypeIfEmpty(
     const typeKey = codeType ?? "";
     if (event?.codeTypes?.includes(typeKey)) {
       const values = { ...(event.codeTypeValues ?? {}) };
-      delete values[typeKey];
+      delete values[blockKey(typeKey)];
       await ctx.db.patch(eventId, {
         codeTypes: event.codeTypes.filter((t) => t !== typeKey),
         codeTypeValues: values,
@@ -101,7 +101,7 @@ export const add = mutation({
         await ctx.db.patch(args.eventId, {
           codeTypeValues: {
             ...(event?.codeTypeValues ?? {}),
-            [codeType ?? ""]: value,
+            [blockKey(codeType)]: value,
           },
         });
       }
@@ -121,7 +121,7 @@ export const setTypeValue = mutation({
     await requireEventAdmin(ctx, args.eventId);
     const event = await ctx.db.get(args.eventId);
     if (!event) throw new Error("Event not found");
-    const key = args.codeType?.trim() || "";
+    const key = blockKey(args.codeType?.trim() || "");
     const value = args.value?.trim();
     const values = { ...(event.codeTypeValues ?? {}) };
     if (value) {
@@ -166,11 +166,12 @@ export const renameType = mutation({
     );
     // Carry the block's value over to its new name.
     const values = { ...(event?.codeTypeValues ?? {}) };
-    const fromKey = from ?? "";
-    if (targets.length > 0 && fromKey in values && !(to in values)) {
-      values[to] = values[fromKey];
+    const fromKey = blockKey(from);
+    const toKey = blockKey(to);
+    if (targets.length > 0 && fromKey in values && !(toKey in values)) {
+      values[toKey] = values[fromKey];
     }
-    delete values[fromKey];
+    if (fromKey !== toKey) delete values[fromKey];
     await ctx.db.patch(args.eventId, { codeTypes, codeTypeValues: values });
     return { renamed: targets.length };
   },
@@ -214,7 +215,7 @@ export const removeType = mutation({
       removed++;
     }
     const values = { ...(event.codeTypeValues ?? {}) };
-    if (kept === 0) delete values[typeKey];
+    if (kept === 0) delete values[blockKey(typeKey)];
     await ctx.db.patch(args.eventId, {
       codeTypes: event.codeTypes.filter((t) => t !== typeKey),
       codeTypeValues: values,

--- a/convex/events.ts
+++ b/convex/events.ts
@@ -1,6 +1,7 @@
 import { mutation, query } from "./_generated/server";
 import { v } from "convex/values";
 import { adminEmailStatus, requireAdmin, requireEventAdmin } from "./admins";
+import { decodeBlockValues } from "./blockValues";
 
 function slugify(name: string): string {
   return name
@@ -93,7 +94,7 @@ export const getBySlug = query({
       eventDate: event.eventDate,
       claimInstructions: event.claimInstructions,
       creditAmount: event.creditAmount,
-      codeTypeValues: event.codeTypeValues,
+      codeTypeValues: decodeBlockValues(event.codeTypeValues),
       soldOut: availableTypes.size === 0,
       // Preserve the event's stored (creation) order of code types.
       codeTypes: [
@@ -118,7 +119,7 @@ export const get = query({
       description: event.description,
       creditAmount: event.creditAmount,
       codeTypes: event.codeTypes,
-      codeTypeValues: event.codeTypeValues,
+      codeTypeValues: decodeBlockValues(event.codeTypeValues),
       eventDate: event.eventDate,
       claimInstructions: event.claimInstructions,
       hidden: event.hidden,


### PR DESCRIPTION
## Summary
Adding a code block whose name starts with `$` (e.g. `$100 Credits`) failed because block names are used as field names in the event's `codeTypeValues` record, and Convex rejects field names starting with `$` or `_`.

Fix: escape such keys with a leading space when stored, and decode them back at the query boundary so the UI never sees the escaped form. Block names are always trimmed on write, so the space-prefixed form can't collide with a real name.

- `blockValues.ts`: new `blockKey(codeType)` (prefixes `" "` when the name starts with `$`/`_`) and `decodeBlockValues(values)`; `blockValue` now looks up via `blockKey`.
- `codes.ts`: all `codeTypeValues` reads/writes (`add`, `setTypeValue`, `renameType`, `removeType`, `dropTypeIfEmpty`) key through `blockKey`.
- `events.ts`: `get` and `getBySlug` return `decodeBlockValues(event.codeTypeValues)`.

Existing data is unaffected: `$`-prefixed names could never have been stored before, so all stored keys already equal their `blockKey` form.

Link to Devin session: https://app.devin.ai/sessions/b737a49a3fee415ebdbf846c519c3177
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/173" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->