### PR TITLE
Show cross-event attendee history from the blacklist search

### DIFF
--- a/app/admin/blacklist/page.tsx
+++ b/app/admin/blacklist/page.tsx
@@ -329,6 +329,12 @@ export default function BlacklistPage() {
                           </li>
                         ))}
                       </ul>
+                      {attendee.historyTruncated ? (
+                        <p className="mt-2 text-xs text-muted-dim">
+                          History is too long to show in full; some events
+                          are omitted.
+                        </p>
+                      ) : null}
                     </li>
                   ))}
                 </ul>

--- a/app/admin/blacklist/page.tsx
+++ b/app/admin/blacklist/page.tsx
@@ -324,15 +324,18 @@ export default function BlacklistPage() {
                             <span className="shrink-0 text-muted-foreground">
                               {event.claimedAt !== null
                                 ? `Claimed ${formatClaimDate(event.claimedAt)}`
-                                : "Eligible, not claimed"}
+                                : attendee.claimsTruncated
+                                  ? "Eligible, claim status unknown"
+                                  : "Eligible, not claimed"}
                             </span>
                           </li>
                         ))}
                       </ul>
-                      {attendee.historyTruncated ? (
+                      {attendee.eligibilityTruncated ||
+                      attendee.claimsTruncated ? (
                         <p className="mt-2 text-xs text-muted-dim">
                           History is too long to show in full; some events
-                          are omitted.
+                          may be missing.
                         </p>
                       ) : null}
                     </li>

--- a/app/admin/blacklist/page.tsx
+++ b/app/admin/blacklist/page.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import Link from "next/link";
 import { Ban, Search, ShieldAlert, X } from "lucide-react";
 import { toast } from "sonner";
 import { useMutation, useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { Id } from "@/convex/_generated/dataModel";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Field, FieldLabel } from "@/components/ui/field";
 import {
@@ -18,6 +20,9 @@ import {
 import { Empty, EmptyDescription, EmptyHeader } from "@/components/ui/empty";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
+import { formatEventDate } from "@/lib/event-date";
+
+const SEARCH_DEBOUNCE_MS = 250;
 
 export default function BlacklistPage() {
   const access = useQuery(api.admins.accessLevel);
@@ -31,6 +36,7 @@ export default function BlacklistPage() {
   const [email, setEmail] = useState("");
   const [search, setSearch] = useState("");
   const [submitting, setSubmitting] = useState(false);
+  const [addingEmail, setAddingEmail] = useState<string | null>(null);
   const [removingId, setRemovingId] = useState<Id<"blacklistedEmails"> | null>(
     null
   );
@@ -40,21 +46,49 @@ export default function BlacklistPage() {
     (entry) =>
       normalizedSearch === "" || entry.email.includes(normalizedSearch)
   );
+  const blacklisted = new Set(entries?.map((entry) => entry.email));
 
-  async function handleAdd(e: React.FormEvent) {
-    e.preventDefault();
-    setSubmitting(true);
+  // The attendee lookup hits the backend, so it trails typing slightly
+  // instead of re-querying on every keystroke.
+  const [historyQuery, setHistoryQuery] = useState("");
+  useEffect(() => {
+    const timer = setTimeout(
+      () => setHistoryQuery(normalizedSearch),
+      SEARCH_DEBOUNCE_MS
+    );
+    return () => clearTimeout(timer);
+  }, [normalizedSearch]);
+  const history = useQuery(
+    api.emails.searchAttendees,
+    access?.isGlobalAdmin && historyQuery ? { query: historyQuery } : "skip"
+  );
+  const historyLoading =
+    history === undefined || historyQuery !== normalizedSearch;
+
+  async function blacklist(address: string) {
     try {
-      await addEmail({ email });
-      toast.success(`${email.trim().toLowerCase()} is now blacklisted`);
-      setEmail("");
+      await addEmail({ email: address });
+      toast.success(`${address.trim().toLowerCase()} is now blacklisted`);
+      return true;
     } catch (err) {
       toast.error(
         err instanceof Error ? err.message : "Failed to blacklist email"
       );
-    } finally {
-      setSubmitting(false);
+      return false;
     }
+  }
+
+  async function handleAdd(e: React.FormEvent) {
+    e.preventDefault();
+    setSubmitting(true);
+    if (await blacklist(email)) setEmail("");
+    setSubmitting(false);
+  }
+
+  async function handleQuickAdd(address: string) {
+    setAddingEmail(address);
+    await blacklist(address);
+    setAddingEmail(null);
   }
 
   async function handleRemove(id: Id<"blacklistedEmails">) {
@@ -85,6 +119,57 @@ export default function BlacklistPage() {
       </div>
     );
   }
+
+  const blacklistRows =
+    entries === undefined ? (
+      <div className="flex flex-col gap-2">
+        <Skeleton className="h-12 rounded-md" />
+        <Skeleton className="h-12 rounded-md" />
+      </div>
+    ) : entries.length === 0 ? (
+      <Empty className="border border-dashed border-border-strong py-16">
+        <EmptyHeader>
+          <EmptyDescription>No blacklisted emails.</EmptyDescription>
+        </EmptyHeader>
+      </Empty>
+    ) : visibleEntries.length === 0 ? (
+      <Empty className="border border-dashed border-border-strong py-10">
+        <EmptyHeader>
+          <EmptyDescription>
+            No blacklisted emails match &ldquo;{search.trim()}&rdquo;.
+          </EmptyDescription>
+        </EmptyHeader>
+      </Empty>
+    ) : (
+      <ul className="divide-y divide-border border-y border-border">
+        {visibleEntries.map((entry) => (
+          <li
+            key={entry._id}
+            className="flex min-h-12 items-center justify-between gap-3 px-1 py-2 transition-colors hover:bg-surface"
+          >
+            <span className="flex min-w-0 flex-col">
+              <span className="truncate text-sm">{entry.email}</span>
+              {entry.addedBy ? (
+                <span className="truncate text-xs text-muted-dim">
+                  Added by {entry.addedBy}
+                </span>
+              ) : null}
+            </span>
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              aria-label={`Remove ${entry.email} from blacklist`}
+              onClick={() => handleRemove(entry._id)}
+              disabled={removingId === entry._id}
+              aria-busy={removingId === entry._id}
+              className="shrink-0 text-muted-foreground"
+            >
+              {removingId === entry._id ? <Spinner /> : <X />}
+            </Button>
+          </li>
+        ))}
+      </ul>
+    );
 
   return (
     <div className="mx-auto max-w-2xl">
@@ -132,78 +217,140 @@ export default function BlacklistPage() {
         </Field>
       </form>
 
-      {entries && entries.length > 0 ? (
-        <div className="mb-4 flex items-center justify-between gap-3">
-          <InputGroup className="max-w-sm">
-            <InputGroupAddon align="inline-start">
-              <Search />
-            </InputGroupAddon>
-            <InputGroupInput
-              type="search"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              placeholder="Search blacklisted emails"
-              aria-label="Search blacklisted emails"
-              className="text-sm"
-            />
-          </InputGroup>
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <InputGroup className="max-w-sm">
+          <InputGroupAddon align="inline-start">
+            <Search />
+          </InputGroupAddon>
+          <InputGroupInput
+            type="search"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search emails"
+            aria-label="Search blacklisted emails and event history"
+            className="text-sm"
+          />
+        </InputGroup>
+        {entries && entries.length > 0 ? (
           <span className="shrink-0 text-xs text-muted-dim">
             {normalizedSearch
-              ? `${visibleEntries.length} of ${entries.length}`
+              ? `${visibleEntries.length} of ${entries.length} blacklisted`
               : `${entries.length} ${entries.length === 1 ? "email" : "emails"}`}
           </span>
-        </div>
-      ) : null}
+        ) : null}
+      </div>
+      <p className="-mt-2 mb-6 text-xs text-muted-dim">
+        Filters the blacklist and looks up which events an address has been
+        eligible for or claimed a code at.
+      </p>
 
-      {entries === undefined ? (
-        <div className="flex flex-col gap-2">
-          <Skeleton className="h-12 rounded-md" />
-          <Skeleton className="h-12 rounded-md" />
-        </div>
-      ) : entries.length === 0 ? (
-        <Empty className="border border-dashed border-border-strong py-16">
-          <EmptyHeader>
-            <EmptyDescription>No blacklisted emails.</EmptyDescription>
-          </EmptyHeader>
-        </Empty>
-      ) : visibleEntries.length === 0 ? (
-        <Empty className="border border-dashed border-border-strong py-16">
-          <EmptyHeader>
-            <EmptyDescription>
-              No blacklisted emails match &ldquo;{search.trim()}&rdquo;.
-            </EmptyDescription>
-          </EmptyHeader>
-        </Empty>
+      {normalizedSearch === "" ? (
+        blacklistRows
       ) : (
-        <ul className="divide-y divide-border border-y border-border">
-          {visibleEntries.map((entry) => (
-            <li
-              key={entry._id}
-              className="flex min-h-12 items-center justify-between gap-3 px-1 py-2 transition-colors hover:bg-surface"
-            >
-              <span className="flex min-w-0 flex-col">
-                <span className="truncate text-sm">{entry.email}</span>
-                {entry.addedBy ? (
-                  <span className="truncate text-xs text-muted-dim">
-                    Added by {entry.addedBy}
-                  </span>
+        <div className="flex flex-col gap-10">
+          <section>
+            <h2 className="eyebrow mb-3 text-muted-foreground">Blacklist</h2>
+            {blacklistRows}
+          </section>
+
+          <section>
+            <h2 className="eyebrow mb-3 text-muted-foreground">
+              Event history
+            </h2>
+            {historyLoading ? (
+              <div className="flex flex-col gap-2">
+                <Skeleton className="h-16 rounded-md" />
+                <Skeleton className="h-16 rounded-md" />
+              </div>
+            ) : history.attendees.length === 0 ? (
+              <Empty className="border border-dashed border-border-strong py-10">
+                <EmptyHeader>
+                  <EmptyDescription>
+                    No attendees start with &ldquo;{search.trim()}&rdquo;.
+                  </EmptyDescription>
+                </EmptyHeader>
+              </Empty>
+            ) : (
+              <>
+                <ul className="divide-y divide-border border-y border-border">
+                  {history.attendees.map((attendee) => (
+                    <li key={attendee.email} className="px-1 py-3">
+                      <div className="flex items-center justify-between gap-3">
+                        <span className="flex min-w-0 items-center gap-2">
+                          <span className="truncate text-sm">
+                            {attendee.email}
+                          </span>
+                          {blacklisted.has(attendee.email) ? (
+                            <Badge variant="destructive">Blacklisted</Badge>
+                          ) : null}
+                        </span>
+                        {blacklisted.has(attendee.email) ? null : (
+                          <Button
+                            variant="ghost"
+                            size="xs"
+                            onClick={() => handleQuickAdd(attendee.email)}
+                            disabled={addingEmail === attendee.email}
+                            aria-busy={addingEmail === attendee.email}
+                            className="shrink-0 text-muted-foreground"
+                          >
+                            {addingEmail === attendee.email ? (
+                              <Spinner />
+                            ) : (
+                              <Ban data-icon="inline-start" />
+                            )}
+                            Blacklist
+                          </Button>
+                        )}
+                      </div>
+                      <ul className="mt-2 flex flex-col gap-1">
+                        {attendee.events.map((event) => (
+                          <li
+                            key={event.id}
+                            className="flex items-center justify-between gap-3 text-xs"
+                          >
+                            <span className="flex min-w-0 items-baseline gap-2">
+                              <Link
+                                href={`/admin/events/${event.id}`}
+                                className="truncate text-foreground underline-offset-4 hover:underline"
+                              >
+                                {event.name}
+                              </Link>
+                              {event.eventDate ? (
+                                <span className="shrink-0 text-muted-dim">
+                                  {formatEventDate(event.eventDate)}
+                                </span>
+                              ) : null}
+                            </span>
+                            <span className="shrink-0 text-muted-foreground">
+                              {event.claimedAt !== null
+                                ? `Claimed ${formatClaimDate(event.claimedAt)}`
+                                : "Eligible, not claimed"}
+                            </span>
+                          </li>
+                        ))}
+                      </ul>
+                    </li>
+                  ))}
+                </ul>
+                {history.hasMore ? (
+                  <p className="mt-3 text-xs text-muted-dim">
+                    Showing the first {history.attendees.length} matches — keep
+                    typing to narrow the search.
+                  </p>
                 ) : null}
-              </span>
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                aria-label={`Remove ${entry.email} from blacklist`}
-                onClick={() => handleRemove(entry._id)}
-                disabled={removingId === entry._id}
-                aria-busy={removingId === entry._id}
-                className="shrink-0 text-muted-foreground"
-              >
-                {removingId === entry._id ? <Spinner /> : <X />}
-              </Button>
-            </li>
-          ))}
-        </ul>
+              </>
+            )}
+          </section>
+        </div>
       )}
     </div>
   );
+}
+
+function formatClaimDate(timestamp: number): string {
+  return new Date(timestamp).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
 }

--- a/convex/emails.ts
+++ b/convex/emails.ts
@@ -265,6 +265,16 @@ export const rejectFlagged = mutation({
 const ATTENDEE_SEARCH_ROWS = 200;
 const ATTENDEE_SEARCH_LIMIT = 20;
 
+// Single timeline for ordering events: the YYYY-MM-DD event date when set,
+// otherwise when the event was created.
+function eventTimestamp(event: Doc<"events">): number {
+  if (event.eventDate) {
+    const [year, month, day] = event.eventDate.split("-").map(Number);
+    if (year && month && day) return Date.UTC(year, month - 1, day);
+  }
+  return event._creationTime;
+}
+
 // Cross-event history for addresses starting with `query`: every event the
 // address was made eligible for, plus any code claims (which may exist even
 // without an eligible-list row, e.g. after a re-claim or list cleanup).
@@ -277,6 +287,9 @@ export const searchAttendees = query({
     if (!prefix) return { attendees: [], hasMore: false };
     const upper = prefix + "\uffff";
 
+    // Discovery pass: a bounded prefix scan of both indexes just to find
+    // which addresses match. Each returned address then gets its own exact
+    // lookups so its history is complete even if the scan cut through it.
     const eligibleRows = await ctx.db
       .query("emails")
       .withIndex("by_email", (q) => q.gte("email", prefix).lt("email", upper))
@@ -287,68 +300,69 @@ export const searchAttendees = query({
         q.gte("claimedBy", prefix).lt("claimedBy", upper)
       )
       .take(ATTENDEE_SEARCH_ROWS);
-
-    type EventHistory = { eligible: boolean; claimedAt: number | null };
-    const byEmail = new Map<string, Map<Id<"events">, EventHistory>>();
-    const historyFor = (email: string, eventId: Id<"events">) => {
-      let events = byEmail.get(email);
-      if (!events) {
-        events = new Map();
-        byEmail.set(email, events);
-      }
-      let history = events.get(eventId);
-      if (!history) {
-        history = { eligible: false, claimedAt: null };
-        events.set(eventId, history);
-      }
-      return history;
-    };
-    for (const row of eligibleRows) {
-      historyFor(row.email, row.eventId).eligible = true;
-    }
+    const matched = new Set<string>();
+    for (const row of eligibleRows) matched.add(row.email);
     for (const code of claimRows) {
-      if (!code.claimedBy) continue;
-      const history = historyFor(code.claimedBy, code.eventId);
-      const claimedAt = code.claimedAt ?? code._creationTime;
-      if (history.claimedAt === null || claimedAt > history.claimedAt) {
-        history.claimedAt = claimedAt;
-      }
+      if (code.claimedBy) matched.add(code.claimedBy);
     }
-
-    const emails = [...byEmail.keys()].sort();
+    const emails = [...matched].sort();
     const hasMore =
       emails.length > ATTENDEE_SEARCH_LIMIT ||
       eligibleRows.length === ATTENDEE_SEARCH_ROWS ||
       claimRows.length === ATTENDEE_SEARCH_ROWS;
 
+    type EventHistory = { eligible: boolean; claimedAt: number | null };
     const eventCache = new Map<Id<"events">, Doc<"events"> | null>();
     const attendees = [];
     for (const email of emails.slice(0, ATTENDEE_SEARCH_LIMIT)) {
-      const events = [];
-      for (const [eventId, history] of byEmail.get(email)!) {
+      const byEvent = new Map<Id<"events">, EventHistory>();
+      const historyFor = (eventId: Id<"events">) => {
+        let history = byEvent.get(eventId);
+        if (!history) {
+          history = { eligible: false, claimedAt: null };
+          byEvent.set(eventId, history);
+        }
+        return history;
+      };
+      const eligible = await ctx.db
+        .query("emails")
+        .withIndex("by_email", (q) => q.eq("email", email))
+        .collect();
+      for (const row of eligible) {
+        historyFor(row.eventId).eligible = true;
+      }
+      const claims = await ctx.db
+        .query("codes")
+        .withIndex("by_claimedBy", (q) => q.eq("claimedBy", email))
+        .collect();
+      for (const code of claims) {
+        const history = historyFor(code.eventId);
+        const claimedAt = code.claimedAt ?? code._creationTime;
+        if (history.claimedAt === null || claimedAt > history.claimedAt) {
+          history.claimedAt = claimedAt;
+        }
+      }
+
+      const rows: { event: Doc<"events">; history: EventHistory }[] = [];
+      for (const [eventId, history] of byEvent) {
         let event = eventCache.get(eventId);
         if (event === undefined) {
           event = await ctx.db.get(eventId);
           eventCache.set(eventId, event);
         }
-        if (!event) continue;
-        events.push({
-          id: eventId,
+        if (event) rows.push({ event, history });
+      }
+      rows.sort((a, b) => eventTimestamp(b.event) - eventTimestamp(a.event));
+      attendees.push({
+        email,
+        events: rows.map(({ event, history }) => ({
+          id: event._id,
           name: event.name,
           eventDate: event.eventDate ?? null,
-          createdAt: event._creationTime,
           eligible: history.eligible,
           claimedAt: history.claimedAt,
-        });
-      }
-      // Most recent event first; undated events fall back to creation order.
-      events.sort((a, b) => {
-        if (a.eventDate && b.eventDate && a.eventDate !== b.eventDate) {
-          return a.eventDate < b.eventDate ? 1 : -1;
-        }
-        return b.createdAt - a.createdAt;
+        })),
       });
-      attendees.push({ email, events });
     }
     return { attendees, hasMore };
   },

--- a/convex/emails.ts
+++ b/convex/emails.ts
@@ -264,6 +264,9 @@ export const rejectFlagged = mutation({
 
 const ATTENDEE_SEARCH_ROWS = 200;
 const ATTENDEE_SEARCH_LIMIT = 20;
+// Per-address cap on eligibility/claim rows so a request can never read an
+// unbounded number of documents. Far above any real attendee's history.
+const ATTENDEE_HISTORY_ROWS = 500;
 
 // Single timeline for ordering events: the YYYY-MM-DD event date when set,
 // otherwise when the event was created.
@@ -327,14 +330,14 @@ export const searchAttendees = query({
       const eligible = await ctx.db
         .query("emails")
         .withIndex("by_email", (q) => q.eq("email", email))
-        .collect();
+        .take(ATTENDEE_HISTORY_ROWS);
       for (const row of eligible) {
         historyFor(row.eventId).eligible = true;
       }
       const claims = await ctx.db
         .query("codes")
         .withIndex("by_claimedBy", (q) => q.eq("claimedBy", email))
-        .collect();
+        .take(ATTENDEE_HISTORY_ROWS);
       for (const code of claims) {
         const history = historyFor(code.eventId);
         const claimedAt = code.claimedAt ?? code._creationTime;
@@ -355,6 +358,9 @@ export const searchAttendees = query({
       rows.sort((a, b) => eventTimestamp(b.event) - eventTimestamp(a.event));
       attendees.push({
         email,
+        historyTruncated:
+          eligible.length === ATTENDEE_HISTORY_ROWS ||
+          claims.length === ATTENDEE_HISTORY_ROWS,
         events: rows.map(({ event, history }) => ({
           id: event._id,
           name: event.name,

--- a/convex/emails.ts
+++ b/convex/emails.ts
@@ -1,7 +1,7 @@
 import { mutation, query } from "./_generated/server";
 import { v } from "convex/values";
-import type { Id } from "./_generated/dataModel";
-import { adminEmailStatus, requireEventAdmin } from "./admins";
+import type { Doc, Id } from "./_generated/dataModel";
+import { adminEmailStatus, requireAdmin, requireEventAdmin } from "./admins";
 import { isBlacklisted, recordBlacklistHit } from "./blacklist";
 import { logAudit } from "./auditLog";
 
@@ -259,6 +259,98 @@ export const rejectFlagged = mutation({
       subjectEmail: flagged.email,
       details: `Duplicate across ${flagged.matchedEventIds.length} other event(s)`,
     });
+  },
+});
+
+const ATTENDEE_SEARCH_ROWS = 200;
+const ATTENDEE_SEARCH_LIMIT = 20;
+
+// Cross-event history for addresses starting with `query`: every event the
+// address was made eligible for, plus any code claims (which may exist even
+// without an eligible-list row, e.g. after a re-claim or list cleanup).
+// Prefix matching lets both lookups stay on their email indexes.
+export const searchAttendees = query({
+  args: { query: v.string() },
+  handler: async (ctx, args) => {
+    await requireAdmin(ctx);
+    const prefix = args.query.trim().toLowerCase();
+    if (!prefix) return { attendees: [], hasMore: false };
+    const upper = prefix + "\uffff";
+
+    const eligibleRows = await ctx.db
+      .query("emails")
+      .withIndex("by_email", (q) => q.gte("email", prefix).lt("email", upper))
+      .take(ATTENDEE_SEARCH_ROWS);
+    const claimRows = await ctx.db
+      .query("codes")
+      .withIndex("by_claimedBy", (q) =>
+        q.gte("claimedBy", prefix).lt("claimedBy", upper)
+      )
+      .take(ATTENDEE_SEARCH_ROWS);
+
+    type EventHistory = { eligible: boolean; claimedAt: number | null };
+    const byEmail = new Map<string, Map<Id<"events">, EventHistory>>();
+    const historyFor = (email: string, eventId: Id<"events">) => {
+      let events = byEmail.get(email);
+      if (!events) {
+        events = new Map();
+        byEmail.set(email, events);
+      }
+      let history = events.get(eventId);
+      if (!history) {
+        history = { eligible: false, claimedAt: null };
+        events.set(eventId, history);
+      }
+      return history;
+    };
+    for (const row of eligibleRows) {
+      historyFor(row.email, row.eventId).eligible = true;
+    }
+    for (const code of claimRows) {
+      if (!code.claimedBy) continue;
+      const history = historyFor(code.claimedBy, code.eventId);
+      const claimedAt = code.claimedAt ?? code._creationTime;
+      if (history.claimedAt === null || claimedAt > history.claimedAt) {
+        history.claimedAt = claimedAt;
+      }
+    }
+
+    const emails = [...byEmail.keys()].sort();
+    const hasMore =
+      emails.length > ATTENDEE_SEARCH_LIMIT ||
+      eligibleRows.length === ATTENDEE_SEARCH_ROWS ||
+      claimRows.length === ATTENDEE_SEARCH_ROWS;
+
+    const eventCache = new Map<Id<"events">, Doc<"events"> | null>();
+    const attendees = [];
+    for (const email of emails.slice(0, ATTENDEE_SEARCH_LIMIT)) {
+      const events = [];
+      for (const [eventId, history] of byEmail.get(email)!) {
+        let event = eventCache.get(eventId);
+        if (event === undefined) {
+          event = await ctx.db.get(eventId);
+          eventCache.set(eventId, event);
+        }
+        if (!event) continue;
+        events.push({
+          id: eventId,
+          name: event.name,
+          eventDate: event.eventDate ?? null,
+          createdAt: event._creationTime,
+          eligible: history.eligible,
+          claimedAt: history.claimedAt,
+        });
+      }
+      // Most recent event first; undated events fall back to creation order.
+      events.sort((a, b) => {
+        if (a.eventDate && b.eventDate && a.eventDate !== b.eventDate) {
+          return a.eventDate < b.eventDate ? 1 : -1;
+        }
+        return b.createdAt - a.createdAt;
+      });
+      attendees.push({ email, events });
+    }
+    return { attendees, hasMore };
   },
 });
 

--- a/convex/emails.ts
+++ b/convex/emails.ts
@@ -327,18 +327,21 @@ export const searchAttendees = query({
         }
         return history;
       };
-      const eligible = await ctx.db
+      // One extra row past the cap tells us whether anything was cut off.
+      const eligibleRows = await ctx.db
         .query("emails")
         .withIndex("by_email", (q) => q.eq("email", email))
-        .take(ATTENDEE_HISTORY_ROWS);
-      for (const row of eligible) {
+        .take(ATTENDEE_HISTORY_ROWS + 1);
+      const eligibilityTruncated = eligibleRows.length > ATTENDEE_HISTORY_ROWS;
+      for (const row of eligibleRows.slice(0, ATTENDEE_HISTORY_ROWS)) {
         historyFor(row.eventId).eligible = true;
       }
-      const claims = await ctx.db
+      const claimRows = await ctx.db
         .query("codes")
         .withIndex("by_claimedBy", (q) => q.eq("claimedBy", email))
-        .take(ATTENDEE_HISTORY_ROWS);
-      for (const code of claims) {
+        .take(ATTENDEE_HISTORY_ROWS + 1);
+      const claimsTruncated = claimRows.length > ATTENDEE_HISTORY_ROWS;
+      for (const code of claimRows.slice(0, ATTENDEE_HISTORY_ROWS)) {
         const history = historyFor(code.eventId);
         const claimedAt = code.claimedAt ?? code._creationTime;
         if (history.claimedAt === null || claimedAt > history.claimedAt) {
@@ -358,9 +361,8 @@ export const searchAttendees = query({
       rows.sort((a, b) => eventTimestamp(b.event) - eventTimestamp(a.event));
       attendees.push({
         email,
-        historyTruncated:
-          eligible.length === ATTENDEE_HISTORY_ROWS ||
-          claims.length === ATTENDEE_HISTORY_ROWS,
+        eligibilityTruncated,
+        claimsTruncated,
         events: rows.map(({ event, history }) => ({
           id: event._id,
           name: event.name,


### PR DESCRIPTION
## Summary
The blacklist page's search bar now does double duty: it still filters the blacklist, and once you type it also looks up which events matching addresses have attended. One bar, two result sections ("Blacklist" and "Event history"), so a global admin can vet an address in one place.

**Backend** — new `emails.searchAttendees({ query })` (global admin only). Prefix-matches on the existing `emails.by_email` and `codes.by_claimedBy` indexes:

```ts
emails.by_email    gte(prefix) lt(prefix + "\uffff")   → eligible rows
codes.by_claimedBy gte(prefix) lt(prefix + "\uffff")   → claim rows
→ group by email → per event { eligible, claimedAt (latest) }
→ returns { attendees: [{ email, events: [{ id, name, eventDate, eligible, claimedAt }] }], hasMore }
```

Reads are bounded (`take(200)` per table, first 20 distinct emails returned, `hasMore` when truncated) so it stays inside Convex read limits on big lists. Claims are included even when the address is no longer on the eligible list, so re-claims / list cleanups don't hide history.

**UI** (`app/admin/blacklist/page.tsx`)
- Search bar is always shown now (previously only when the blacklist was non-empty), with a one-line hint about what it searches.
- Empty query → unchanged blacklist view. Non-empty → "Blacklist" section (substring filter, as before) + "Event history" section: each attendee shows a `Blacklisted` badge or a quick **Blacklist** button, and per-event rows linking to `/admin/events/[id]` with the event date and `Claimed <date>` / `Eligible, not claimed`.
- The backend lookup is debounced 250ms; the filter stays instant.

Note: the history lookup is prefix-based (indexed), while the blacklist filter remains substring — the empty state says "No attendees start with …" to make that explicit.

Link to Devin session: https://app.devin.ai/sessions/d7bbf09809db46e495121e3271de2e45
Open in Devin Desktop: https://app.devin.ai/desktop/session/d7bbf09809db46e495121e3271de2e45?variant=devin
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/179" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->