### PR TITLE
Add live event showcase with attendee submissions and crowd voting

### DIFF
--- a/app/[slug]/showcase/page.tsx
+++ b/app/[slug]/showcase/page.tsx
@@ -1,0 +1,10 @@
+import ShowcasePage from "@/components/ShowcasePage";
+
+export default async function EventShowcasePage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  return <ShowcasePage slug={slug} />;
+}

--- a/components/ClaimPage.tsx
+++ b/components/ClaimPage.tsx
@@ -14,6 +14,7 @@ import {
   QrCode,
   ShieldCheck,
   SearchX,
+  Sparkles,
   Undo2,
 } from "lucide-react";
 import { QRCodeSVG } from "qrcode.react";
@@ -562,6 +563,26 @@ export default function ClaimPage({
               </div>
             </div>
           )}
+          {event?.showcaseOpen ? (
+            <Link
+              href={`/${slug}/showcase`}
+              className="group mt-4 flex items-center justify-between gap-3 rounded-xl border border-border bg-card px-5 py-4 text-sm transition-colors hover:border-brand/60 hover:bg-muted/40 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+            >
+              <span className="flex min-w-0 items-center gap-3">
+                <Sparkles className="size-4 shrink-0 text-brand" aria-hidden />
+                <span className="min-w-0">
+                  <span className="block font-medium">Live showcase</span>
+                  <span className="block text-xs text-muted-foreground">
+                    Share what you built and vote for crowd favorites
+                  </span>
+                </span>
+              </span>
+              <ArrowUpRight
+                className="size-4 shrink-0 text-muted-dim transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5 group-hover:text-foreground"
+                aria-hidden
+              />
+            </Link>
+          ) : null}
         </div>
       </main>
       <SiteFooter />

--- a/components/ManageEvent.tsx
+++ b/components/ManageEvent.tsx
@@ -16,6 +16,7 @@ import {
   QrCode,
   RotateCcw,
   ShieldCheck,
+  Sparkles,
   Ticket,
   Trash2,
   Upload,
@@ -468,6 +469,11 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
               <QrCode data-icon="inline-start" />
               Walk-up claim
             </Button>
+            <ShowcaseToggle
+              eventId={id}
+              slug={event.slug}
+              open={event.showcaseOpen}
+            />
             <Button
               variant="outline"
               render={
@@ -1621,5 +1627,70 @@ function EventDetailsForm({
         </form>
       </CardContent>
     </Card>
+  );
+}
+
+// Opens or closes the live showcase where attendees share what they built
+// and vote for crowd favorites; links to the public board while open.
+function ShowcaseToggle({
+  eventId,
+  slug,
+  open,
+}: {
+  eventId: Id<"events">;
+  slug: string;
+  open: boolean;
+}) {
+  const setOpen = useMutation(api.showcase.setOpen);
+  const [busy, setBusy] = useState(false);
+
+  async function toggle() {
+    setBusy(true);
+    try {
+      await setOpen({ eventId, open: !open });
+      toast.success(open ? "Showcase closed" : "Showcase is live", {
+        description: open
+          ? "Entries and votes are frozen; the board stays visible."
+          : `Attendees can now submit and vote at /${slug}/showcase`,
+      });
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Couldn't update showcase");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <>
+      <Button
+        variant="outline"
+        onClick={toggle}
+        disabled={busy}
+        aria-busy={busy}
+        aria-pressed={open}
+      >
+        {busy ? (
+          <Spinner data-icon="inline-start" />
+        ) : (
+          <Sparkles
+            data-icon="inline-start"
+            className={cn(open && "text-brand")}
+          />
+        )}
+        {open ? "Close showcase" : "Open showcase"}
+      </Button>
+      {open ? (
+        <Button
+          variant="outline"
+          render={
+            <Link href={`/${slug}/showcase`} target="_blank" rel="noreferrer" />
+          }
+          nativeButton={false}
+        >
+          <span className="font-mono text-xs">/{slug}/showcase</span>
+          <ArrowUpRight data-icon="inline-end" />
+        </Button>
+      ) : null}
+    </>
   );
 }

--- a/components/ShowcasePage.tsx
+++ b/components/ShowcasePage.tsx
@@ -253,7 +253,10 @@ export default function ShowcasePage({ slug }: { slug: string }) {
                         canVote={board.event.showcaseOpen && board.canParticipate}
                         votesLeft={board.votesRemaining > 0}
                         pending={pendingId === entry._id}
-                        canRemove={entry.mine || board.viewerIsAdmin}
+                        canRemove={
+                          board.viewerIsAdmin ||
+                          (entry.mine && board.event.showcaseOpen)
+                        }
                         onVote={() => handleVote(entry)}
                         onRemove={() => handleRemove(entry)}
                       />

--- a/components/ShowcasePage.tsx
+++ b/components/ShowcasePage.tsx
@@ -1,0 +1,544 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import {
+  ArrowLeft,
+  ArrowUpRight,
+  Heart,
+  LogIn,
+  Pencil,
+  SearchX,
+  Sparkles,
+  Trash2,
+  Trophy,
+} from "lucide-react";
+import { toast } from "sonner";
+import { SignInButton } from "@clerk/nextjs";
+import { useConvexAuth, useMutation, useQuery } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import type { Id } from "@/convex/_generated/dataModel";
+import { cn } from "@/lib/utils";
+import SiteHeader from "@/components/SiteHeader";
+import SiteFooter from "@/components/SiteFooter";
+import { Alert, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
+import {
+  Field,
+  FieldDescription,
+  FieldGroup,
+  FieldLabel,
+} from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Spinner } from "@/components/ui/spinner";
+import { Textarea } from "@/components/ui/textarea";
+
+type Board = NonNullable<
+  ReturnType<typeof useQuery<typeof api.showcase.board>>
+>;
+type Entry = Board["entries"][number];
+
+function hostname(url: string) {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return url;
+  }
+}
+
+export default function ShowcasePage({ slug }: { slug: string }) {
+  const { isLoading: authLoading, isAuthenticated } = useConvexAuth();
+  const board = useQuery(api.showcase.board, { slug });
+  const toggleVote = useMutation(api.showcase.toggleVote);
+  const removeEntry = useMutation(api.showcase.remove);
+  const [pendingId, setPendingId] = useState<Id<"showcaseEntries"> | null>(null);
+
+  async function handleVote(entry: Entry) {
+    if (!board) return;
+    if (!isAuthenticated) {
+      toast.error("Sign in to vote.");
+      return;
+    }
+    if (!board.canParticipate) {
+      toast.error("Only attendees of this event can vote.");
+      return;
+    }
+    setPendingId(entry._id);
+    try {
+      await toggleVote({ slug, entryId: entry._id });
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Couldn't record your vote");
+    } finally {
+      setPendingId(null);
+    }
+  }
+
+  async function handleRemove(entry: Entry) {
+    try {
+      await removeEntry({ entryId: entry._id });
+      toast.success(entry.mine ? "Your entry was withdrawn" : "Entry removed");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Couldn't remove entry");
+    }
+  }
+
+  const mine = board?.entries.find((entry) => entry.mine);
+  const leaderIds = new Set(
+    board?.entries
+      .filter((entry) => entry.rank <= 3 && entry.voteCount > 0)
+      .map((entry) => entry._id),
+  );
+
+  return (
+    <div className="flex min-h-screen flex-col">
+      <SiteHeader />
+      <main id="main-content" className="flex-1">
+        <section className="mx-auto w-full max-w-5xl px-4 py-12 sm:px-6 sm:py-14">
+          {board === undefined ? (
+            <BoardSkeleton />
+          ) : board === null ? (
+            <Empty className="border border-dashed border-border-strong py-16">
+              <EmptyHeader>
+                <EmptyMedia variant="icon">
+                  <SearchX />
+                </EmptyMedia>
+                <EmptyTitle>Event not found</EmptyTitle>
+                <EmptyDescription>
+                  There is no event at <span className="font-mono">/{slug}</span>.
+                </EmptyDescription>
+              </EmptyHeader>
+            </Empty>
+          ) : (
+            <>
+              <div className="mb-10 flex flex-wrap items-end justify-between gap-6">
+                <div>
+                  <Button
+                    variant="ghost"
+                    size="xs"
+                    className="-ml-2 text-muted-foreground"
+                    render={<Link href={`/${slug}`} />}
+                    nativeButton={false}
+                  >
+                    <ArrowLeft data-icon="inline-start" />
+                    {board.event.name}
+                  </Button>
+                  <div className="mt-3 flex flex-wrap items-center gap-3">
+                    <h1 className="font-heading text-3xl font-semibold tracking-[-0.02em]">
+                      Showcase
+                    </h1>
+                    {board.event.showcaseOpen ? (
+                      <Badge variant="secondary" className="gap-1.5">
+                        <span
+                          className="size-1.5 animate-pulse rounded-full bg-brand motion-reduce:animate-none"
+                          aria-hidden
+                        />
+                        Live
+                      </Badge>
+                    ) : (
+                      <Badge variant="secondary">Closed</Badge>
+                    )}
+                  </div>
+                  <p className="mt-2 max-w-prose text-sm text-muted-foreground">
+                    See what attendees built and vote for your crowd
+                    favorites. Everyone gets {board.maxVotes} votes; results
+                    update live.
+                  </p>
+                </div>
+                <div className="flex flex-wrap items-center gap-2">
+                  {board.viewerIsAdmin ? (
+                    <Button
+                      variant="outline"
+                      render={<Link href={`/admin/events/${board.event._id}`} />}
+                      nativeButton={false}
+                    >
+                      Manage
+                    </Button>
+                  ) : null}
+                  {board.event.showcaseOpen && board.canParticipate ? (
+                    <SubmitDialog slug={slug} existing={mine} />
+                  ) : null}
+                </div>
+              </div>
+
+              {!board.event.showcaseOpen ? (
+                <Alert className="mb-6">
+                  <Trophy />
+                  <AlertTitle>
+                    {board.entries.length > 0
+                      ? "Voting has closed — here are the final standings."
+                      : "The showcase isn't open yet. Check back during the event."}
+                  </AlertTitle>
+                </Alert>
+              ) : authLoading ? null : !isAuthenticated ? (
+                <Alert className="mb-6">
+                  <LogIn />
+                  <AlertTitle className="flex flex-wrap items-center justify-between gap-3">
+                    <span>Sign in to share your project and vote.</span>
+                    <SignInButton mode="modal">
+                      <Button size="xs" variant="brand">
+                        Sign in
+                      </Button>
+                    </SignInButton>
+                  </AlertTitle>
+                </Alert>
+              ) : !board.canParticipate ? (
+                <Alert className="mb-6">
+                  <Sparkles />
+                  <AlertTitle>
+                    Voting is for attendees of this event. You can still follow
+                    along live.
+                  </AlertTitle>
+                </Alert>
+              ) : (
+                <div className="mb-6 flex flex-wrap items-center justify-between gap-3 text-sm text-muted-foreground">
+                  <span>
+                    <span className="font-medium text-foreground tabular-nums">
+                      {board.votesRemaining}
+                    </span>{" "}
+                    of {board.maxVotes} votes left
+                  </span>
+                  <span className="tabular-nums">
+                    {board.entries.length}{" "}
+                    {board.entries.length === 1 ? "project" : "projects"} ·{" "}
+                    {board.totalVotes} {board.totalVotes === 1 ? "vote" : "votes"}
+                  </span>
+                </div>
+              )}
+
+              {board.entries.length === 0 ? (
+                <Empty className="border border-dashed border-border-strong py-16">
+                  <EmptyHeader>
+                    <EmptyMedia variant="icon">
+                      <Sparkles />
+                    </EmptyMedia>
+                    <EmptyTitle>Nothing here yet</EmptyTitle>
+                    <EmptyDescription>
+                      {board.event.showcaseOpen && board.canParticipate
+                        ? "Be the first to share what you built."
+                        : "Projects will appear here as attendees share them."}
+                    </EmptyDescription>
+                  </EmptyHeader>
+                </Empty>
+              ) : (
+                <ol className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                  {board.entries.map((entry) => (
+                    <li key={entry._id} className="flex">
+                      <EntryCard
+                        entry={entry}
+                        leader={leaderIds.has(entry._id)}
+                        canVote={board.event.showcaseOpen && board.canParticipate}
+                        votesLeft={board.votesRemaining > 0}
+                        pending={pendingId === entry._id}
+                        canRemove={entry.mine || board.viewerIsAdmin}
+                        onVote={() => handleVote(entry)}
+                        onRemove={() => handleRemove(entry)}
+                      />
+                    </li>
+                  ))}
+                </ol>
+              )}
+            </>
+          )}
+        </section>
+      </main>
+      <SiteFooter />
+    </div>
+  );
+}
+
+function EntryCard({
+  entry,
+  leader,
+  canVote,
+  votesLeft,
+  pending,
+  canRemove,
+  onVote,
+  onRemove,
+}: {
+  entry: Entry;
+  leader: boolean;
+  canVote: boolean;
+  votesLeft: boolean;
+  pending: boolean;
+  canRemove: boolean;
+  onVote: () => void;
+  onRemove: () => void;
+}) {
+  const disabled =
+    !canVote || entry.mine || pending || (!entry.voted && !votesLeft);
+  return (
+    <Card
+      className={cn(
+        "w-full transition-shadow",
+        leader && "border-brand/60 shadow-[0_2px_24px_-8px_var(--brand)]",
+      )}
+    >
+      <CardHeader>
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex min-w-0 items-center gap-2">
+            <span
+              className={cn(
+                "font-mono text-xs tabular-nums text-muted-foreground",
+                leader && "text-brand",
+              )}
+            >
+              #{entry.rank}
+            </span>
+            {leader ? (
+              <Trophy className="size-3.5 text-brand" aria-label="Crowd favorite" />
+            ) : null}
+            {entry.mine ? (
+              <Badge variant="secondary" className="text-[10px]">
+                Yours
+              </Badge>
+            ) : null}
+          </div>
+          {canRemove ? (
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              className="-mt-1 -mr-2 text-muted-foreground"
+              onClick={onRemove}
+              aria-label={entry.mine ? "Withdraw your entry" : "Remove entry"}
+              title={entry.mine ? "Withdraw your entry" : "Remove entry"}
+            >
+              <Trash2 />
+            </Button>
+          ) : null}
+        </div>
+        <CardTitle className="font-heading text-lg text-balance wrap-anywhere">
+          {entry.title}
+        </CardTitle>
+        {entry.email ? (
+          <CardDescription className="font-mono text-xs wrap-anywhere">
+            {entry.email}
+          </CardDescription>
+        ) : null}
+      </CardHeader>
+      <CardContent className="flex flex-1 flex-col gap-4">
+        {entry.description ? (
+          <p className="text-sm leading-relaxed whitespace-pre-wrap wrap-anywhere text-muted-foreground">
+            {entry.description}
+          </p>
+        ) : null}
+        <div className="mt-auto flex items-center justify-between gap-3">
+          {entry.url ? (
+            <a
+              href={entry.url}
+              target="_blank"
+              rel="noreferrer"
+              className="group flex min-w-0 items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+            >
+              <span className="truncate">{hostname(entry.url)}</span>
+              <ArrowUpRight
+                className="size-3 shrink-0 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
+                aria-hidden
+              />
+            </a>
+          ) : (
+            <span />
+          )}
+          <Button
+            variant={entry.voted ? "brand" : "outline"}
+            size="sm"
+            onClick={onVote}
+            disabled={disabled}
+            aria-pressed={entry.voted}
+            aria-busy={pending}
+            aria-label={`${entry.voted ? "Remove vote for" : "Vote for"} ${entry.title}`}
+            className="shrink-0 tabular-nums"
+          >
+            {pending ? (
+              <Spinner data-icon="inline-start" />
+            ) : (
+              <Heart
+                data-icon="inline-start"
+                className={cn(entry.voted && "fill-current")}
+              />
+            )}
+            {entry.voteCount}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function SubmitDialog({
+  slug,
+  existing,
+}: {
+  slug: string;
+  existing?: Entry;
+}) {
+  const submit = useMutation(api.showcase.submit);
+  const [open, setOpen] = useState(false);
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [url, setUrl] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  function handleOpenChange(next: boolean) {
+    if (next) {
+      setTitle(existing?.title ?? "");
+      setDescription(existing?.description ?? "");
+      setUrl(existing?.url ?? "");
+    }
+    setOpen(next);
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    try {
+      const result = await submit({
+        slug,
+        title,
+        description: description || undefined,
+        url: url || undefined,
+      });
+      toast.success(result.updated ? "Entry updated" : "You're in the showcase");
+      setOpen(false);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Couldn't submit");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger render={<Button variant={existing ? "outline" : "brand"} />}>
+        {existing ? (
+          <>
+            <Pencil data-icon="inline-start" />
+            Edit my entry
+          </>
+        ) : (
+          <>
+            <Sparkles data-icon="inline-start" />
+            Share what you built
+          </>
+        )}
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="font-heading tracking-tight">
+            {existing ? "Edit your entry" : "Share what you built"}
+          </DialogTitle>
+          <DialogDescription>
+            One entry per attendee. Other attendees vote for their favorites.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-6">
+          <FieldGroup>
+            <Field>
+              <FieldLabel htmlFor="showcase-title">Project name</FieldLabel>
+              <Input
+                id="showcase-title"
+                required
+                maxLength={80}
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder="What did you build?"
+                autoFocus
+              />
+            </Field>
+            <Field>
+              <FieldLabel htmlFor="showcase-description">
+                What it does
+              </FieldLabel>
+              <Textarea
+                id="showcase-description"
+                rows={4}
+                maxLength={500}
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                className="resize-y"
+              />
+              <FieldDescription>Optional — a sentence or two.</FieldDescription>
+            </Field>
+            <Field>
+              <FieldLabel htmlFor="showcase-url">Link</FieldLabel>
+              <Input
+                id="showcase-url"
+                type="text"
+                inputMode="url"
+                value={url}
+                onChange={(e) => setUrl(e.target.value)}
+                placeholder="github.com/you/project"
+              />
+              <FieldDescription>Optional — demo, repo, or video.</FieldDescription>
+            </Field>
+          </FieldGroup>
+          <Button
+            type="submit"
+            variant="brand"
+            size="lg"
+            className="w-full"
+            disabled={saving}
+            aria-busy={saving}
+          >
+            {saving ? (
+              <>
+                <Spinner data-icon="inline-start" />
+                Saving...
+              </>
+            ) : existing ? (
+              "Save changes"
+            ) : (
+              "Add to showcase"
+            )}
+          </Button>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function BoardSkeleton() {
+  return (
+    <div role="status" aria-label="Loading showcase">
+      <Skeleton className="mb-3 h-4 w-32 rounded-sm" />
+      <Skeleton className="mb-10 h-9 w-48 rounded-sm" />
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {[0, 1, 2].map((i) => (
+          <div
+            key={i}
+            className="flex flex-col gap-4 rounded-xl border border-border bg-card p-6"
+          >
+            <Skeleton className="h-4 w-10 rounded-sm" />
+            <Skeleton className="h-6 w-3/4 rounded-sm" />
+            <Skeleton className="h-4 w-full rounded-sm" />
+            <Skeleton className="h-7 w-16 self-end rounded-md" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -19,6 +19,7 @@ import type * as emails from "../emails.js";
 import type * as eventAdmins from "../eventAdmins.js";
 import type * as events from "../events.js";
 import type * as notifications from "../notifications.js";
+import type * as showcase from "../showcase.js";
 import type * as stripeBatchModel from "../stripeBatchModel.js";
 import type * as stripeBatches from "../stripeBatches.js";
 import type * as stripeValidation from "../stripeValidation.js";
@@ -43,6 +44,7 @@ declare const fullApi: ApiFromModules<{
   eventAdmins: typeof eventAdmins;
   events: typeof events;
   notifications: typeof notifications;
+  showcase: typeof showcase;
   stripeBatchModel: typeof stripeBatchModel;
   stripeBatches: typeof stripeBatches;
   stripeValidation: typeof stripeValidation;

--- a/convex/events.ts
+++ b/convex/events.ts
@@ -3,6 +3,7 @@ import { ConvexError, v } from "convex/values";
 import { attachBatchToEvent, startBatch } from "./stripeBatchModel";
 import { generationFields } from "./stripeValidation";
 import { notExpired } from "./codeExpiry";
+import { deleteShowcaseForEvent } from "./showcase";
 import {
   adminEmailStatus,
   isEventAdmin,
@@ -104,6 +105,7 @@ export const getBySlug = query({
       claimInstructions: event.claimInstructions,
       creditAmount: event.creditAmount,
       codeTypeValues: event.codeTypeValues,
+      showcaseOpen: event.showcaseOpen === true,
       // Lets the claim page show a manage link to this event's admins.
       viewerIsAdmin: await isEventAdmin(ctx, event._id),
       soldOut: availableTypes.size === 0,
@@ -134,6 +136,7 @@ export const get = query({
       eventDate: event.eventDate,
       claimInstructions: event.claimInstructions,
       hidden: event.hidden,
+      showcaseOpen: event.showcaseOpen === true,
     };
   },
 });
@@ -287,6 +290,7 @@ export const remove = mutation({
       .withIndex("by_event", (q) => q.eq("eventId", args.id))
       .collect();
     for (const entry of auditLogs) await ctx.db.delete(entry._id);
+    await deleteShowcaseForEvent(ctx, args.id);
     await ctx.db.delete(args.id);
   },
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -61,7 +61,31 @@ export default defineSchema({
     // Optional free-text value per code block, keyed by type ("" = unnamed),
     // e.g. "100" or "Team plan". Rendered with a "$" prefix only when numeric.
     codeTypeValues: v.optional(v.record(v.string(), v.string())),
+    // When set, attendees can share what they built and vote on the
+    // event's live showcase page.
+    showcaseOpen: v.optional(v.boolean()),
   }).index("by_slug", ["slug"]),
+
+  showcaseEntries: defineTable({
+    eventId: v.id("events"),
+    email: v.string(),
+    title: v.string(),
+    description: v.optional(v.string()),
+    url: v.optional(v.string()),
+    // Denormalized vote tally kept in sync by showcase.toggleVote.
+    voteCount: v.number(),
+  })
+    .index("by_event", ["eventId"])
+    .index("by_event_email", ["eventId", "email"]),
+
+  showcaseVotes: defineTable({
+    eventId: v.id("events"),
+    entryId: v.id("showcaseEntries"),
+    voterEmail: v.string(),
+  })
+    .index("by_entry", ["entryId"])
+    .index("by_event_voter", ["eventId", "voterEmail"])
+    .index("by_entry_voter", ["entryId", "voterEmail"]),
 
   emails: defineTable({
     eventId: v.id("events"),

--- a/convex/showcase.ts
+++ b/convex/showcase.ts
@@ -1,0 +1,282 @@
+import { mutation, query, type MutationCtx, type QueryCtx } from "./_generated/server";
+import type { Doc, Id } from "./_generated/dataModel";
+import { v } from "convex/values";
+import { isEventAdmin, requireEventAdmin } from "./admins";
+import { logAudit } from "./auditLog";
+
+export const MAX_VOTES_PER_VOTER = 3;
+const TITLE_MAX = 80;
+const DESCRIPTION_MAX = 500;
+
+async function verifiedEmail(ctx: QueryCtx | MutationCtx) {
+  const identity = await ctx.auth.getUserIdentity();
+  const email = identity?.email?.trim().toLowerCase();
+  if (!email || identity?.emailVerified !== true) return null;
+  return email;
+}
+
+// Attendees are people on the whitelist or who already hold a code for the
+// event; event admins may also participate so they can seed and demo it.
+async function isAttendee(
+  ctx: QueryCtx | MutationCtx,
+  eventId: Id<"events">,
+  email: string,
+) {
+  const listed = await ctx.db
+    .query("emails")
+    .withIndex("by_event_email", (q) => q.eq("eventId", eventId).eq("email", email))
+    .unique();
+  if (listed) return true;
+  const claimed = await ctx.db
+    .query("codes")
+    .withIndex("by_event_claimedBy", (q) =>
+      q.eq("eventId", eventId).eq("claimedBy", email),
+    )
+    .first();
+  if (claimed) return true;
+  return isEventAdmin(ctx, eventId);
+}
+
+async function eventBySlug(ctx: QueryCtx | MutationCtx, slug: string) {
+  return ctx.db
+    .query("events")
+    .withIndex("by_slug", (q) => q.eq("slug", slug))
+    .unique();
+}
+
+function normalizeUrl(raw?: string) {
+  const trimmed = raw?.trim();
+  if (!trimmed) return undefined;
+  const withScheme = /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+  let parsed: URL;
+  try {
+    parsed = new URL(withScheme);
+  } catch {
+    throw new Error("Enter a valid link");
+  }
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    throw new Error("Links must start with http:// or https://");
+  }
+  return parsed.toString();
+}
+
+export const board = query({
+  args: { slug: v.string() },
+  handler: async (ctx, args) => {
+    const event = await eventBySlug(ctx, args.slug);
+    if (!event) return null;
+    const viewerEmail = await verifiedEmail(ctx);
+    const viewerIsAdmin = await isEventAdmin(ctx, event._id);
+    const canParticipate =
+      viewerEmail !== null && (await isAttendee(ctx, event._id, viewerEmail));
+
+    const entries = await ctx.db
+      .query("showcaseEntries")
+      .withIndex("by_event", (q) => q.eq("eventId", event._id))
+      .collect();
+    const myVotes = viewerEmail
+      ? await ctx.db
+          .query("showcaseVotes")
+          .withIndex("by_event_voter", (q) =>
+            q.eq("eventId", event._id).eq("voterEmail", viewerEmail),
+          )
+          .collect()
+      : [];
+    const votedIds = new Set(myVotes.map((vote) => vote.entryId));
+
+    const ranked = [...entries].sort(
+      (a, b) => b.voteCount - a.voteCount || a._creationTime - b._creationTime,
+    );
+    const totalVotes = entries.reduce((sum, entry) => sum + entry.voteCount, 0);
+
+    return {
+      event: {
+        _id: event._id,
+        name: event.name,
+        slug: event.slug,
+        showcaseOpen: event.showcaseOpen === true,
+      },
+      viewerIsAdmin,
+      canParticipate,
+      signedIn: viewerEmail !== null,
+      votesRemaining: MAX_VOTES_PER_VOTER - myVotes.length,
+      maxVotes: MAX_VOTES_PER_VOTER,
+      totalVotes,
+      entries: ranked.map((entry, index) => ({
+        _id: entry._id,
+        _creationTime: entry._creationTime,
+        title: entry.title,
+        description: entry.description,
+        url: entry.url,
+        voteCount: entry.voteCount,
+        rank: index + 1,
+        // Emails are only exposed to event admins (for moderation).
+        email: viewerIsAdmin ? entry.email : undefined,
+        mine: viewerEmail !== null && entry.email === viewerEmail,
+        voted: votedIds.has(entry._id),
+      })),
+    };
+  },
+});
+
+async function requireParticipant(ctx: MutationCtx, slug: string) {
+  const email = await verifiedEmail(ctx);
+  if (!email) {
+    throw new Error("Sign in with a verified email to join the showcase.");
+  }
+  const event = await eventBySlug(ctx, slug);
+  if (!event) throw new Error("Event not found");
+  if (event.showcaseOpen !== true) {
+    throw new Error("The showcase isn't open for this event.");
+  }
+  if (!(await isAttendee(ctx, event._id, email))) {
+    throw new Error("Only attendees of this event can take part in the showcase.");
+  }
+  return { email, event };
+}
+
+// One entry per attendee per event; resubmitting edits the existing entry.
+export const submit = mutation({
+  args: {
+    slug: v.string(),
+    title: v.string(),
+    description: v.optional(v.string()),
+    url: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const { email, event } = await requireParticipant(ctx, args.slug);
+    const title = args.title.trim().slice(0, TITLE_MAX);
+    if (!title) throw new Error("Give your project a title");
+    const description = args.description?.trim().slice(0, DESCRIPTION_MAX) || undefined;
+    const url = normalizeUrl(args.url);
+
+    const existing = await ctx.db
+      .query("showcaseEntries")
+      .withIndex("by_event_email", (q) =>
+        q.eq("eventId", event._id).eq("email", email),
+      )
+      .unique();
+    if (existing) {
+      await ctx.db.patch(existing._id, { title, description, url });
+      return { entryId: existing._id, updated: true as const };
+    }
+    const entryId = await ctx.db.insert("showcaseEntries", {
+      eventId: event._id,
+      email,
+      title,
+      description,
+      url,
+      voteCount: 0,
+    });
+    await logAudit(ctx, {
+      eventId: event._id,
+      action: "showcase_entry_submitted",
+      actorEmail: email,
+      subjectEmail: email,
+      details: title,
+    });
+    return { entryId, updated: false as const };
+  },
+});
+
+// Casts or retracts a vote. Voters get MAX_VOTES_PER_VOTER per event and
+// can't vote for their own entry.
+export const toggleVote = mutation({
+  args: { slug: v.string(), entryId: v.id("showcaseEntries") },
+  handler: async (ctx, args) => {
+    const { email, event } = await requireParticipant(ctx, args.slug);
+    const entry = await ctx.db.get(args.entryId);
+    if (!entry || entry.eventId !== event._id) {
+      throw new Error("That project is no longer in the showcase.");
+    }
+    if (entry.email === email) {
+      throw new Error("You can't vote for your own project.");
+    }
+    const existing = await ctx.db
+      .query("showcaseVotes")
+      .withIndex("by_entry_voter", (q) =>
+        q.eq("entryId", entry._id).eq("voterEmail", email),
+      )
+      .unique();
+    if (existing) {
+      await ctx.db.delete(existing._id);
+      await ctx.db.patch(entry._id, { voteCount: Math.max(0, entry.voteCount - 1) });
+      return { voted: false as const };
+    }
+    const cast = await ctx.db
+      .query("showcaseVotes")
+      .withIndex("by_event_voter", (q) =>
+        q.eq("eventId", event._id).eq("voterEmail", email),
+      )
+      .collect();
+    if (cast.length >= MAX_VOTES_PER_VOTER) {
+      throw new Error(
+        `You've used all ${MAX_VOTES_PER_VOTER} votes — remove one to vote for something else.`,
+      );
+    }
+    await ctx.db.insert("showcaseVotes", {
+      eventId: event._id,
+      entryId: entry._id,
+      voterEmail: email,
+    });
+    await ctx.db.patch(entry._id, { voteCount: entry.voteCount + 1 });
+    return { voted: true as const };
+  },
+});
+
+export const setOpen = mutation({
+  args: { eventId: v.id("events"), open: v.boolean() },
+  handler: async (ctx, args) => {
+    const adminEmail = await requireEventAdmin(ctx, args.eventId);
+    await ctx.db.patch(args.eventId, { showcaseOpen: args.open || undefined });
+    await logAudit(ctx, {
+      eventId: args.eventId,
+      action: args.open ? "showcase_opened" : "showcase_closed",
+      actorEmail: adminEmail ?? undefined,
+    });
+    return null;
+  },
+});
+
+async function deleteEntry(ctx: MutationCtx, entry: Doc<"showcaseEntries">) {
+  const votes = await ctx.db
+    .query("showcaseVotes")
+    .withIndex("by_entry", (q) => q.eq("entryId", entry._id))
+    .collect();
+  await Promise.all(votes.map((vote) => ctx.db.delete(vote._id)));
+  await ctx.db.delete(entry._id);
+}
+
+// Admin moderation, or an attendee withdrawing their own entry.
+export const remove = mutation({
+  args: { entryId: v.id("showcaseEntries") },
+  handler: async (ctx, args) => {
+    const entry = await ctx.db.get(args.entryId);
+    if (!entry) return null;
+    const email = await verifiedEmail(ctx);
+    if (entry.email !== email) {
+      await requireEventAdmin(ctx, entry.eventId);
+    }
+    await deleteEntry(ctx, entry);
+    await logAudit(ctx, {
+      eventId: entry.eventId,
+      action: "showcase_entry_removed",
+      actorEmail: email ?? undefined,
+      subjectEmail: entry.email,
+      details: entry.title,
+    });
+    return null;
+  },
+});
+
+// Called from events.remove so showcase data doesn't outlive its event.
+export async function deleteShowcaseForEvent(
+  ctx: MutationCtx,
+  eventId: Id<"events">,
+) {
+  const entries = await ctx.db
+    .query("showcaseEntries")
+    .withIndex("by_event", (q) => q.eq("eventId", eventId))
+    .collect();
+  for (const entry of entries) await deleteEntry(ctx, entry);
+}

--- a/convex/showcase.ts
+++ b/convex/showcase.ts
@@ -247,7 +247,8 @@ async function deleteEntry(ctx: MutationCtx, entry: Doc<"showcaseEntries">) {
   await ctx.db.delete(entry._id);
 }
 
-// Admin moderation, or an attendee withdrawing their own entry.
+// Admin moderation, or an attendee withdrawing their own entry while the
+// showcase is still open (closed standings are final).
 export const remove = mutation({
   args: { entryId: v.id("showcaseEntries") },
   handler: async (ctx, args) => {
@@ -256,6 +257,11 @@ export const remove = mutation({
     const email = await verifiedEmail(ctx);
     if (entry.email !== email) {
       await requireEventAdmin(ctx, entry.eventId);
+    } else if (!(await isEventAdmin(ctx, entry.eventId))) {
+      const event = await ctx.db.get(entry.eventId);
+      if (event?.showcaseOpen !== true) {
+        throw new Error("The showcase has closed — entries can no longer be withdrawn.");
+      }
     }
     await deleteEntry(ctx, entry);
     await logAudit(ctx, {

--- a/tests/showcase.test.ts
+++ b/tests/showcase.test.ts
@@ -1,0 +1,232 @@
+import { convexTest } from "convex-test";
+import { expect, test } from "vitest";
+import { api } from "../convex/_generated/api";
+import schema from "../convex/schema";
+
+const modules = import.meta.glob("../convex/**/*.ts");
+
+const admin = { subject: "admin", email: "admin@example.com", emailVerified: true };
+const alice = { subject: "alice", email: "alice@example.com", emailVerified: true };
+const bob = { subject: "bob", email: "bob@example.com", emailVerified: true };
+const carol = { subject: "carol", email: "carol@example.com", emailVerified: true };
+const stranger = { subject: "zed", email: "zed@example.com", emailVerified: true };
+
+async function setup(open = true) {
+  const t = convexTest(schema, modules);
+  const eventId = await t.run(async (ctx) => {
+    await ctx.db.insert("admins", { email: admin.email });
+    const eventId = await ctx.db.insert("events", {
+      name: "Hack Night",
+      slug: "hack-night",
+      showcaseOpen: open || undefined,
+    });
+    // Alice is whitelisted; Bob only holds a claimed code; Carol is both.
+    await ctx.db.insert("emails", { eventId, email: alice.email });
+    await ctx.db.insert("codes", { eventId, code: "B1", claimedBy: bob.email });
+    await ctx.db.insert("emails", { eventId, email: carol.email });
+    return eventId;
+  });
+  return { t, eventId };
+}
+
+test("attendees submit one entry each and can edit it", async () => {
+  const { t } = await setup();
+  const a = t.withIdentity(alice);
+  const first = await a.mutation(api.showcase.submit, {
+    slug: "hack-night",
+    title: "  Robot DJ  ",
+    url: "github.com/alice/robot-dj",
+  });
+  expect(first.updated).toBe(false);
+  const second = await a.mutation(api.showcase.submit, {
+    slug: "hack-night",
+    title: "Robot DJ v2",
+  });
+  expect(second).toEqual({ entryId: first.entryId, updated: true });
+
+  const board = await a.query(api.showcase.board, { slug: "hack-night" });
+  expect(board?.entries).toHaveLength(1);
+  expect(board?.entries[0]).toMatchObject({
+    title: "Robot DJ v2",
+    mine: true,
+    voteCount: 0,
+    rank: 1,
+  });
+  expect(board?.entries[0].email).toBeUndefined();
+  // The url was normalized on the first submit and cleared on the second.
+  expect(board?.entries[0].url).toBeUndefined();
+});
+
+test("only attendees of an open showcase may submit", async () => {
+  const { t } = await setup();
+  await expect(
+    t.mutation(api.showcase.submit, { slug: "hack-night", title: "Anon" }),
+  ).rejects.toThrow(/sign in/i);
+  await expect(
+    t.withIdentity(stranger).mutation(api.showcase.submit, {
+      slug: "hack-night",
+      title: "Gatecrasher",
+    }),
+  ).rejects.toThrow(/only attendees/i);
+  await expect(
+    t.withIdentity(alice).mutation(api.showcase.submit, {
+      slug: "hack-night",
+      title: "Bad link",
+      url: "javascript:alert(1)",
+    }),
+  ).rejects.toThrow(/link/i);
+
+  const { t: closed } = await setup(false);
+  await expect(
+    closed.withIdentity(alice).mutation(api.showcase.submit, {
+      slug: "hack-night",
+      title: "Too early",
+    }),
+  ).rejects.toThrow(/isn't open/i);
+});
+
+test("votes are capped, toggle off, exclude own entry, and rank the board", async () => {
+  const { t } = await setup();
+  const a = t.withIdentity(alice);
+  const b = t.withIdentity(bob);
+  const c = t.withIdentity(carol);
+  const { entryId: aliceEntry } = await a.mutation(api.showcase.submit, {
+    slug: "hack-night",
+    title: "Alice",
+  });
+  const { entryId: bobEntry } = await b.mutation(api.showcase.submit, {
+    slug: "hack-night",
+    title: "Bob",
+  });
+  const { entryId: carolEntry } = await c.mutation(api.showcase.submit, {
+    slug: "hack-night",
+    title: "Carol",
+  });
+
+  await expect(
+    a.mutation(api.showcase.toggleVote, { slug: "hack-night", entryId: aliceEntry }),
+  ).rejects.toThrow(/own project/i);
+
+  expect(
+    await a.mutation(api.showcase.toggleVote, { slug: "hack-night", entryId: bobEntry }),
+  ).toEqual({ voted: true });
+  await c.mutation(api.showcase.toggleVote, { slug: "hack-night", entryId: bobEntry });
+  await b.mutation(api.showcase.toggleVote, { slug: "hack-night", entryId: carolEntry });
+
+  let board = await a.query(api.showcase.board, { slug: "hack-night" });
+  expect(board?.entries.map((e) => [e.title, e.voteCount, e.rank])).toEqual([
+    ["Bob", 2, 1],
+    ["Carol", 1, 2],
+    ["Alice", 0, 3],
+  ]);
+  expect(board?.votesRemaining).toBe(2);
+  expect(board?.entries.find((e) => e.title === "Bob")?.voted).toBe(true);
+
+  // Toggling again retracts the vote.
+  expect(
+    await a.mutation(api.showcase.toggleVote, { slug: "hack-night", entryId: bobEntry }),
+  ).toEqual({ voted: false });
+  board = await a.query(api.showcase.board, { slug: "hack-night" });
+  expect(board?.votesRemaining).toBe(3);
+  expect(board?.entries[0]).toMatchObject({ title: "Bob", voteCount: 1 });
+
+  // Cap: a fourth distinct vote is refused.
+  const extra = await t.run(async (ctx) => {
+    const eventId = (await ctx.db.query("events").first())!._id;
+    return Promise.all(
+      ["d", "e"].map((n) =>
+        ctx.db.insert("showcaseEntries", {
+          eventId,
+          email: `${n}@example.com`,
+          title: n,
+          voteCount: 0,
+        }),
+      ),
+    );
+  });
+  await a.mutation(api.showcase.toggleVote, { slug: "hack-night", entryId: bobEntry });
+  await a.mutation(api.showcase.toggleVote, { slug: "hack-night", entryId: carolEntry });
+  await a.mutation(api.showcase.toggleVote, { slug: "hack-night", entryId: extra[0] });
+  await expect(
+    a.mutation(api.showcase.toggleVote, { slug: "hack-night", entryId: extra[1] }),
+  ).rejects.toThrow(/all 3 votes/i);
+
+  // Strangers and signed-out visitors can watch but not vote.
+  await expect(
+    t.withIdentity(stranger).mutation(api.showcase.toggleVote, {
+      slug: "hack-night",
+      entryId: bobEntry,
+    }),
+  ).rejects.toThrow(/only attendees/i);
+  const publicBoard = await t.query(api.showcase.board, { slug: "hack-night" });
+  expect(publicBoard).toMatchObject({
+    signedIn: false,
+    canParticipate: false,
+    viewerIsAdmin: false,
+  });
+  expect(publicBoard?.entries.every((e) => e.email === undefined)).toBe(true);
+});
+
+test("admins open/close the showcase, see emails, and moderate entries", async () => {
+  const { t, eventId } = await setup(false);
+  const a = t.withIdentity(alice);
+  const adm = t.withIdentity(admin);
+
+  await expect(
+    a.mutation(api.showcase.setOpen, { eventId, open: true }),
+  ).rejects.toThrow();
+  await adm.mutation(api.showcase.setOpen, { eventId, open: true });
+  expect(
+    (await t.query(api.events.getBySlug, { slug: "hack-night" }))?.showcaseOpen,
+  ).toBe(true);
+
+  const { entryId } = await a.mutation(api.showcase.submit, {
+    slug: "hack-night",
+    title: "Alice",
+  });
+  await t
+    .withIdentity(bob)
+    .mutation(api.showcase.toggleVote, { slug: "hack-night", entryId });
+
+  const board = await adm.query(api.showcase.board, { slug: "hack-night" });
+  expect(board?.viewerIsAdmin).toBe(true);
+  expect(board?.entries[0].email).toBe(alice.email);
+
+  await expect(
+    t.withIdentity(bob).mutation(api.showcase.remove, { entryId }),
+  ).rejects.toThrow();
+  await adm.mutation(api.showcase.remove, { entryId });
+  const votes = await t.run((ctx) => ctx.db.query("showcaseVotes").collect());
+  expect(votes).toHaveLength(0);
+  expect(
+    (await t.query(api.showcase.board, { slug: "hack-night" }))?.entries,
+  ).toEqual([]);
+
+  // Closing freezes submissions but the board remains readable.
+  await adm.mutation(api.showcase.setOpen, { eventId, open: false });
+  await expect(
+    a.mutation(api.showcase.submit, { slug: "hack-night", title: "Late" }),
+  ).rejects.toThrow(/isn't open/i);
+  expect(
+    (await t.query(api.showcase.board, { slug: "hack-night" }))?.event.showcaseOpen,
+  ).toBe(false);
+});
+
+test("deleting an event removes its showcase data", async () => {
+  const { t, eventId } = await setup();
+  const { entryId } = await t
+    .withIdentity(alice)
+    .mutation(api.showcase.submit, { slug: "hack-night", title: "Alice" });
+  await t
+    .withIdentity(bob)
+    .mutation(api.showcase.toggleVote, { slug: "hack-night", entryId });
+  await t.withIdentity(admin).mutation(api.events.remove, { id: eventId });
+  const [entries, votes] = await t.run((ctx) =>
+    Promise.all([
+      ctx.db.query("showcaseEntries").collect(),
+      ctx.db.query("showcaseVotes").collect(),
+    ]),
+  );
+  expect(entries).toEqual([]);
+  expect(votes).toEqual([]);
+});

--- a/tests/showcase.test.ts
+++ b/tests/showcase.test.ts
@@ -202,11 +202,23 @@ test("admins open/close the showcase, see emails, and moderate entries", async (
     (await t.query(api.showcase.board, { slug: "hack-night" }))?.entries,
   ).toEqual([]);
 
-  // Closing freezes submissions but the board remains readable.
+  // Closing freezes submissions and withdrawals but the board remains
+  // readable; admins can still moderate.
+  const { entryId: finalEntry } = await a.mutation(api.showcase.submit, {
+    slug: "hack-night",
+    title: "Final",
+  });
   await adm.mutation(api.showcase.setOpen, { eventId, open: false });
   await expect(
     a.mutation(api.showcase.submit, { slug: "hack-night", title: "Late" }),
   ).rejects.toThrow(/isn't open/i);
+  await expect(
+    a.mutation(api.showcase.remove, { entryId: finalEntry }),
+  ).rejects.toThrow(/closed/i);
+  expect(
+    (await t.query(api.showcase.board, { slug: "hack-night" }))?.entries,
+  ).toHaveLength(1);
+  await adm.mutation(api.showcase.remove, { entryId: finalEntry });
   expect(
     (await t.query(api.showcase.board, { slug: "hack-night" }))?.event.showcaseOpen,
   ).toBe(false);


### PR DESCRIPTION
## Summary

Adds a per-event live showcase at `/{slug}/showcase` where attendees share what they built and vote for crowd favorites. Convex subscriptions keep the board live for everyone watching (e.g. projected on a screen).

**Backend (`convex/showcase.ts`, new tables `showcaseEntries` / `showcaseVotes`, `events.showcaseOpen`)**
- `board({slug})` — public query; returns entries ranked by `voteCount` then submission time, plus viewer state (`canParticipate`, `votesRemaining`, `mine`, `voted`). Submitter emails are only returned to event admins.
- `submit({slug,title,description?,url?})` — one entry per attendee; resubmitting edits in place. URLs are normalized to http(s) (bare `github.com/x` → `https://github.com/x`; `javascript:` rejected).
- `toggleVote({slug,entryId})` — cast/retract; `MAX_VOTES_PER_VOTER = 3` per event, can't vote for your own entry. Tally is denormalized onto `showcaseEntries.voteCount`.
- `setOpen({eventId,open})` — event-admin gate. When closed, submit/vote are rejected but the board stays readable as final standings.
- `remove({entryId})` — owner or event admin; cascades votes. `events.remove` now also purges showcase data.
- "Attendee" = on the event whitelist **or** holds a claimed code for the event **or** is an event admin. Signed-out/non-attendees can watch but not participate.

**UI**
- `components/ShowcasePage.tsx` + `app/[slug]/showcase/page.tsx`: ranked card grid, top-3 with votes highlighted as crowd favorites, submit/edit dialog, vote-count buttons, remaining-votes counter, Live/Closed badge.
- `ManageEvent`: "Open showcase / Close showcase" toggle in the header actions with a link to the public board when open.
- `ClaimPage`: shows a "Live showcase" link card under the claim card when the event's showcase is open.

**Notes**
- `convex/_generated/api.d.ts` was edited by hand to register the `showcase` module (no `CONVEX_DEPLOYMENT` here to run codegen); the schema and functions need a Convex deploy before the UI works.
- Tests in `tests/showcase.test.ts` cover eligibility, editing, vote cap/toggle/self-vote, ranking, admin open/close/moderation, and cascade on event delete. `npm test`, `npm run lint`, and `tsc --noEmit` pass; `next build` compiles but the sandbox lacks `NEXT_PUBLIC_CONVEX_URL` so prerender can't finish here.

Link to Devin session: https://app.devin.ai/sessions/7f0c3cf71d4c4e9ab85d393ae9c9d425
Open in Devin Desktop: https://app.devin.ai/desktop/session/7f0c3cf71d4c4e9ab85d393ae9c9d425?variant=devin
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/181" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->