### PR TITLE
Home page: show only the last 7 days of past events; drop "Access control" eyebrow

### DIFF
--- a/app/admin/admins/page.tsx
+++ b/app/admin/admins/page.tsx
@@ -84,11 +84,7 @@ export default function AdminsPage() {
   return (
     <div className="mx-auto max-w-2xl">
       <div className="mb-10">
-        <p className="eyebrow flex items-center gap-2 text-muted-foreground">
-          <span className="inline-block size-1.5 rounded-full bg-border-strong" />
-          Access control
-        </p>
-        <h1 className="mt-3 font-heading text-3xl font-semibold tracking-[-0.02em]">
+        <h1 className="font-heading text-3xl font-semibold tracking-[-0.02em]">
           Admins
         </h1>
         <p className="mt-2 text-sm text-muted-foreground">

--- a/app/admin/blacklist/page.tsx
+++ b/app/admin/blacklist/page.tsx
@@ -174,11 +174,7 @@ export default function BlacklistPage() {
   return (
     <div className="mx-auto max-w-2xl">
       <div className="mb-10">
-        <p className="eyebrow flex items-center gap-2 text-muted-foreground">
-          <span className="inline-block size-1.5 rounded-full bg-border-strong" />
-          Access control
-        </p>
-        <h1 className="mt-3 font-heading text-3xl font-semibold tracking-[-0.02em]">
+        <h1 className="font-heading text-3xl font-semibold tracking-[-0.02em]">
           Blacklist
         </h1>
         <p className="mt-2 text-sm text-muted-foreground">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -22,6 +22,8 @@ import {
 import { cn } from "@/lib/utils";
 import { getAppName } from "@/lib/app-name";
 
+const RECENT_PAST_DAYS = 7;
+
 // The hero background is a theme-paired Unicorn Studio WebGL scene
 // (experiment). A Unicorn project publishes exactly one authored design and
 // the SDK has no color-scheme awareness, so a light-authored project shows
@@ -153,13 +155,13 @@ export default function Home() {
       .sort((a, b) => (a.eventDate ?? "").localeCompare(b.eventDate ?? "")),
     ...active.filter((e) => !e.eventDate),
   ];
-  // Past events drop off the page entirely once they are 14 days or more
-  // old; they stay reachable via their claim URL.
+  // Past events drop off the page entirely once they are RECENT_PAST_DAYS or
+  // more days old; they stay reachable via their claim URL.
   const past = (
     events?.filter((e) => {
       if (!e.eventDate) return false;
       const days = daysUntilEvent(e.eventDate);
-      return days < 0 && days > -14;
+      return days < 0 && days > -RECENT_PAST_DAYS;
     }) ?? []
   ).sort((a, b) => (b.eventDate ?? "").localeCompare(a.eventDate ?? ""));
 

--- a/tests/home-ui.test.tsx
+++ b/tests/home-ui.test.tsx
@@ -68,10 +68,10 @@ test.each(["light", "dark"])("the %s homepage preserves event links, grouping, a
 });
 
 test.each([
-  { date: "2026-08-25", visible: true },
+  { date: "2026-09-01", visible: true },
+  { date: "2026-08-31", visible: false },
+  { date: "2026-08-30", visible: false },
   { date: "2026-08-24", visible: false },
-  { date: "2026-08-23", visible: false },
-  { date: "2026-08-08", visible: false },
 ])("front page visibility for an event dated $date", ({ date, visible }) => {
   vi.setSystemTime(new Date(2026, 8, 7, 12));
   state.events = [{ _id: "boundary", name: "Boundary event", slug: "boundary", eventDate: date }];


### PR DESCRIPTION
## Summary
Two small UI requests:

**Home page past-events window: 14 → 7 days.** The cutoff in `app/page.tsx` is now `RECENT_PAST_DAYS = 7`; an event is listed under "Past events" while `0 < daysAgo < 7`, so an event exactly 7 days old drops off. Ended events stay reachable via their claim URL; the admin dashboard (14-day split with paged archive) is untouched. The boundary test in `tests/home-ui.test.tsx` was re-pinned to the new threshold (Sep 1 visible, Aug 31 hidden, with "today" = Sep 7).

**Removed the "Access control" eyebrow** (mono label + dot) above the `Admins` and `Blacklist` page titles, and the `mt-3` that spaced the `h1` beneath it.

Link to Devin session: https://app.devin.ai/sessions/26b39c11c69c4df9bc721e407ddd6f59
Open in Devin Desktop: https://app.devin.ai/desktop/session/26b39c11c69c4df9bc721e407ddd6f59?variant=devin
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/185" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->