### PR TITLE
Add Pro/Max redemption instruction presets to event forms

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -40,6 +40,7 @@ import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { Textarea } from "@/components/ui/textarea";
+import { ClaimInstructionsField } from "@/components/ClaimInstructionsField";
 
 interface ManagedEventItem {
   _id: string;
@@ -287,22 +288,12 @@ function NewEventDialog() {
                 Optional — shown on the home and claim pages.
               </FieldDescription>
             </Field>
-            <Field>
-              <FieldLabel htmlFor="event-instructions">
-                Redemption instructions
-              </FieldLabel>
-              <Textarea
-                id="event-instructions"
-                value={claimInstructions}
-                onChange={(e) => setClaimInstructions(e.target.value)}
-                placeholder="How to redeem the code after claiming"
-                rows={4}
-                className="resize-y"
-              />
-              <FieldDescription>
-                Optional — shown to attendees after they claim a code.
-              </FieldDescription>
-            </Field>
+            <ClaimInstructionsField
+              id="event-instructions"
+              value={claimInstructions}
+              onChange={setClaimInstructions}
+              description="Optional — shown to attendees after they claim a code."
+            />
             <Field orientation="horizontal">
               <Checkbox
                 id="event-hidden"

--- a/components/ClaimInstructionsField.tsx
+++ b/components/ClaimInstructionsField.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useState } from "react";
+import {
+  CLAIM_INSTRUCTION_PRESETS,
+  claimInstructionsMode,
+  type ClaimInstructionsMode,
+} from "@/lib/claim-instructions";
+import { Field, FieldDescription, FieldLabel } from "@/components/ui/field";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Textarea } from "@/components/ui/textarea";
+
+const MODES: { value: ClaimInstructionsMode; label: string }[] = [
+  { value: "none", label: "None" },
+  ...Object.entries(CLAIM_INSTRUCTION_PRESETS).map(([value, preset]) => ({
+    value: value as ClaimInstructionsMode,
+    label: preset.label,
+  })),
+  { value: "custom", label: "Custom" },
+];
+
+export function ClaimInstructionsField({
+  id,
+  value,
+  onChange,
+  description,
+  className,
+}: {
+  id: string;
+  value: string;
+  onChange: (value: string) => void;
+  description: string;
+  className?: string;
+}) {
+  const [mode, setMode] = useState<ClaimInstructionsMode>(() =>
+    claimInstructionsMode(value)
+  );
+
+  function selectMode(next: ClaimInstructionsMode) {
+    setMode(next);
+    if (next === "none") onChange("");
+    else if (next === "custom") {
+      if (claimInstructionsMode(value) !== "custom") onChange("");
+    } else onChange(CLAIM_INSTRUCTION_PRESETS[next].text);
+  }
+
+  return (
+    <Field className={className}>
+      <FieldLabel htmlFor={id}>Redemption instructions</FieldLabel>
+      <Tabs
+        value={mode}
+        onValueChange={(next) => selectMode(next as ClaimInstructionsMode)}
+      >
+        <TabsList className="w-full" aria-label="Redemption instructions">
+          {MODES.map((m) => (
+            <TabsTrigger key={m.value} value={m.value}>
+              {m.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+      </Tabs>
+      {mode === "custom" ? (
+        <Textarea
+          id={id}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder="How to redeem the code after claiming"
+          rows={4}
+          className="resize-y"
+        />
+      ) : mode !== "none" ? (
+        <p
+          id={id}
+          className="rounded-md border bg-muted/40 px-3 py-2 text-sm text-muted-foreground"
+        >
+          {CLAIM_INSTRUCTION_PRESETS[mode].text}
+        </p>
+      ) : null}
+      <FieldDescription>{description}</FieldDescription>
+    </Field>
+  );
+}

--- a/components/ManageEvent.tsx
+++ b/components/ManageEvent.tsx
@@ -71,6 +71,7 @@ import { Progress } from "@/components/ui/progress";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { Textarea } from "@/components/ui/textarea";
+import { ClaimInstructionsField } from "@/components/ClaimInstructionsField";
 
 const UPLOAD_CHUNK_SIZE = 500;
 
@@ -1556,22 +1557,13 @@ function EventDetailsForm({
                 Optional — shown on the home and claim pages.
               </FieldDescription>
             </Field>
-            <Field className="sm:col-span-2">
-              <FieldLabel htmlFor="detail-instructions">
-                Redemption instructions
-              </FieldLabel>
-              <Textarea
-                id="detail-instructions"
-                value={claimInstructions}
-                onChange={(e) => setClaimInstructions(e.target.value)}
-                rows={4}
-                className="resize-y"
-              />
-              <FieldDescription>
-                Optional — when set, attendees see a &ldquo;How to
-                redeem&rdquo; button after claiming their code.
-              </FieldDescription>
-            </Field>
+            <ClaimInstructionsField
+              id="detail-instructions"
+              className="sm:col-span-2"
+              value={claimInstructions}
+              onChange={setClaimInstructions}
+              description="Optional — when set, attendees see a “How to redeem” button after claiming their code."
+            />
             <Field orientation="horizontal" className="sm:col-span-2">
               <Checkbox
                 id="detail-hidden"

--- a/lib/claim-instructions.ts
+++ b/lib/claim-instructions.ts
@@ -1,0 +1,24 @@
+export const CLAIM_INSTRUCTION_PRESETS = {
+  pro: {
+    label: "Pro",
+    text: "Redeem at checkout for a free Devin Pro plan. If you had a previous Windsurf account and your code does not work, try using a new email address.",
+  },
+  max: {
+    label: "Max",
+    text: "Redeem at checkout for a free Devin Max plan. If you had a previous Windsurf account and your code does not work, try using a new email address.",
+  },
+} as const;
+
+export type ClaimInstructionPreset = keyof typeof CLAIM_INSTRUCTION_PRESETS;
+
+export type ClaimInstructionsMode = "none" | ClaimInstructionPreset | "custom";
+
+export function claimInstructionsMode(
+  instructions: string
+): ClaimInstructionsMode {
+  if (!instructions.trim()) return "none";
+  for (const [key, preset] of Object.entries(CLAIM_INSTRUCTION_PRESETS)) {
+    if (preset.text === instructions) return key as ClaimInstructionPreset;
+  }
+  return "custom";
+}


### PR DESCRIPTION
## Summary

Replaces the free-text "Redemption instructions" textarea in the new-event dialog and the event-details editor with a `ClaimInstructionsField` that offers a segmented choice: **None / Pro / Max / Custom**.

- Preset text lives in `lib/claim-instructions.ts` (`CLAIM_INSTRUCTION_PRESETS`); Pro/Max show the preset as a read-only preview, Custom shows the textarea, None clears the value.
- No schema or backend change — the field still emits a plain `claimInstructions` string, so existing events keep working. On edit, the mode is derived from the saved text (`claimInstructionsMode`): exact preset match → Pro/Max, other text → Custom, empty → None.
- Switching to Custom from None/preset starts with an empty textarea; switching between presets replaces the value.


Link to Devin session: https://app.devin.ai/sessions/dceb2069aec6401fa03737a3cd3a0aeb
Open in Devin Desktop: https://app.devin.ai/desktop/session/dceb2069aec6401fa03737a3cd3a0aeb?variant=devin
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/180" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->