### PR TITLE
Dynamic events are always hidden from the home page, with no option to unhide

### DIFF
--- a/components/ManageEvent.tsx
+++ b/components/ManageEvent.tsx
@@ -1610,11 +1610,13 @@ function EventDetailsForm({
             <Field orientation="horizontal" className="sm:col-span-2">
               <Checkbox
                 id="detail-hidden"
-                checked={hidden}
+                checked={hidden || dynamic}
+                disabled={dynamic}
                 onCheckedChange={(checked) => setHidden(checked === true)}
               />
               <FieldLabel htmlFor="detail-hidden" className="font-normal">
                 Hide from home page
+                {dynamic ? " (always on for dynamic events)" : null}
               </FieldLabel>
             </Field>
             <Field orientation="horizontal" className="sm:col-span-2">

--- a/components/NewEventForm.tsx
+++ b/components/NewEventForm.tsx
@@ -236,7 +236,8 @@ export default function NewEventForm({
                     <Field orientation="horizontal">
                       <Checkbox
                         id="event-hidden"
-                        checked={hidden}
+                        checked={hidden || dynamic}
+                        disabled={dynamic}
                         onCheckedChange={(checked) =>
                           setHidden(checked === true)
                         }
@@ -246,8 +247,9 @@ export default function NewEventForm({
                       </FieldLabel>
                     </Field>
                     <FieldDescription>
-                      Hidden events are still accessible through their claim
-                      URL.
+                      {dynamic
+                        ? "Dynamic events are always hidden and only reachable through their claim URL or QR code."
+                        : "Hidden events are still accessible through their claim URL."}
                     </FieldDescription>
                     <Field orientation="horizontal">
                       <Checkbox

--- a/convex/events.ts
+++ b/convex/events.ts
@@ -30,12 +30,18 @@ function normalizeEventDate(raw?: string): string | undefined {
   return trimmed;
 }
 
+// Dynamic events are only reachable through their claim URL / QR code, so
+// they are always hidden from the home page regardless of the stored flag.
+function isHidden(event: { hidden?: boolean; dynamic?: boolean }) {
+  return Boolean(event.hidden || event.dynamic);
+}
+
 export const list = query({
   args: {},
   handler: async (ctx) => {
     const events = await ctx.db.query("events").order("desc").collect();
     return events
-      .filter((event) => !event.hidden)
+      .filter((event) => !isHidden(event))
       .map((event) => ({
         _id: event._id,
         _creationTime: event._creationTime,
@@ -134,7 +140,7 @@ export const get = query({
       codeTypeValues: event.codeTypeValues,
       eventDate: event.eventDate,
       claimInstructions: event.claimInstructions,
-      hidden: event.hidden,
+      hidden: isHidden(event) || undefined,
       dynamic: event.dynamic,
     };
   },
@@ -168,7 +174,7 @@ export const listManaged = query({
       slug: event.slug,
       description: event.description,
       eventDate: event.eventDate,
-      hidden: event.hidden,
+      hidden: isHidden(event) || undefined,
       dynamic: event.dynamic,
     }));
   },
@@ -206,7 +212,7 @@ export const create = mutation({
       description: args.description?.trim() || undefined,
       eventDate: normalizeEventDate(args.eventDate),
       claimInstructions: args.claimInstructions?.trim() || undefined,
-      hidden: args.hidden || undefined,
+      hidden: isHidden(args) || undefined,
       dynamic: args.dynamic || undefined,
     });
     if (args.stripeGeneration) await startBatch(ctx, args.stripeGeneration, id);
@@ -248,7 +254,7 @@ export const update = mutation({
       description: args.description?.trim() || undefined,
       eventDate: normalizeEventDate(args.eventDate),
       claimInstructions: args.claimInstructions?.trim() || undefined,
-      hidden: args.hidden || undefined,
+      hidden: isHidden(args) || undefined,
       dynamic: args.dynamic || undefined,
     });
     return { slug };

--- a/tests/dynamic-events.test.ts
+++ b/tests/dynamic-events.test.ts
@@ -121,3 +121,49 @@ test("blacklisted emails cannot claim from dynamic events", async () => {
     ok: false,
   });
 });
+
+test("dynamic events are always hidden from the home page", async () => {
+  const t = convexTest(schema, modules);
+  await t.run(async (ctx) => {
+    await ctx.db.insert("admins", { email: walkUpEmail });
+  });
+  const admin = t.withIdentity(walkUp);
+
+  const { id } = await admin.mutation(api.events.create, {
+    name: "Dynamic",
+    dynamic: true,
+    hidden: false,
+  });
+  expect(await admin.query(api.events.get, { id })).toMatchObject({
+    dynamic: true,
+    hidden: true,
+  });
+  expect(await t.query(api.events.list, {})).toEqual([]);
+
+  // Legacy dynamic rows without the stored flag are still treated as hidden.
+  await t.run(async (ctx) => {
+    await ctx.db.patch(id, { hidden: undefined });
+  });
+  expect(await t.query(api.events.list, {})).toEqual([]);
+  expect(await admin.query(api.events.listManaged, {})).toMatchObject([
+    { dynamic: true, hidden: true },
+  ]);
+
+  await admin.mutation(api.events.update, {
+    id,
+    name: "Dynamic",
+    slug: "dynamic",
+    dynamic: true,
+    hidden: false,
+  });
+  expect(await admin.query(api.events.get, { id })).toMatchObject({ hidden: true });
+
+  await admin.mutation(api.events.update, {
+    id,
+    name: "Dynamic",
+    slug: "dynamic",
+    dynamic: false,
+    hidden: false,
+  });
+  expect(await t.query(api.events.list, {})).toMatchObject([{ slug: "dynamic" }]);
+});


### PR DESCRIPTION
## Summary

Dynamic events are meant to be reached only via their claim URL / QR code, so they are now forced hidden and the Hidden toggle can't turn that off.

**Backend (`convex/events.ts`)** — one helper, applied everywhere `hidden` is read or written:

```ts
const isHidden = (e: { hidden?: boolean; dynamic?: boolean }) => Boolean(e.hidden || e.dynamic);
```

- `create` / `update` store `hidden: isHidden(args) || undefined` → passing `dynamic: true, hidden: false` still persists `hidden: true`.
- `list` (home page) filters on `isHidden(event)`, and `get` / `listManaged` report `hidden: isHidden(event)` — so dynamic events created before this change (no stored `hidden`) are hidden too and show the "Hidden" badge on the dashboard.
- Turning `dynamic` off again releases the lock; `hidden` then follows whatever the admin sends.

**UI** — `NewEventForm` and `ManageEvent` details: the "Hide from home page" checkbox is `checked={hidden || dynamic}` and `disabled={dynamic}`, with a note explaining why.

Test added in `tests/dynamic-events.test.ts`. Needs a Convex deploy (`events` functions only, no schema change) to take effect against prod.


Link to Devin session: https://app.devin.ai/sessions/26b39c11c69c4df9bc721e407ddd6f59
Open in Devin Desktop: https://app.devin.ai/desktop/session/26b39c11c69c4df9bc721e407ddd6f59?variant=devin
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/194" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->