### PR TITLE
Derive dynamic claimant list from claimed codes; shorten redeem CTA for narrow phones

### DIFF
--- a/components/ClaimPage.tsx
+++ b/components/ClaimPage.tsx
@@ -422,7 +422,7 @@ export default function ClaimPage({
                         }
                       >
                         <BookOpen data-icon="inline-start" />
-                        Read instructions to claim
+                        Read how to redeem
                       </DialogTrigger>
                       <DialogContent className="sm:max-w-md">
                         <DialogHeader>

--- a/components/ManageEvent.tsx
+++ b/components/ManageEvent.tsx
@@ -161,9 +161,10 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
   // Dynamic events have no participant list to manage; the emails card only
   // shows who has actually claimed a code.
   const isDynamic = event?.dynamic === true;
-  const listedEmails = isDynamic
-    ? emails?.filter((e) => claimedCodesByEmail.has(e.email))
-    : emails;
+  const listedEmails: { email: string; id?: Id<"emails"> }[] | undefined =
+    isDynamic
+      ? codes && [...claimedCodesByEmail.keys()].map((email) => ({ email }))
+      : emails?.map((e) => ({ email: e.email, id: e._id }));
   const unclaimedCodeCount = codeCount - claimedCount;
   const pendingEmailCount = countItems(emailInput);
   const pendingCodeCount = countItems(codeInput);
@@ -729,23 +730,27 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
             )}
             <RowList
               fill
-              items={listedEmails?.map((e) => ({
-                key: e._id,
-                label: e.email,
-                onReclaim: claimedCodesByEmail.has(e.email)
-                  ? () =>
-                      setReclaimTarget({
-                        email: e.email,
-                        codes: claimedCodesByEmail.get(e.email) ?? [],
-                      })
-                  : undefined,
-                onRemove: isDynamic
-                  ? undefined
-                  : () =>
-                      removeEmail({ id: e._id }).catch(() =>
-                        toast.error("Failed to remove email")
-                      ),
-              }))}
+              items={listedEmails?.map((e) => {
+                const emailId = e.id;
+                return {
+                  key: emailId ?? e.email,
+                  label: e.email,
+                  onReclaim: claimedCodesByEmail.has(e.email)
+                    ? () =>
+                        setReclaimTarget({
+                          email: e.email,
+                          codes: claimedCodesByEmail.get(e.email) ?? [],
+                        })
+                    : undefined,
+                  onRemove:
+                    emailId === undefined
+                      ? undefined
+                      : () =>
+                          removeEmail({ id: emailId }).catch(() =>
+                            toast.error("Failed to remove email")
+                          ),
+                };
+              })}
               emptyText={isDynamic ? "No one has claimed yet." : "No emails yet."}
             />
             <AlertDialog


### PR DESCRIPTION
## Summary

Follow-ups to Devin Review findings on #188 and #189.

**Manage page (dynamic events)** — the "Claimed emails" list was `emails ∩ codes.claimedBy`, which had two holes: an address whose `emails` row was removed (via `emails.remove`, which keeps the claimed code) disappeared from the list/CSV, and while `codes` was still loading the card briefly showed "No one has claimed yet." Now:

```ts
listedEmails: { email: string; id?: Id<"emails"> }[] | undefined = isDynamic
  ? codes && [...claimedCodesByEmail.keys()].map((email) => ({ email }))   // undefined until codes load
  : emails?.map((e) => ({ email: e.email, id: e._id }));
```

Rows key on `id ?? email`; the remove action exists only when `id` is present (so it's still gone on dynamic events), and export/count/reclaim all read from the same `listedEmails`. Non-dynamic behavior unchanged.

**Claim page** — "Read instructions to claim" still overflowed the `whitespace-nowrap` button at 320px. Label is now "Read how to redeem" (echoes the sentence right above it and the dialog title).


Link to Devin session: https://app.devin.ai/sessions/26b39c11c69c4df9bc721e407ddd6f59
Open in Devin Desktop: https://app.devin.ai/desktop/session/26b39c11c69c4df9bc721e407ddd6f59?variant=devin
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/190" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->