### PR TITLE
Claim page: keep the read-instructions button on one line on mobile

### DIFF
--- a/components/ClaimPage.tsx
+++ b/components/ClaimPage.tsx
@@ -418,15 +418,11 @@ export default function ClaimPage({
                     <Dialog open={readOpen} onOpenChange={setReadOpen}>
                       <DialogTrigger
                         render={
-                          <Button
-                            variant="brand"
-                            size="lg"
-                            className="h-auto min-h-9 w-full py-1.5 whitespace-normal"
-                          />
+                          <Button variant="brand" size="lg" className="w-full" />
                         }
                       >
                         <BookOpen data-icon="inline-start" />
-                        Read redemption instructions to claim.
+                        Read instructions to claim
                       </DialogTrigger>
                       <DialogContent className="sm:max-w-md">
                         <DialogHeader>


### PR DESCRIPTION
## Summary

On phones the "Read redemption instructions to claim." button on the claim page wrapped onto two centered lines (it had `h-auto whitespace-normal` to allow that), which looked broken.

Shortened the label to **"Read instructions to claim"** so it fits on one line at mobile widths, and dropped the wrapping overrides so it renders as a normal `size="lg"` brand button like the rest of the claim flow. No behavior change.


Link to Devin session: https://app.devin.ai/sessions/26b39c11c69c4df9bc721e407ddd6f59
Open in Devin Desktop: https://app.devin.ai/desktop/session/26b39c11c69c4df9bc721e407ddd6f59?variant=devin
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/189" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->