### PR TITLE
Use the same header font on the admin nav as the public header

### DIFF
--- a/components/AdminNav.tsx
+++ b/components/AdminNav.tsx
@@ -40,7 +40,7 @@ export default function AdminNav() {
             href={link.href}
             aria-current={active ? "page" : undefined}
             className={cn(
-              "rounded-md px-2.5 py-1.5 text-sm whitespace-nowrap transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60 sm:px-3",
+              "rounded-md px-2.5 py-1.5 font-mono text-[0.8rem] font-medium whitespace-nowrap transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60 sm:px-3",
               active
                 ? "bg-muted text-foreground"
                 : "text-muted-foreground hover:text-foreground"


### PR DESCRIPTION
## Summary
The public header's links ("Sign in", "My codes", "Admin") render through `Button`, which the recent design pass switched to `font-mono` (IBM Plex Mono). The admin header's nav (`AdminNav`: Events / Codes / Admins / Blacklist) is plain `Link`s and was still falling back to the body sans (General Sans), so the two headers showed different fonts.

`AdminNav` links now carry the same typography as `size="sm"` buttons:

```diff
- "rounded-md px-2.5 py-1.5 text-sm whitespace-nowrap …"
+ "rounded-md px-2.5 py-1.5 font-mono text-[0.8rem] font-medium whitespace-nowrap …"
```

No other header pieces changed (wordmark is an image; `ProfileMenu` trigger is an avatar; the "Admin" badge keeps the shared `Badge` style).

Link to Devin session: https://app.devin.ai/sessions/26b39c11c69c4df9bc721e407ddd6f59
Open in Devin Desktop: https://app.devin.ai/desktop/session/26b39c11c69c4df9bc721e407ddd6f59?variant=devin
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/183" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->