### PR TITLE
Render badges as plain text labels instead of pills

### DIFF
--- a/app/admin/admins/page.tsx
+++ b/app/admin/admins/page.tsx
@@ -153,7 +153,7 @@ export default function AdminsPage() {
                 {admin.isSelf ? (
                   <Badge
                     variant="outline"
-                    className="shrink-0 border-border-strong text-muted-foreground"
+                    className="shrink-0"
                   >
                     You
                   </Badge>

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -28,7 +28,7 @@ export default function AdminLayout({
             </Link>
             <Badge
               variant="outline"
-              className="shrink-0 border-border-strong text-muted-foreground"
+              className="shrink-0"
             >
               Admin
             </Badge>

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -5,20 +5,16 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const badgeVariants = cva(
-  "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/20 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
+  "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-sm text-xs font-medium whitespace-nowrap transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring aria-invalid:text-destructive [&>svg]:pointer-events-none [&>svg]:size-3!",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
-        secondary:
-          "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
-        destructive:
-          "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
-        outline:
-          "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
-        ghost:
-          "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
-        link: "text-primary underline-offset-4 hover:underline",
+        default: "text-foreground [a]:hover:text-muted-foreground",
+        secondary: "text-muted-foreground [a]:hover:text-foreground",
+        destructive: "text-destructive [a]:hover:text-destructive/80",
+        outline: "text-muted-foreground [a]:hover:text-foreground",
+        ghost: "text-muted-foreground hover:text-foreground",
+        link: "text-link underline-offset-4 hover:underline",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## Summary
Every small encircled label in the app ("Admin" in the header, "System admins only", "Hidden", "You", "Claimed", "Blacklisted", card counts, code-type tags, Stripe mode, …) is the shared `Badge` component. Rather than touch ~25 call sites, the pill treatment is removed at the source.

`badgeVariants` base: drops `rounded-4xl border px-2 py-0.5` and every variant's background/border fill; variants now only pick a text color:

```
default     → text-foreground
secondary   → text-muted-foreground
outline     → text-muted-foreground
destructive → text-destructive
ghost       → text-muted-foreground hover:text-foreground
link        → text-link hover:underline
```

Size, weight (`text-xs font-medium`), icon sizing, `h-5` line box, and `data-slot="badge"` are unchanged so surrounding layouts don't shift. The two callers that overrode `border-border-strong` had that dead override removed.

Link to Devin session: https://app.devin.ai/sessions/26b39c11c69c4df9bc721e407ddd6f59
Open in Devin Desktop: https://app.devin.ai/desktop/session/26b39c11c69c4df9bc721e407ddd6f59?variant=devin
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/184" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->