### PR TITLE
Add dynamic events: anyone who signs in can claim once, no participant list

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -37,6 +37,7 @@ interface ManagedEventItem {
   slug: string;
   eventDate?: string;
   hidden?: boolean;
+  dynamic?: boolean;
 }
 
 function AdminEventRow({
@@ -59,6 +60,7 @@ function AdminEventRow({
           <div className="flex flex-wrap items-center gap-x-3 gap-y-1 font-heading font-medium tracking-tight">
             {event.name}
             {event.hidden ? <Badge variant="outline">Hidden</Badge> : null}
+            {event.dynamic ? <Badge variant="outline">Dynamic</Badge> : null}
           </div>
         </div>
         <span className="hidden text-xs text-muted-dim tabular-nums md:inline">

--- a/components/ClaimPage.tsx
+++ b/components/ClaimPage.tsx
@@ -336,8 +336,9 @@ export default function ClaimPage({
                 ) : !isAuthenticated ? (
                   <div className="flex flex-col gap-4">
                     <p className="text-sm leading-relaxed text-muted-foreground">
-                      Sign in with the email you registered with — codes are
-                      only dispensed to verified addresses.
+                      {event.dynamic
+                        ? "Sign in to claim your code — one per verified email address."
+                        : "Sign in with the email you registered with — codes are only dispensed to verified addresses."}
                     </p>
                     <SignInButton mode="modal">
                       <Button variant="brand" size="lg" className="w-full">
@@ -364,11 +365,20 @@ export default function ClaimPage({
                       <AlertTitle>
                         {eligibility.reason === "unverified"
                           ? "No verified email on your account"
-                          : "You're not on the list for this event"}
+                          : event.dynamic
+                            ? "You can't claim a code for this event"
+                            : "You're not on the list for this event"}
                       </AlertTitle>
                       <AlertDescription>
                         {eligibility.reason === "unverified" ? (
                           "Sign in with the email you registered with."
+                        ) : event.dynamic ? (
+                          <>
+                            <span className="font-medium text-foreground">
+                              {eligibility.email ?? "This email"}
+                            </span>{" "}
+                            isn&apos;t eligible for this event.
+                          </>
                         ) : (
                           <>
                             <span className="font-medium text-foreground">
@@ -401,8 +411,9 @@ export default function ClaimPage({
                 ) : mustReadInstructions ? (
                   <div className="flex flex-col gap-5">
                     <p className="text-sm leading-relaxed text-muted-foreground">
-                      You&apos;re on the list. Before your code is dispensed,
-                      take a moment to read how to redeem it.
+                      {event.dynamic ? "You're in." : "You're on the list."}{" "}
+                      Before your code is dispensed, take a moment to read how
+                      to redeem it.
                     </p>
                     <Dialog open={readOpen} onOpenChange={setReadOpen}>
                       <DialogTrigger

--- a/components/ManageEvent.tsx
+++ b/components/ManageEvent.tsx
@@ -1478,6 +1478,7 @@ function EventDetailsForm({
     event.claimInstructions ?? ""
   );
   const [hidden, setHidden] = useState(event.hidden ?? false);
+  const [dynamic, setDynamic] = useState(event.dynamic ?? false);
   const [saving, setSaving] = useState(false);
 
   async function handleSave(e: React.FormEvent) {
@@ -1492,6 +1493,7 @@ function EventDetailsForm({
         eventDate: eventDate || undefined,
         claimInstructions: claimInstructions || undefined,
         hidden: hidden || undefined,
+        dynamic: dynamic || undefined,
       });
       setSlug(savedSlug);
       toast.success("Event saved");
@@ -1575,6 +1577,17 @@ function EventDetailsForm({
               />
               <FieldLabel htmlFor="detail-hidden" className="font-normal">
                 Hide from home page
+              </FieldLabel>
+            </Field>
+            <Field orientation="horizontal" className="sm:col-span-2">
+              <Checkbox
+                id="detail-dynamic"
+                checked={dynamic}
+                onCheckedChange={(checked) => setDynamic(checked === true)}
+              />
+              <FieldLabel htmlFor="detail-dynamic" className="font-normal">
+                Dynamic — anyone who signs in can claim, no participant list
+                needed (one code per email)
               </FieldLabel>
             </Field>
           </FieldGroup>

--- a/components/NewEventForm.tsx
+++ b/components/NewEventForm.tsx
@@ -63,6 +63,7 @@ export default function NewEventForm({
   const [description, setDescription] = useState("");
   const [instructions, setInstructions] = useState("");
   const [hidden, setHidden] = useState(false);
+  const [dynamic, setDynamic] = useState(false);
   const [source, setSource] = useState(initialBatchId ? "saved" : "generate");
   const [batchId, setBatchId] = useState<Id<"stripeBatches"> | "">(
     initialBatchId ?? "",
@@ -88,6 +89,7 @@ export default function NewEventForm({
         description: description || undefined,
         claimInstructions: instructions || undefined,
         hidden,
+        dynamic,
         stripeGeneration: generation,
         stripeBatchId: source === "saved" && batchId ? batchId : undefined,
       });
@@ -246,6 +248,23 @@ export default function NewEventForm({
                     <FieldDescription>
                       Hidden events are still accessible through their claim
                       URL.
+                    </FieldDescription>
+                    <Field orientation="horizontal">
+                      <Checkbox
+                        id="event-dynamic"
+                        checked={dynamic}
+                        onCheckedChange={(checked) =>
+                          setDynamic(checked === true)
+                        }
+                      />
+                      <FieldLabel htmlFor="event-dynamic">
+                        Dynamic — anyone can claim
+                      </FieldLabel>
+                    </Field>
+                    <FieldDescription>
+                      No participant list needed. Anyone who signs in from the
+                      claim URL or QR code gets a code, and their email is
+                      recorded so each address can only claim once.
                     </FieldDescription>
                   </FieldGroup>
                 </details>

--- a/convex/claims.ts
+++ b/convex/claims.ts
@@ -1,10 +1,46 @@
-import { mutation, query } from "./_generated/server";
+import {
+  mutation,
+  query,
+  type MutationCtx,
+  type QueryCtx,
+} from "./_generated/server";
 import { v } from "convex/values";
+import type { Doc } from "./_generated/dataModel";
 import { isEventAdmin, requireEventAdmin } from "./admins";
 import { logAudit } from "./auditLog";
+import { isBlacklisted } from "./blacklist";
 import { blockValue } from "./blockValues";
 import { dropTypeIfEmpty } from "./codes";
 import { notExpired } from "./codeExpiry";
+
+async function findParticipant(
+  ctx: QueryCtx | MutationCtx,
+  event: Doc<"events">,
+  email: string
+) {
+  return await ctx.db
+    .query("emails")
+    .withIndex("by_event_email", (q) =>
+      q.eq("eventId", event._id).eq("email", email)
+    )
+    .unique();
+}
+
+// Dynamic events have no pre-uploaded participant list: the first time a
+// signed-in verified email interacts with the event it is enrolled on the
+// spot, so the usual per-email claim and instructions tracking applies.
+// Blacklisted addresses are never enrolled.
+async function findOrEnrollParticipant(
+  ctx: MutationCtx,
+  event: Doc<"events">,
+  email: string
+) {
+  const existing = await findParticipant(ctx, event, email);
+  if (existing || !event.dynamic) return existing;
+  if (await isBlacklisted(ctx, email)) return null;
+  const id = await ctx.db.insert("emails", { eventId: event._id, email });
+  return await ctx.db.get(id);
+}
 
 // Whether the signed-in viewer is on the participant list for the event,
 // so the claim UI can hold back code options until eligibility is confirmed.
@@ -28,12 +64,7 @@ export const eligibility = query({
     if (!event) {
       return { eligible: false as const, reason: "not_found" as const };
     }
-    const allowed = await ctx.db
-      .query("emails")
-      .withIndex("by_event_email", (q) =>
-        q.eq("eventId", event._id).eq("email", email)
-      )
-      .unique();
+    const allowed = await findParticipant(ctx, event, email);
     if (args.preview && (await isEventAdmin(ctx, event._id))) {
       return {
         eligible: true as const,
@@ -42,7 +73,8 @@ export const eligibility = query({
         preview: true as const,
       };
     }
-    if (!allowed) {
+    const walkUpEligible = event.dynamic && !(await isBlacklisted(ctx, email));
+    if (!allowed && !walkUpEligible) {
       return { eligible: false as const, reason: "not_listed" as const, email };
     }
     const claimed = await ctx.db
@@ -51,7 +83,7 @@ export const eligibility = query({
         q.eq("eventId", event._id).eq("claimedBy", email)
       )
       .unique();
-    const instructionsViewed = allowed.instructionsViewedAt !== undefined;
+    const instructionsViewed = allowed?.instructionsViewedAt !== undefined;
     if (claimed) {
       return {
         eligible: true as const,
@@ -82,12 +114,7 @@ export const markInstructionsRead = mutation({
       .withIndex("by_slug", (q) => q.eq("slug", args.slug))
       .unique();
     if (!event) return;
-    const allowed = await ctx.db
-      .query("emails")
-      .withIndex("by_event_email", (q) =>
-        q.eq("eventId", event._id).eq("email", email)
-      )
-      .unique();
+    const allowed = await findOrEnrollParticipant(ctx, event, email);
     if (!allowed || allowed.instructionsViewedAt !== undefined) return;
     await ctx.db.patch(allowed._id, { instructionsViewedAt: Date.now() });
   },
@@ -154,16 +181,13 @@ export const claim = mutation({
       return { ok: false as const, error: "Event not found." };
     }
 
-    const allowed = await ctx.db
-      .query("emails")
-      .withIndex("by_event_email", (q) =>
-        q.eq("eventId", event._id).eq("email", email)
-      )
-      .unique();
+    const allowed = await findOrEnrollParticipant(ctx, event, email);
     if (!allowed) {
       return {
         ok: false as const,
-        error: `${email} is not on the participant list for this event. Sign in with the email you registered with.`,
+        error: event.dynamic
+          ? `${email} is not eligible to claim a code for this event.`
+          : `${email} is not on the participant list for this event. Sign in with the email you registered with.`,
       };
     }
 

--- a/convex/events.ts
+++ b/convex/events.ts
@@ -104,6 +104,7 @@ export const getBySlug = query({
       claimInstructions: event.claimInstructions,
       creditAmount: event.creditAmount,
       codeTypeValues: event.codeTypeValues,
+      dynamic: event.dynamic ?? false,
       // Lets the claim page show a manage link to this event's admins.
       viewerIsAdmin: await isEventAdmin(ctx, event._id),
       soldOut: availableTypes.size === 0,
@@ -134,6 +135,7 @@ export const get = query({
       eventDate: event.eventDate,
       claimInstructions: event.claimInstructions,
       hidden: event.hidden,
+      dynamic: event.dynamic,
     };
   },
 });
@@ -167,6 +169,7 @@ export const listManaged = query({
       description: event.description,
       eventDate: event.eventDate,
       hidden: event.hidden,
+      dynamic: event.dynamic,
     }));
   },
 });
@@ -179,6 +182,7 @@ export const create = mutation({
     eventDate: v.optional(v.string()),
     claimInstructions: v.optional(v.string()),
     hidden: v.optional(v.boolean()),
+    dynamic: v.optional(v.boolean()),
     stripeGeneration: v.optional(v.object(generationFields)),
     stripeBatchId: v.optional(v.id("stripeBatches")),
   },
@@ -203,6 +207,7 @@ export const create = mutation({
       eventDate: normalizeEventDate(args.eventDate),
       claimInstructions: args.claimInstructions?.trim() || undefined,
       hidden: args.hidden || undefined,
+      dynamic: args.dynamic || undefined,
     });
     if (args.stripeGeneration) await startBatch(ctx, args.stripeGeneration, id);
     if (args.stripeBatchId) {
@@ -224,6 +229,7 @@ export const update = mutation({
     eventDate: v.optional(v.string()),
     claimInstructions: v.optional(v.string()),
     hidden: v.optional(v.boolean()),
+    dynamic: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     await requireEventAdmin(ctx, args.id);
@@ -243,6 +249,7 @@ export const update = mutation({
       eventDate: normalizeEventDate(args.eventDate),
       claimInstructions: args.claimInstructions?.trim() || undefined,
       hidden: args.hidden || undefined,
+      dynamic: args.dynamic || undefined,
     });
     return { slug };
   },

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -55,6 +55,10 @@ export default defineSchema({
     // Hidden events are excluded from the public home page listing but
     // remain reachable via their claim URL.
     hidden: v.optional(v.boolean()),
+    // Dynamic events skip the participant list: any signed-in verified email
+    // can claim, and is recorded in `emails` on first contact so it can only
+    // claim once.
+    dynamic: v.optional(v.boolean()),
     // Distinct code types in this event's pool ("" = unnamed), maintained by
     // codes.add/remove so availability checks don't scan the pool.
     codeTypes: v.optional(v.array(v.string())),

--- a/tests/admin-ui.test.tsx
+++ b/tests/admin-ui.test.tsx
@@ -244,6 +244,7 @@ test("the dashboard collapses events 14+ days old behind a view-more button", ()
     description: undefined,
     eventDate,
     hidden: undefined,
+    dynamic: undefined,
   });
   try {
     state.events = [

--- a/tests/dynamic-events.test.ts
+++ b/tests/dynamic-events.test.ts
@@ -1,0 +1,123 @@
+import { convexTest } from "convex-test";
+import { expect, test } from "vitest";
+import { api } from "../convex/_generated/api";
+import schema from "../convex/schema";
+
+const modules = import.meta.glob("../convex/**/*.ts");
+const walkUp = {
+  subject: "walk-up",
+  email: "Walk.Up@Example.com",
+  emailVerified: true,
+};
+const walkUpEmail = "walk.up@example.com";
+
+async function setup({ dynamic, codes }: { dynamic: boolean; codes: string[] }) {
+  const t = convexTest(schema, modules);
+  const eventId = await t.run(async (ctx) => {
+    const eventId = await ctx.db.insert("events", {
+      name: "Meetup",
+      slug: "meetup",
+      dynamic: dynamic || undefined,
+    });
+    for (const code of codes) {
+      await ctx.db.insert("codes", { eventId, code });
+    }
+    return eventId;
+  });
+  return { t, eventId, user: t.withIdentity(walkUp) };
+}
+
+test("non-dynamic events still require the participant list", async () => {
+  const { user } = await setup({ dynamic: false, codes: ["A"] });
+  expect(await user.query(api.claims.eligibility, { slug: "meetup" })).toMatchObject({
+    eligible: false,
+    reason: "not_listed",
+  });
+  expect(await user.mutation(api.claims.claim, { slug: "meetup" })).toMatchObject({
+    ok: false,
+  });
+});
+
+test("dynamic events let any verified email claim once and record the email", async () => {
+  const { t, eventId, user } = await setup({ dynamic: true, codes: ["A", "B"] });
+  expect(await user.query(api.events.getBySlug, { slug: "meetup" })).toMatchObject({
+    dynamic: true,
+  });
+  expect(await user.query(api.claims.eligibility, { slug: "meetup" })).toMatchObject({
+    eligible: true,
+    email: walkUpEmail,
+    instructionsViewed: false,
+  });
+
+  const first = await user.mutation(api.claims.claim, { slug: "meetup" });
+  expect(first).toMatchObject({ ok: true, code: "A" });
+
+  const second = await user.mutation(api.claims.claim, { slug: "meetup" });
+  expect(second).toMatchObject({ ok: true, code: "A", alreadyClaimed: true });
+
+  await t.run(async (ctx) => {
+    const participants = await ctx.db
+      .query("emails")
+      .withIndex("by_event", (q) => q.eq("eventId", eventId))
+      .collect();
+    expect(participants.map((p) => p.email)).toEqual([walkUpEmail]);
+    const claimed = await ctx.db
+      .query("codes")
+      .withIndex("by_event", (q) => q.eq("eventId", eventId))
+      .collect();
+    expect(claimed.filter((c) => c.claimedBy === walkUpEmail)).toHaveLength(1);
+  });
+});
+
+test("dynamic events report sold out once the pool is exhausted", async () => {
+  const { t, eventId, user } = await setup({ dynamic: true, codes: ["A"] });
+  await t.run(async (ctx) => {
+    await ctx.db.insert("emails", { eventId, email: "other@example.com" });
+    const [code] = await ctx.db
+      .query("codes")
+      .withIndex("by_event", (q) => q.eq("eventId", eventId))
+      .collect();
+    await ctx.db.patch(code._id, {
+      claimedBy: "other@example.com",
+      claimedAt: Date.now(),
+    });
+  });
+  expect(await user.mutation(api.claims.claim, { slug: "meetup" })).toMatchObject({
+    ok: false,
+    error: "All codes for this event have been claimed.",
+  });
+});
+
+test("dynamic events gate on instructions and enroll on acknowledgement", async () => {
+  const { t, eventId, user } = await setup({ dynamic: true, codes: ["A"] });
+  await t.run(async (ctx) => {
+    await ctx.db.patch(eventId, { claimInstructions: "Redeem at checkout." });
+  });
+  expect(await user.mutation(api.claims.claim, { slug: "meetup" })).toMatchObject({
+    ok: false,
+    error: "Read the redemption instructions before claiming your code.",
+  });
+  await user.mutation(api.claims.markInstructionsRead, { slug: "meetup" });
+  expect(await user.query(api.claims.eligibility, { slug: "meetup" })).toMatchObject({
+    eligible: true,
+    instructionsViewed: true,
+  });
+  expect(await user.mutation(api.claims.claim, { slug: "meetup" })).toMatchObject({
+    ok: true,
+    code: "A",
+  });
+});
+
+test("blacklisted emails cannot claim from dynamic events", async () => {
+  const { t, user } = await setup({ dynamic: true, codes: ["A"] });
+  await t.run(async (ctx) => {
+    await ctx.db.insert("blacklistedEmails", { email: walkUpEmail });
+  });
+  expect(await user.query(api.claims.eligibility, { slug: "meetup" })).toMatchObject({
+    eligible: false,
+    reason: "not_listed",
+  });
+  expect(await user.mutation(api.claims.claim, { slug: "meetup" })).toMatchObject({
+    ok: false,
+  });
+});


### PR DESCRIPTION
## Summary

Adds a per-event `dynamic` flag. On a dynamic event, the claim page (and therefore its QR code) hands a code from the event's pool to **any** signed-in user with a verified email — no pre-uploaded participant list needed. The claimant's email is recorded so each address can only ever claim once for that event.

**How it's wired (Convex):**
- `events.dynamic?: boolean` in the schema; plumbed through `events.create` / `events.update` / `events.get` / `events.listManaged` / `events.getBySlug`.
- `claims.ts` — the participant-list lookup is now `findParticipant` (queries) / `findOrEnrollParticipant` (mutations):
  ```ts
  // mutations only
  existing = emails.by_event_email(event, email)
  if (existing || !event.dynamic) return existing
  if (isBlacklisted(email)) return null          // never enrolled
  insert emails { eventId, email }                // <- "we save their email"
  ```
  - `eligibility`: a dynamic event treats a missing row as eligible unless the email is blacklisted (returns `not_listed` in that case).
  - `markInstructionsRead` / `claim`: enroll on first contact, then the existing flow runs unchanged — one-claim-per-email is still enforced by `codes.by_event_claimedBy`, redemption-instructions gating still uses `emails.instructionsViewedAt`, code types / reservations / expiry / sold-out / `allowReclaim` all behave as before.
- Non-dynamic events are untouched: still require the uploaded participant list.

Reusing the `emails` table (rather than a new "dynamic claims" table) means walk-up claimants show up in the event's existing attendee list, walk-up claim UI, and reclaim tooling exactly like uploaded attendees do.

**Admin UI:** "Dynamic — anyone can claim" checkbox next to "Hide from home page" on the create-event form and the event-details card; a "Dynamic" label on the dashboard rows. **Claim page:** copy adapts for dynamic events (sign-in prompt, "You're in." before instructions, blacklist rejection wording).

**Not changed / worth knowing:**
- Requires a Convex deploy (schema + functions) before the toggle works against prod — not deployed from this PR.
- Enrolled walk-up emails count as "already in another event" for the cross-event duplicate flagging in `emails.add` on other events, same as uploaded emails.

Tests: `tests/dynamic-events.test.ts` covers non-dynamic regression, claim once + duplicate claim returns the same code + email recorded, sold-out, instructions gating with enrollment on acknowledgement, and blacklist rejection. `npm test`, `npm run lint`, `tsc --noEmit`, and `next build` (with placeholder `NEXT_PUBLIC_*` env) pass.


Link to Devin session: https://app.devin.ai/sessions/26b39c11c69c4df9bc721e407ddd6f59
Open in Devin Desktop: https://app.devin.ai/desktop/session/26b39c11c69c4df9bc721e407ddd6f59?variant=devin
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/187" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->