### PR TITLE
Cap emails.add at 500 addresses per request

### DIFF
--- a/components/ManageEvent.tsx
+++ b/components/ManageEvent.tsx
@@ -218,16 +218,20 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
   }
 
   // Shares the busy flag with the file upload so the two ways of adding to the
-  // same list can't run at once. The textarea is only cleared on success, so a
-  // failed paste isn't lost.
+  // same list can't run at once. Large pastes go up in chunks; on failure the
+  // textarea keeps only the addresses not yet sent, so a retry doesn't
+  // re-submit what already landed.
   async function handleAddEmails(e: React.FormEvent) {
     e.preventDefault();
-    const list = emailInput.split(/[\n,;\s]+/).filter(Boolean);
-    if (list.length === 0) return;
+    const rows = emailInput.split(/[\n,;\s]+/).filter(Boolean);
+    if (rows.length === 0) return;
+    // Dedupe up front so repeats split across chunks aren't double-counted.
+    const list = [...new Set(rows.map((r) => r.trim().toLowerCase()))];
     setEmailBusy(true);
+    let sent = 0;
     try {
       let added = 0;
-      let skipped = 0;
+      let skipped = rows.length - list.length;
       let flagged = 0;
       let blacklisted = 0;
       for (let i = 0; i < list.length; i += UPLOAD_CHUNK_SIZE) {
@@ -235,6 +239,7 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
           eventId: id,
           emails: list.slice(i, i + UPLOAD_CHUNK_SIZE),
         });
+        sent = Math.min(i + UPLOAD_CHUNK_SIZE, list.length);
         added += res.added;
         skipped += res.skipped;
         flagged += res.flagged;
@@ -259,7 +264,15 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
       }
       setEmailInput("");
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Failed to add emails");
+      const message = err instanceof Error ? err.message : "Failed to add emails";
+      if (sent > 0) {
+        setEmailInput(list.slice(sent).join("\n"));
+        toast.error(message, {
+          description: `${sent} of ${list.length} addresses were submitted before the error; the rest are still in the box.`,
+        });
+      } else {
+        toast.error(message);
+      }
     } finally {
       setEmailBusy(false);
     }

--- a/components/ManageEvent.tsx
+++ b/components/ManageEvent.tsx
@@ -29,6 +29,7 @@ import type { Doc, Id } from "@/convex/_generated/dataModel";
 import { blockKey } from "@/convex/blockValues";
 import { downloadCsv } from "@/lib/csv";
 import { fileToItems } from "@/lib/spreadsheet";
+import { UPLOAD_CHUNK_SIZE } from "@/lib/upload-limits";
 import { useCountUp } from "@/lib/use-count-up";
 import { cn } from "@/lib/utils";
 import {
@@ -73,8 +74,6 @@ import { Spinner } from "@/components/ui/spinner";
 import { Textarea } from "@/components/ui/textarea";
 import EventStripeCodes from "@/components/EventStripeCodes";
 import { ClaimInstructionsField } from "@/components/ClaimInstructionsField";
-
-const UPLOAD_CHUNK_SIZE = 500;
 
 export default function ManageEvent({ id }: { id: Id<"events"> }) {
   const event = useQuery(api.events.get, { id });
@@ -227,10 +226,20 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
     if (list.length === 0) return;
     setEmailBusy(true);
     try {
-      const { added, skipped, flagged, blacklisted } = await addEmails({
-        eventId: id,
-        emails: list,
-      });
+      let added = 0;
+      let skipped = 0;
+      let flagged = 0;
+      let blacklisted = 0;
+      for (let i = 0; i < list.length; i += UPLOAD_CHUNK_SIZE) {
+        const res = await addEmails({
+          eventId: id,
+          emails: list.slice(i, i + UPLOAD_CHUNK_SIZE),
+        });
+        added += res.added;
+        skipped += res.skipped;
+        flagged += res.flagged;
+        blacklisted += res.blacklisted;
+      }
       const description =
         [
           blacklisted ? `${blacklisted} rejected (blacklisted).` : "",

--- a/components/ManageEvent.tsx
+++ b/components/ManageEvent.tsx
@@ -738,6 +738,7 @@ export default function ManageEvent({ id }: { id: Id<"events"> }) {
                   aria-label="Email addresses to add"
                   value={emailInput}
                   onChange={(e) => setEmailInput(e.target.value)}
+                  disabled={emailBusy}
                   rows={4}
                   placeholder={"one@example.com\ntwo@example.com"}
                   className="max-h-48 resize-y overflow-y-auto text-sm"

--- a/convex/emails.ts
+++ b/convex/emails.ts
@@ -4,6 +4,7 @@ import type { Doc, Id } from "./_generated/dataModel";
 import { adminEmailStatus, requireAdmin, requireEventAdmin } from "./admins";
 import { isBlacklisted, recordBlacklistHit } from "./blacklist";
 import { logAudit } from "./auditLog";
+import { UPLOAD_CHUNK_SIZE } from "../lib/upload-limits";
 
 export const list = query({
   args: { eventId: v.id("events") },
@@ -20,6 +21,11 @@ export const add = mutation({
   args: { eventId: v.id("events"), emails: v.array(v.string()) },
   handler: async (ctx, args) => {
     await requireEventAdmin(ctx, args.eventId);
+    if (args.emails.length > UPLOAD_CHUNK_SIZE) {
+      throw new Error(
+        `Add at most ${UPLOAD_CHUNK_SIZE} emails per request (got ${args.emails.length}).`
+      );
+    }
     let added = 0;
     let skipped = 0;
     let flagged = 0;

--- a/lib/upload-limits.ts
+++ b/lib/upload-limits.ts
@@ -1,0 +1,3 @@
+// Maximum items accepted by a single bulk-add mutation. Clients chunk larger
+// lists into calls of this size; the server rejects anything above it.
+export const UPLOAD_CHUNK_SIZE = 500;


### PR DESCRIPTION
## Summary
Remediates code-scan finding sfind-23ca6be93a5b4a489fba486677cff514: `emails.add` accepted an unbounded `emails` array and did several index reads (including an all-events `by_email` collect) per element, so an event admin could amplify work per call with an arbitrarily large payload.

- `convex/emails.ts` — `add` now throws if `args.emails.length > UPLOAD_CHUNK_SIZE` (500), matching the existing 500 cap on Stripe batch quantity.
- `lib/upload-limits.ts` — new shared `UPLOAD_CHUNK_SIZE = 500`, replacing the private constant in `ManageEvent.tsx` so client chunking and the server cap can't drift.
- `components/ManageEvent.tsx` — the textarea paste path (`handleAddEmails`) previously sent the whole list in one call; it now normalizes/dedupes the addresses and chunks them by `UPLOAD_CHUNK_SIZE` like the file-upload path already did. If a later chunk fails, only the unsent addresses are left in the textarea (with a toast noting how many went through), and the textarea is disabled while a submission is in flight.

`WalkUpClaim` sends single addresses and is unaffected. `npm test`, `npm run lint`, and `tsc --noEmit` pass.

Link to Devin session: https://app.devin.ai/sessions/701b1bc49bae4f83ae120332752bb55e
Open in Devin Desktop: https://app.devin.ai/desktop/session/701b1bc49bae4f83ae120332752bb55e?variant=devin
Requested by: @dabit3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/vending-machine/pull/196" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->