### PR TITLE
Show admins a manage banner on the event claim page

### DIFF
--- a/components/ClaimPage.tsx
+++ b/components/ClaimPage.tsx
@@ -12,6 +12,7 @@ import {
   LogIn,
   OctagonX,
   QrCode,
+  ShieldCheck,
   SearchX,
   Undo2,
 } from "lucide-react";
@@ -202,6 +203,19 @@ export default function ClaimPage({
               <AlertTitle>
                 Admin preview — you&apos;re seeing this as an eligible
                 attendee. No code is dispensed.
+              </AlertTitle>
+            </Alert>
+          ) : event?.viewerIsAdmin ? (
+            <Alert className="mb-4">
+              <ShieldCheck />
+              <AlertTitle className="flex items-center justify-between gap-3">
+                <span>You&apos;re an admin for this event</span>
+                <Link
+                  href={`/admin/events/${event._id}`}
+                  className="shrink-0 font-medium underline underline-offset-4 hover:text-foreground"
+                >
+                  Manage
+                </Link>
               </AlertTitle>
             </Alert>
           ) : null}

--- a/convex/events.ts
+++ b/convex/events.ts
@@ -1,6 +1,11 @@
 import { mutation, query } from "./_generated/server";
 import { v } from "convex/values";
-import { adminEmailStatus, requireAdmin, requireEventAdmin } from "./admins";
+import {
+  adminEmailStatus,
+  isEventAdmin,
+  requireAdmin,
+  requireEventAdmin,
+} from "./admins";
 
 function slugify(name: string): string {
   return name
@@ -94,6 +99,8 @@ export const getBySlug = query({
       claimInstructions: event.claimInstructions,
       creditAmount: event.creditAmount,
       codeTypeValues: event.codeTypeValues,
+      // Lets the claim page show a manage link to this event's admins.
+      viewerIsAdmin: await isEventAdmin(ctx, event._id),
       soldOut: availableTypes.size === 0,
       // Preserve the event's stored (creation) order of code types.
       codeTypes: [


### PR DESCRIPTION
## Summary
Event admins visiting a claim page now see a subtle alert above the card — `ShieldCheck` icon, "You're an admin for this event", and a "Manage" link to `/admin/events/<id>`.

- `events.getBySlug` now returns `viewerIsAdmin: await isEventAdmin(ctx, event._id)` (true for global admins and per-event admins; false for signed-out/regular viewers).
- `ClaimPage` renders the banner in the same slot as the existing admin-preview alert; preview mode keeps its own alert and suppresses this one.

Link to Devin session: https://app.devin.ai/sessions/b737a49a3fee415ebdbf846c519c3177
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/175" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->