### PR TITLE
Add search to the admin blacklist page

### DIFF
--- a/app/admin/blacklist/page.tsx
+++ b/app/admin/blacklist/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Ban, ShieldAlert, X } from "lucide-react";
+import { Ban, Search, ShieldAlert, X } from "lucide-react";
 import { toast } from "sonner";
 import { useMutation, useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
@@ -29,9 +29,16 @@ export default function BlacklistPage() {
   const removeEmail = useMutation(api.blacklist.remove);
 
   const [email, setEmail] = useState("");
+  const [search, setSearch] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [removingId, setRemovingId] = useState<Id<"blacklistedEmails"> | null>(
     null
+  );
+
+  const normalizedSearch = search.trim().toLowerCase();
+  const visibleEntries = (entries ?? []).filter(
+    (entry) =>
+      normalizedSearch === "" || entry.email.includes(normalizedSearch)
   );
 
   async function handleAdd(e: React.FormEvent) {
@@ -125,6 +132,29 @@ export default function BlacklistPage() {
         </Field>
       </form>
 
+      {entries && entries.length > 0 ? (
+        <div className="mb-4 flex items-center justify-between gap-3">
+          <InputGroup className="max-w-sm">
+            <InputGroupAddon align="inline-start">
+              <Search />
+            </InputGroupAddon>
+            <InputGroupInput
+              type="search"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search blacklisted emails"
+              aria-label="Search blacklisted emails"
+              className="text-sm"
+            />
+          </InputGroup>
+          <span className="shrink-0 text-xs text-muted-dim">
+            {normalizedSearch
+              ? `${visibleEntries.length} of ${entries.length}`
+              : `${entries.length} ${entries.length === 1 ? "email" : "emails"}`}
+          </span>
+        </div>
+      ) : null}
+
       {entries === undefined ? (
         <div className="flex flex-col gap-2">
           <Skeleton className="h-12 rounded-md" />
@@ -136,9 +166,17 @@ export default function BlacklistPage() {
             <EmptyDescription>No blacklisted emails.</EmptyDescription>
           </EmptyHeader>
         </Empty>
+      ) : visibleEntries.length === 0 ? (
+        <Empty className="border border-dashed border-border-strong py-16">
+          <EmptyHeader>
+            <EmptyDescription>
+              No blacklisted emails match &ldquo;{search.trim()}&rdquo;.
+            </EmptyDescription>
+          </EmptyHeader>
+        </Empty>
       ) : (
         <ul className="divide-y divide-border border-y border-border">
-          {entries.map((entry) => (
+          {visibleEntries.map((entry) => (
             <li
               key={entry._id}
               className="flex min-h-12 items-center justify-between gap-3 px-1 py-2 transition-colors hover:bg-surface"


### PR DESCRIPTION
## Summary
Adds a search box above the blacklist on `/admin/blacklist` so global admins can find a specific address without scrolling.

- Filtering is client-side over the already-loaded `api.blacklist.list` result (case-insensitive substring match on `email`), so no Convex changes were needed.
- The search bar only renders once there is at least one entry; a count ("N emails" / "M of N" while searching) sits beside it, and a dedicated empty state shows when nothing matches the query.

Link to Devin session: https://app.devin.ai/sessions/d7bbf09809db46e495121e3271de2e45
Open in Devin Desktop: https://app.devin.ai/desktop/session/d7bbf09809db46e495121e3271de2e45?variant=devin
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/178" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->