### PR TITLE
Fix crash on events with "$"-named code blocks (follow-up to #173)

### DIFF
--- a/components/ClaimPage.tsx
+++ b/components/ClaimPage.tsx
@@ -20,6 +20,7 @@ import { toast } from "sonner";
 import { useConvexAuth, useMutation, useQuery } from "convex/react";
 import { SignInButton, SignOutButton, useUser } from "@clerk/nextjs";
 import { api } from "@/convex/_generated/api";
+import { blockKey } from "@/convex/blockValues";
 import {
   daysUntilEvent,
   eventCountdownLabel,
@@ -150,7 +151,8 @@ export default function ClaimPage({
         code: "PREVIEW-CODE",
         codeType: type,
         alreadyClaimed: false,
-        creditAmount: event.codeTypeValues?.[type ?? ""] ?? event.creditAmount,
+        creditAmount:
+          event.codeTypeValues?.[blockKey(type)] ?? event.creditAmount,
       });
       return;
     }
@@ -441,7 +443,7 @@ export default function ClaimPage({
                         <div className="grid grid-cols-2 gap-2">
                           {codeTypes.map((type) => {
                             const value =
-                              event.codeTypeValues?.[type] ??
+                              event.codeTypeValues?.[blockKey(type)] ??
                               event.creditAmount;
                             return (
                               <Button

--- a/components/ManageEvent.tsx
+++ b/components/ManageEvent.tsx
@@ -26,6 +26,7 @@ import { toast } from "sonner";
 import { useMutation, useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import type { Doc, Id } from "@/convex/_generated/dataModel";
+import { blockKey } from "@/convex/blockValues";
 import { downloadCsv } from "@/lib/csv";
 import { fileToItems } from "@/lib/spreadsheet";
 import { useCountUp } from "@/lib/use-count-up";
@@ -971,7 +972,7 @@ function CodeBlocks({
             key={type || "__unnamed"}
             type={type}
             count={count}
-            value={values?.[type]}
+            value={values?.[blockKey(type)]}
             onRename={onRename}
             onSetValue={onSetValue}
             canDelete={canDelete}

--- a/convex/blockValues.ts
+++ b/convex/blockValues.ts
@@ -1,23 +1,11 @@
-// Convex object field names may not start with "$" or "_", so block names
-// beginning with those characters are stored under a space-prefixed key.
-// Block names are trimmed on write, so the escaped form cannot collide with
-// a real name.
+// Convex object field names may not start with "$" or "_" — in stored
+// documents and in query return values alike — so block names beginning with
+// those characters live under a space-prefixed key everywhere, and readers
+// (server and client) look values up via blockKey. Block names are trimmed
+// on write, so the escaped form cannot collide with a real name.
 export function blockKey(codeType: string | undefined): string {
   const key = codeType ?? "";
   return /^[$_]/.test(key) ? ` ${key}` : key;
-}
-
-// Maps stored codeTypeValues keys back to the block names they represent.
-export function decodeBlockValues(
-  values: Record<string, string> | undefined
-): Record<string, string> | undefined {
-  if (!values) return values;
-  return Object.fromEntries(
-    Object.entries(values).map(([key, value]) => [
-      /^ [$_]/.test(key) ? key.slice(1) : key,
-      value,
-    ])
-  );
 }
 
 // The value shown for a code is its block's value, falling back to the

--- a/convex/events.ts
+++ b/convex/events.ts
@@ -1,7 +1,6 @@
 import { mutation, query } from "./_generated/server";
 import { v } from "convex/values";
 import { adminEmailStatus, requireAdmin, requireEventAdmin } from "./admins";
-import { decodeBlockValues } from "./blockValues";
 
 function slugify(name: string): string {
   return name
@@ -94,7 +93,7 @@ export const getBySlug = query({
       eventDate: event.eventDate,
       claimInstructions: event.claimInstructions,
       creditAmount: event.creditAmount,
-      codeTypeValues: decodeBlockValues(event.codeTypeValues),
+      codeTypeValues: event.codeTypeValues,
       soldOut: availableTypes.size === 0,
       // Preserve the event's stored (creation) order of code types.
       codeTypes: [
@@ -119,7 +118,7 @@ export const get = query({
       description: event.description,
       creditAmount: event.creditAmount,
       codeTypes: event.codeTypes,
-      codeTypeValues: decodeBlockValues(event.codeTypeValues),
+      codeTypeValues: event.codeTypeValues,
       eventDate: event.eventDate,
       claimInstructions: event.claimInstructions,
       hidden: event.hidden,


### PR DESCRIPTION
## Summary
Follow-up to #173. Testing showed the fix crashed instead of erroring: Convex rejects `$`-prefixed field names in **query return values** too, so `decodeBlockValues` (which restored the raw `$100 Credits` key server-side) made `events.get`/`events.getBySlug` throw `Field name ... starts with a '$', which is reserved`, hard-crashing ManageEvent and the claim page for any event with a `$`-named block.

Fix: keep the escaped (space-prefixed) keys in query returns and decode on the client instead.

- `blockValues.ts`: `decodeBlockValues` removed; `blockKey` is now the single lookup convention for readers on both server and client.
- `events.ts`: `get`/`getBySlug` return `event.codeTypeValues` as stored (escaped keys).
- `ClaimPage.tsx` / `ManageEvent.tsx`: value lookups go through `blockKey`, e.g. `event.codeTypeValues?.[blockKey(type)] ?? event.creditAmount`.

Verified end-to-end locally (Convex dev + admin UI): creating a `$100 Credits` block, claim page display, `_`-prefixed rename with value carry-over, and normal-name regression all pass.

Link to Devin session: https://app.devin.ai/sessions/b737a49a3fee415ebdbf846c519c3177
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/174" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->