### PR TITLE
Manage page: add a QR code button (copy link / download PNG) to the event toolbar

### DIFF
--- a/components/EventQrDialog.tsx
+++ b/components/EventQrDialog.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useRef, useSyncExternalStore } from "react";
+import { Copy, Download, QrCode } from "lucide-react";
+import { QRCodeCanvas, QRCodeSVG } from "qrcode.react";
+import { toast } from "sonner";
+import { copyText } from "@/lib/clipboard";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Skeleton } from "@/components/ui/skeleton";
+
+function subscribeNoop() {
+  return () => {};
+}
+
+// Admin-side QR for an event's public claim URL, with copy and a print-ready
+// PNG download. The download renders from an offscreen canvas so the file is
+// black-on-white regardless of the current theme.
+export default function EventQrDialog({
+  eventName,
+  slug,
+}: {
+  eventName: string;
+  slug: string;
+}) {
+  const origin = useSyncExternalStore(
+    subscribeNoop,
+    () => window.location.origin,
+    () => ""
+  );
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const claimUrl = origin ? `${origin}/${slug}` : "";
+
+  async function copyLink() {
+    if (!claimUrl) return;
+    if (await copyText(claimUrl)) toast.success("Claim link copied");
+    else toast.error("Couldn't copy the link");
+  }
+
+  function downloadPng() {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const a = document.createElement("a");
+    a.href = canvas.toDataURL("image/png");
+    a.download = `${slug}-qr.png`;
+    a.click();
+  }
+
+  return (
+    <Dialog>
+      <DialogTrigger
+        render={
+          <Button
+            variant="outline"
+            size="icon"
+            aria-label="Event QR code"
+            title="Event QR code"
+          />
+        }
+      >
+        <QrCode />
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-sm">
+        <DialogHeader>
+          <DialogTitle className="font-heading tracking-tight">
+            Scan to claim
+          </DialogTitle>
+          <DialogDescription>
+            Anyone who scans this lands on the claim page for {eventName}.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col items-center gap-4">
+          <div className="rounded-lg border border-border bg-background p-4 text-foreground">
+            {claimUrl ? (
+              <QRCodeSVG
+                value={claimUrl}
+                size={224}
+                marginSize={0}
+                fgColor="currentColor"
+                bgColor="transparent"
+                aria-label={`QR code linking to ${claimUrl}`}
+              />
+            ) : (
+              <Skeleton className="size-[224px]" />
+            )}
+          </div>
+          <span className="max-w-full truncate font-mono text-xs text-muted-foreground">
+            {claimUrl ? claimUrl.replace(/^https?:\/\//, "") : "\u00A0"}
+          </span>
+          {claimUrl ? (
+            <QRCodeCanvas
+              ref={canvasRef}
+              value={claimUrl}
+              size={1024}
+              marginSize={2}
+              fgColor="#000000"
+              bgColor="#ffffff"
+              className="hidden"
+              aria-hidden
+            />
+          ) : null}
+        </div>
+        <div className="grid grid-cols-2 gap-2">
+          <Button variant="outline" onClick={copyLink} disabled={!claimUrl}>
+            <Copy data-icon="inline-start" />
+            Copy link
+          </Button>
+          <Button onClick={downloadPng} disabled={!claimUrl}>
+            <Download data-icon="inline-start" />
+            Download PNG
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/ManageEvent.tsx
+++ b/components/ManageEvent.tsx
@@ -13,7 +13,6 @@ import {
   Eye,
   Inbox,
   Plus,
-  QrCode,
   RotateCcw,
   ShieldCheck,
   Ticket,
@@ -71,6 +70,7 @@ import { Progress } from "@/components/ui/progress";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { Textarea } from "@/components/ui/textarea";
+import EventQrDialog from "@/components/EventQrDialog";
 import EventStripeCodes from "@/components/EventStripeCodes";
 import { ClaimInstructionsField } from "@/components/ClaimInstructionsField";
 
@@ -472,7 +472,7 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
               render={<Link href={`/admin/events/${id}/walkup`} />}
               nativeButton={false}
             >
-              <QrCode data-icon="inline-start" />
+              <UserPlus data-icon="inline-start" />
               Walk-up claim
             </Button>
             <Button
@@ -489,6 +489,7 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
               <Eye data-icon="inline-start" />
               Preview claim
             </Button>
+            <EventQrDialog eventName={event.name} slug={event.slug} />
           <Button
             variant="outline"
             render={


### PR DESCRIPTION
## Summary

The manage-page toolbar (Walk-up claim · Preview claim · /slug) had no direct way to get the event's QR code — you had to open the public page and flip the card. This adds a fourth control: an outline QR icon button that opens a dialog.

New `components/EventQrDialog.tsx` (`<EventQrDialog eventName slug />`):
- Renders `QRCodeSVG` of `${window.location.origin}/${slug}` (origin via `useSyncExternalStore`, same pattern as `ClaimPage`/`WalkUpClaim`, so SSR renders a skeleton) plus the URL.
- **Copy link** → `copyText` + toast.
- **Download PNG** → `canvas.toDataURL()` from a hidden 1024px `QRCodeCanvas` rendered black-on-white, so the file prints correctly regardless of theme. Filename `${slug}-qr.png`.

`ManageEvent`: places the button after "Preview claim"; the Walk-up claim button's icon switches from `QrCode` to `UserPlus` so the QR glyph means one thing in that row.

UI-only, no Convex changes.


Link to Devin session: https://app.devin.ai/sessions/26b39c11c69c4df9bc721e407ddd6f59
Open in Devin Desktop: https://app.devin.ai/desktop/session/26b39c11c69c4df9bc721e407ddd6f59?variant=devin
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/191" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->