### PR TITLE
Home page: rename "Past events" to "Recent past events" and drop its count

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -277,14 +277,9 @@ export default function Home() {
               )}
               {past.length > 0 ? (
                 <>
-                  <div className="mt-14 flex items-baseline justify-between">
-                    <h2 className="text-sm font-medium text-muted-foreground">
-                      Past events
-                    </h2>
-                    <span className="font-mono text-xs text-muted-dim tabular-nums">
-                      {String(past.length).padStart(2, "0")}
-                    </span>
-                  </div>
+                  <h2 className="mt-14 text-sm font-medium text-muted-foreground">
+                    Past events
+                  </h2>
                   <ul className="mt-4 border-t border-border">
                     {past.map((event, index) => (
                       <EventRow

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -278,7 +278,7 @@ export default function Home() {
               {past.length > 0 ? (
                 <>
                   <h2 className="mt-14 text-sm font-medium text-muted-foreground">
-                    Past events
+                    Recent past events
                   </h2>
                   <ul className="mt-4 border-t border-border">
                     {past.map((event, index) => (

--- a/tests/home-ui.test.tsx
+++ b/tests/home-ui.test.tsx
@@ -62,7 +62,7 @@ test.each(["light", "dark"])("the %s homepage preserves event links, grouping, a
   expect(html).toContain("Claimed");
   expect(html.indexOf('href="/today"')).toBeLessThan(html.indexOf('href="/upcoming"'));
   expect(html.indexOf('href="/upcoming"')).toBeLessThan(html.indexOf('href="/open"'));
-  expect(html.indexOf("Past events")).toBeLessThan(html.indexOf('href="/recent"'));
+  expect(html.indexOf("Recent past events")).toBeLessThan(html.indexOf('href="/recent"'));
   expect(html).not.toContain("text-black");
   expect(html).not.toContain("text-white");
 });
@@ -77,7 +77,7 @@ test.each([
   state.events = [{ _id: "boundary", name: "Boundary event", slug: "boundary", eventDate: date }];
   const html = renderToStaticMarkup(<Home />);
   expect(html.includes('href="/boundary"')).toBe(visible);
-  expect(html.includes("Past events")).toBe(visible);
+  expect(html.includes("Recent past events")).toBe(visible);
 });
 
 test("anonymous visitors can browse without querying claimed codes", () => {


### PR DESCRIPTION
## Summary
Home page only:

- Heading `Past events` → `Recent past events` (matches the 7-day window it now shows).
- Removed the zero-padded mono counter (`02`) right-aligned beside it; the flex wrapper is gone and the `h2` keeps `mt-14` so the list doesn't shift.

`tests/home-ui.test.tsx` string assertions updated to the new label. Admin dashboard headings/counters (Active / Past / Older) are untouched.

Link to Devin session: https://app.devin.ai/sessions/26b39c11c69c4df9bc721e407ddd6f59
Open in Devin Desktop: https://app.devin.ai/desktop/session/26b39c11c69c4df9bc721e407ddd6f59?variant=devin
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/186" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->