### PR TITLE
QR page: render the QR black-on-white so it prints in dark theme

### DIFF
--- a/components/EventQrPage.tsx
+++ b/components/EventQrPage.tsx
@@ -81,14 +81,14 @@ export default function EventQrPage({ slug }: { slug: string }) {
                   </h1>
                 )}
               </div>
-              <div className="rounded-xl border border-border bg-background p-5 text-foreground">
+              <div className="rounded-xl border border-border bg-white p-5">
                 {claimUrl ? (
                   <QRCodeSVG
                     value={claimUrl}
                     size={288}
                     marginSize={0}
-                    fgColor="currentColor"
-                    bgColor="transparent"
+                    fgColor="#000000"
+                    bgColor="#ffffff"
                     className="size-[min(288px,70vw)]"
                     aria-label={`QR code linking to ${claimUrl}`}
                   />


### PR DESCRIPTION
## Summary

Follow-up to #192 from Devin Review: on `/{slug}/qr` the QR used `fgColor="currentColor"` on a transparent background, so in the (default) dark theme a print produced white modules on the browser's white page — i.e. a blank QR.

`EventQrPage` now renders the on-screen `QRCodeSVG` with fixed `#000000` on `#ffffff` inside a `bg-white` tile, matching the downloaded PNG. Renders the same in both themes and survives printing.


Link to Devin session: https://app.devin.ai/sessions/26b39c11c69c4df9bc721e407ddd6f59
Open in Devin Desktop: https://app.devin.ai/desktop/session/26b39c11c69c4df9bc721e407ddd6f59?variant=devin
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/193" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->