### PR TITLE
Hide events more than 30 days past from the home page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -141,8 +141,14 @@ export default function Home() {
       .sort((a, b) => (a.eventDate ?? "").localeCompare(b.eventDate ?? "")),
     ...active.filter((e) => !e.eventDate),
   ];
+  // Past events drop off the page entirely once they are more than 30 days
+  // old; they stay reachable via their claim URL.
   const past = (
-    events?.filter((e) => e.eventDate && daysUntilEvent(e.eventDate) < 0) ?? []
+    events?.filter((e) => {
+      if (!e.eventDate) return false;
+      const days = daysUntilEvent(e.eventDate);
+      return days < 0 && days >= -30;
+    }) ?? []
   ).sort((a, b) => (b.eventDate ?? "").localeCompare(a.eventDate ?? ""));
 
   // Shared hero copy: crisp DOM stacked above the theme's scene. pt-15.25


### PR DESCRIPTION
## Summary
The home page's "Past events" group now only includes events that ended within the last 30 days; older ones drop off the listing entirely (they stay reachable via their claim URL, matching how hidden events behave).

In `app/page.tsx`, the `past` filter becomes `days < 0 && days >= -30` using the existing `daysUntilEvent` helper. Undated events are unaffected (still treated as current). Admin dashboard listing is unchanged.

Link to Devin session: https://app.devin.ai/sessions/b737a49a3fee415ebdbf846c519c3177
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/176" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->